### PR TITLE
feat: config-change preview (#374) + Delta Arrow columnar path (#375)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Free runner disk space
         # The all-features instrumented build (bundled DuckDB + the full
-        # connector tree) exceeds the hosted runner's free disk. Drop the
-        # large preinstalled toolchains we never use (~25-30 GB).
+        # connector tree) plus the coverage profraw data and testcontainer
+        # images exceed the hosted runner's free disk. Drop every large
+        # preinstalled toolchain we never use (~40 GB) and clear the apt cache.
+        # None of these are used by the Rust / DuckDB / testcontainers build.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift \
+            /usr/local/share/powershell \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /opt/microsoft
+          sudo apt-get clean
           df -h /
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -475,10 +487,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Free runner disk space
         # The all-features instrumented build (bundled DuckDB + the full
-        # connector tree) exceeds the hosted runner's free disk. Drop the
-        # large preinstalled toolchains we never use (~25-30 GB).
+        # connector tree) plus the coverage profraw data and testcontainer
+        # images exceed the hosted runner's free disk. Drop every large
+        # preinstalled toolchain we never use (~40 GB) and clear the apt cache.
+        # None of these are used by the Rust / DuckDB / testcontainers build.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift \
+            /usr/local/share/powershell \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /opt/microsoft
+          sudo apt-get clean
           df -h /
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5487,11 +5487,13 @@ dependencies = [
  "criterion",
  "duckdb",
  "faucet-core",
+ "futures",
  "parquet 58.3.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,7 @@ dependencies = [
  "faucet-conformance",
  "faucet-core",
  "faucet-source-delta",
+ "futures",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -222,6 +222,8 @@ arrow = [
     "faucet-core/arrow",
     "faucet-source-parquet?/arrow",
     "faucet-sink-parquet?/arrow",
+    "faucet-source-delta?/arrow",
+    "faucet-sink-delta?/arrow",
 ]
 
 # Secrets-manager interpolation resolvers for the config layer. None in

--- a/cli/README.md
+++ b/cli/README.md
@@ -33,6 +33,7 @@ cargo install faucet-cli --no-default-features \
 | `faucet list` | List every compiled-in source, sink, transform, and state-store backend, each with its conformance maturity tier. |
 | `faucet conformance [name] [--kind K] [--json] [--min-tier T]` | Score connectors against the SDK contract, print a scorecard + maturity tier (Stable/Experimental/Beta/Draft) and capability badges. `--min-tier` exits non-zero as an opt-in CI gate. |
 | `faucet preview <config> --limit N` | Run only the source side and emit the first N records to stdout as JSONL. |
+| `faucet plan <config> [--sample F\|--live] [--diff] [--json]` | Read-only "what would this do" preview (resolved pipeline, output schema, sink delta — never writes). `--diff` shows a `terraform plan`-style per-row config diff against the last recorded run (needs a `catalog:` block + `catalog` feature; secrets stored only as stable `<secret:sha256:…>` tokens). |
 | `faucet init [name] [--source X] [--sink Y]` | Scaffold a pipeline.yaml from each connector's JSON Schema. |
 | `faucet doctor <config> [--timeout-secs N] [--json]` | Probe every connector (auth/network/permissions/reachability) and print a checklist. Exits with the failed-probe count. |
 | `faucet test <specs…> [--filter S] [--json] [--clock C]` | Run fixture-based **offline** pipeline tests: stream sample records through a config's transforms/quality/contract with in-memory source/sink/DLQ and assert the output. Exits with the failed-case count. `faucet schema test` prints the spec-file JSON Schema. |

--- a/cli/src/catalog/mod.rs
+++ b/cli/src/catalog/mod.rs
@@ -18,12 +18,14 @@
 //! backends and `lineage` for record sampling + column-lineage derivation).
 
 pub mod model;
+pub mod snapshot;
 pub mod spec;
 
 pub use spec::CatalogSpec;
 
 use crate::error::{CliError, CliResult};
 use crate::serve::config::HistoryBackendSpec;
+use crate::serve::history::catalog::ConfigSnapshot;
 use crate::serve::history::{self, RunHistory, catalog::CatalogUpdate};
 use std::sync::Arc;
 use std::time::Duration;
@@ -99,6 +101,18 @@ pub async fn record(handle: &CatalogHandle, update: &CatalogUpdate) {
             row = %update.row,
             error = %e,
             "catalog write failed — run unaffected"
+        );
+    }
+}
+
+/// Persist the latest resolved+expanded config snapshot for `faucet plan --diff`
+/// (#374). Best-effort, same never-fails-the-run contract as [`record`].
+pub async fn record_config_snapshot(handle: &CatalogHandle, snapshot: &ConfigSnapshot) {
+    if let Err(e) = handle.store.catalog_record_config_snapshot(snapshot).await {
+        tracing::warn!(
+            pipeline = %snapshot.pipeline,
+            error = %e,
+            "config-snapshot write failed — run unaffected"
         );
     }
 }

--- a/cli/src/catalog/snapshot.rs
+++ b/cli/src/catalog/snapshot.rs
@@ -1,0 +1,497 @@
+//! Config-change preview (#374): build a redacted snapshot of the resolved +
+//! expanded config, and diff the current config against the last recorded one.
+//!
+//! `faucet run` / `replicate` / `schedule` record a [`ConfigSnapshot`] on every
+//! successful invocation (best-effort — see [`super::record_config_snapshot`]).
+//! `faucet plan --diff` re-expands the current config, loads the last snapshot,
+//! and renders a **semantic, per-row** diff (rows created / changed / removed,
+//! and within each changed row the exact fields that differ).
+//!
+//! Two properties make this trustworthy where a raw YAML text-diff is not:
+//!
+//! - **Resolved, not textual.** The snapshot is built from the *expanded* nodes
+//!   (post `extends`/`vars`/`${env:}` interpolation and matrix fan-out), so a
+//!   one-line `${vars.x}` edit that fans out across many rows shows up as the
+//!   real per-row effect, and two textually-different files that resolve to the
+//!   same movement show no diff.
+//! - **Secret-safe.** Every secret-sourced value is replaced with a stable
+//!   `<secret:sha256:…>` token before storage (see [`redact_value`]). No secret
+//!   material is ever persisted, and a rotated secret surfaces as a changed hash
+//!   ("secret rotated") rather than printing either value.
+
+use crate::config::{ExecutionSpec, OnError, PipelineConfig};
+use crate::expand::ExpandedNode;
+use crate::serve::history::catalog::{
+    ConfigSnapshot, ConnectorSnapshot, RowSnapshot, TransformSnapshot,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+/// The canonical pipeline name used to key snapshots — identical logic to the
+/// `run` / `replicate` / `schedule` observability label, so the record side and
+/// the `plan --diff` side always agree on the key: the explicit `name:`, else
+/// the config file stem, else `"pipeline"`.
+pub fn resolve_name(cfg: &PipelineConfig, config_path: Option<&Path>) -> String {
+    cfg.name.clone().unwrap_or_else(|| {
+        config_path
+            .and_then(|p| p.file_stem())
+            .and_then(|s| s.to_str())
+            .unwrap_or("pipeline")
+            .to_owned()
+    })
+}
+
+/// The `execution.on_error` policy as a stable string (`"stop"` / `"continue"`).
+pub fn on_error_str(execution: &Option<ExecutionSpec>) -> &'static str {
+    match execution.as_ref().map(|e| e.on_error).unwrap_or_default() {
+        OnError::Stop => "stop",
+        OnError::Continue => "continue",
+    }
+}
+
+/// Build a redacted snapshot from the resolved + expanded nodes. `pipeline` and
+/// `on_error` are passed in (via [`resolve_name`] / [`on_error_str`]) so every
+/// call site keys snapshots identically; `clock` is the record time (passed in
+/// so callers stay deterministic in tests).
+pub fn build_snapshot(
+    pipeline: String,
+    on_error: &str,
+    nodes: &[ExpandedNode],
+    clock: DateTime<Utc>,
+) -> ConfigSnapshot {
+    let mut rows = BTreeMap::new();
+    for node in nodes {
+        let state_key = node
+            .state
+            .as_ref()
+            .map(|_| format!("{pipeline}::{}", node.id));
+        rows.insert(
+            node.id.clone(),
+            RowSnapshot {
+                source: connector_snapshot(&node.source.kind, &node.source.config),
+                sink: connector_snapshot(&node.sink.kind, &node.sink.config),
+                transforms: node
+                    .transforms
+                    .iter()
+                    .map(|t| TransformSnapshot {
+                        kind: t.kind.clone(),
+                        config: redact_value(&t.config),
+                    })
+                    .collect(),
+                state_key,
+                delivery_guarantee: format!("{:?}", node.delivery_guarantee),
+                on_error: on_error.to_owned(),
+                dlq: node.dlq.is_some(),
+            },
+        );
+    }
+    ConfigSnapshot {
+        pipeline,
+        recorded_at: clock,
+        faucet_version: env!("CARGO_PKG_VERSION").to_owned(),
+        rows,
+    }
+}
+
+fn connector_snapshot(kind: &str, config: &Value) -> ConnectorSnapshot {
+    ConnectorSnapshot {
+        kind: kind.to_owned(),
+        config: redact_value(config),
+    }
+}
+
+/// Recursively replace every secret-sourced string in `value` with a stable
+/// `<secret:sha256:…>` token. Non-secret strings pass through verbatim, so real
+/// config changes (paths, table names, page sizes) stay visible in the diff.
+pub fn redact_value(value: &Value) -> Value {
+    match value {
+        Value::String(s) => {
+            Value::String(crate::secrets::registry::redact_with(s, secret_token).into_owned())
+        }
+        Value::Array(items) => Value::Array(items.iter().map(redact_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), redact_value(v)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// The stable, non-reversible token a secret value is replaced with. The 12-hex
+/// prefix of sha256 is enough to detect rotation without bloating the snapshot.
+fn secret_token(secret: &str) -> String {
+    let digest = Sha256::digest(secret.as_bytes());
+    let hex: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    format!("<secret:sha256:{hex}>")
+}
+
+// ── Diff ─────────────────────────────────────────────────────────────────────
+
+/// Per-row status in a config diff, `terraform plan`-style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RowStatus {
+    /// Present now, absent in the last snapshot — will be created.
+    New,
+    /// Present in both, with field-level differences.
+    Changed,
+    /// Present in the last snapshot, absent now — no longer part of the run set.
+    Removed,
+    /// Present in both, identical.
+    Unchanged,
+}
+
+impl RowStatus {
+    fn glyph(self) -> char {
+        match self {
+            Self::New => '+',
+            Self::Changed => '~',
+            Self::Removed => '-',
+            Self::Unchanged => '=',
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            Self::New => "NEW ROW — will be created",
+            Self::Changed => "CHANGED",
+            Self::Removed => "REMOVED — no longer in the run set",
+            Self::Unchanged => "unchanged",
+        }
+    }
+}
+
+/// One field-level change within a changed row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FieldChange {
+    /// Dotted path within the row snapshot (e.g. `source.config.page_size`).
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    /// True when both sides are secret tokens that differ (a rotation), so the
+    /// renderer can say "secret rotated" instead of printing hashes.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub secret_rotated: bool,
+}
+
+/// One row's entry in the diff.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RowDiff {
+    pub id: String,
+    pub status: RowStatus,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub changes: Vec<FieldChange>,
+}
+
+/// Roll-up counts, `terraform plan`-style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
+pub struct DiffSummary {
+    pub create: usize,
+    pub change: usize,
+    pub remove: usize,
+    pub unchanged: usize,
+}
+
+/// The full config diff, serialized verbatim by `--json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SnapshotDiff {
+    pub pipeline: String,
+    /// When the compared snapshot was recorded (`None` on a first-ever diff).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_recorded_at: Option<DateTime<Utc>>,
+    /// True when no prior snapshot existed — every row is `New`.
+    pub first_run: bool,
+    pub rows: Vec<RowDiff>,
+    pub summary: DiffSummary,
+}
+
+/// Diff `current` against the last recorded snapshot (`previous`). With no
+/// previous snapshot every row is `New` (first-run, like `terraform plan` on
+/// fresh state).
+pub fn diff(previous: Option<&ConfigSnapshot>, current: &ConfigSnapshot) -> SnapshotDiff {
+    let first_run = previous.is_none();
+    let empty = BTreeMap::new();
+    let prev_rows = previous.map(|p| &p.rows).unwrap_or(&empty);
+
+    let ids: BTreeSet<&String> = prev_rows.keys().chain(current.rows.keys()).collect();
+    let mut rows = Vec::new();
+    let mut summary = DiffSummary::default();
+
+    for id in ids {
+        let diff = match (prev_rows.get(id), current.rows.get(id)) {
+            (None, Some(_)) => {
+                summary.create += 1;
+                RowDiff {
+                    id: id.clone(),
+                    status: RowStatus::New,
+                    changes: Vec::new(),
+                }
+            }
+            (Some(_), None) => {
+                summary.remove += 1;
+                RowDiff {
+                    id: id.clone(),
+                    status: RowStatus::Removed,
+                    changes: Vec::new(),
+                }
+            }
+            (Some(prev), Some(curr)) => {
+                let changes = field_changes(prev, curr);
+                if changes.is_empty() {
+                    summary.unchanged += 1;
+                    RowDiff {
+                        id: id.clone(),
+                        status: RowStatus::Unchanged,
+                        changes,
+                    }
+                } else {
+                    summary.change += 1;
+                    RowDiff {
+                        id: id.clone(),
+                        status: RowStatus::Changed,
+                        changes,
+                    }
+                }
+            }
+            (None, None) => unreachable!("id came from the union of both maps"),
+        };
+        rows.push(diff);
+    }
+
+    SnapshotDiff {
+        pipeline: current.pipeline.clone(),
+        previous_recorded_at: previous.map(|p| p.recorded_at),
+        first_run,
+        rows,
+        summary,
+    }
+}
+
+/// Flatten a row to `dotted.path -> scalar` and compare, producing one
+/// [`FieldChange`] per differing leaf.
+fn field_changes(prev: &RowSnapshot, curr: &RowSnapshot) -> Vec<FieldChange> {
+    let a = flatten_row(prev);
+    let b = flatten_row(curr);
+    let paths: BTreeSet<&String> = a.keys().chain(b.keys()).collect();
+    let mut out = Vec::new();
+    for path in paths {
+        let before = a.get(path);
+        let after = b.get(path);
+        if before != after {
+            let secret_rotated = matches!((before, after), (Some(x), Some(y))
+                if is_secret_token(x) && is_secret_token(y));
+            out.push(FieldChange {
+                path: path.clone(),
+                before: before.cloned(),
+                after: after.cloned(),
+                secret_rotated,
+            });
+        }
+    }
+    out
+}
+
+fn is_secret_token(s: &str) -> bool {
+    s.starts_with("<secret:sha256:")
+}
+
+/// Serialize a row and flatten every leaf to a `dotted.path -> String` map.
+fn flatten_row(row: &RowSnapshot) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let value = serde_json::to_value(row).unwrap_or(Value::Null);
+    flatten_value("", &value, &mut out);
+    out
+}
+
+fn flatten_value(prefix: &str, value: &Value, out: &mut BTreeMap<String, String>) {
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map {
+                let path = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                flatten_value(&path, v, out);
+            }
+        }
+        Value::Array(items) => {
+            // Empty arrays are a meaningful leaf (e.g. `transforms: []`).
+            if items.is_empty() {
+                out.insert(prefix.to_owned(), "[]".to_owned());
+            } else {
+                for (i, v) in items.iter().enumerate() {
+                    flatten_value(&format!("{prefix}[{i}]"), v, out);
+                }
+            }
+        }
+        Value::String(s) => {
+            out.insert(prefix.to_owned(), s.clone());
+        }
+        other => {
+            out.insert(prefix.to_owned(), other.to_string());
+        }
+    }
+}
+
+// ── Render ───────────────────────────────────────────────────────────────────
+
+/// Render the diff as human-readable text (the default `plan --diff` output).
+pub fn render_human(d: &SnapshotDiff) -> String {
+    let mut s = String::new();
+    let when = match d.previous_recorded_at {
+        Some(ts) => format!("last run {}", ts.format("%Y-%m-%d %H:%M UTC")),
+        None => "nothing recorded yet — first diff".to_owned(),
+    };
+    s.push_str(&format!("Pipeline: {}   ({when})\n\n", d.pipeline));
+
+    if d.first_run {
+        s.push_str(
+            "  No prior snapshot. The next `faucet run` will record one; every row below is new.\n\n",
+        );
+    }
+
+    for row in &d.rows {
+        s.push_str(&format!(
+            "  {} {:<18} {}\n",
+            row.status.glyph(),
+            row.id,
+            row.status.label()
+        ));
+        for c in &row.changes {
+            if c.secret_rotated {
+                s.push_str(&format!("      {:<28} (secret rotated)\n", c.path));
+            } else {
+                let before = c.before.as_deref().unwrap_or("(absent)");
+                let after = c.after.as_deref().unwrap_or("(absent)");
+                s.push_str(&format!("      {:<28} {before}  ->  {after}\n", c.path));
+            }
+        }
+    }
+
+    let sm = &d.summary;
+    s.push_str(&format!(
+        "\nSummary: {} to create, {} to change, {} removed, {} unchanged.\n",
+        sm.create, sm.change, sm.remove, sm.unchanged
+    ));
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::history::catalog::ConnectorSnapshot;
+    use serde_json::json;
+
+    fn conn(kind: &str, cfg: Value) -> ConnectorSnapshot {
+        ConnectorSnapshot {
+            kind: kind.into(),
+            config: cfg,
+        }
+    }
+
+    fn row(source_cfg: Value) -> RowSnapshot {
+        RowSnapshot {
+            source: conn("rest", source_cfg),
+            sink: conn("jsonl", json!({"path": "out.jsonl"})),
+            transforms: vec![],
+            state_key: None,
+            delivery_guarantee: "AtLeastOnce".into(),
+            on_error: "stop".into(),
+            dlq: false,
+        }
+    }
+
+    fn snap(rows: Vec<(&str, RowSnapshot)>) -> ConfigSnapshot {
+        ConfigSnapshot {
+            pipeline: "p".into(),
+            recorded_at: DateTime::parse_from_rfc3339("2026-07-18T00:00:00Z")
+                .unwrap()
+                .to_utc(),
+            faucet_version: "0.0.0".into(),
+            rows: rows.into_iter().map(|(k, v)| (k.to_owned(), v)).collect(),
+        }
+    }
+
+    #[test]
+    fn first_run_marks_every_row_new() {
+        let curr = snap(vec![("a", row(json!({"path": "/v1"})))]);
+        let d = diff(None, &curr);
+        assert!(d.first_run);
+        assert_eq!(d.summary.create, 1);
+        assert_eq!(d.rows[0].status, RowStatus::New);
+    }
+
+    #[test]
+    fn detects_added_removed_changed_and_unchanged() {
+        let prev = snap(vec![
+            ("payroll", row(json!({"path": "/v1/pay", "page_size": 100}))),
+            ("benefits", row(json!({"path": "/v1/benefits"}))),
+            ("employees", row(json!({"path": "/v1/emp"}))),
+        ]);
+        let curr = snap(vec![
+            ("people", row(json!({"path": "/v1/people"}))), // NEW
+            (
+                "payroll",
+                row(json!({"path": "/v1/payroll", "page_size": 500})),
+            ), // CHANGED
+            ("employees", row(json!({"path": "/v1/emp"}))), // unchanged
+                                                            // benefits REMOVED
+        ]);
+        let d = diff(Some(&prev), &curr);
+        assert_eq!(d.summary.create, 1);
+        assert_eq!(d.summary.change, 1);
+        assert_eq!(d.summary.remove, 1);
+        assert_eq!(d.summary.unchanged, 1);
+
+        let payroll = d.rows.iter().find(|r| r.id == "payroll").unwrap();
+        assert_eq!(payroll.status, RowStatus::Changed);
+        let paths: Vec<&str> = payroll.changes.iter().map(|c| c.path.as_str()).collect();
+        assert!(paths.contains(&"source.config.path"));
+        assert!(paths.contains(&"source.config.page_size"));
+        let ps = payroll
+            .changes
+            .iter()
+            .find(|c| c.path == "source.config.page_size")
+            .unwrap();
+        assert_eq!(ps.before.as_deref(), Some("100"));
+        assert_eq!(ps.after.as_deref(), Some("500"));
+    }
+
+    #[test]
+    fn secret_rotation_is_surfaced_not_printed() {
+        let prev = snap(vec![(
+            "r",
+            row(json!({"token": "<secret:sha256:aaaaaaaaaaaa>"})),
+        )]);
+        let curr = snap(vec![(
+            "r",
+            row(json!({"token": "<secret:sha256:bbbbbbbbbbbbb>"})),
+        )]);
+        let d = diff(Some(&prev), &curr);
+        let r = &d.rows[0];
+        assert_eq!(r.status, RowStatus::Changed);
+        assert!(r.changes[0].secret_rotated);
+        let text = render_human(&d);
+        assert!(text.contains("secret rotated"), "{text}");
+        assert!(!text.contains("bbbbbbbbbbbb"), "hash should not be printed");
+    }
+
+    #[test]
+    fn redact_value_replaces_registered_secret_with_stable_token() {
+        crate::secrets::registry::register("supersecrettoken");
+        let redacted = redact_value(&json!({"auth": "supersecrettoken", "path": "/v1"}));
+        let token = redacted["auth"].as_str().unwrap();
+        assert!(token.starts_with("<secret:sha256:"), "{token}");
+        assert_eq!(redacted["path"], json!("/v1"));
+        // Stable: same value → same token.
+        let again = redact_value(&json!("supersecrettoken"));
+        assert_eq!(again.as_str().unwrap(), token);
+    }
+}

--- a/cli/src/catalog/snapshot.rs
+++ b/cli/src/catalog/snapshot.rs
@@ -104,6 +104,29 @@ fn connector_snapshot(kind: &str, config: &Value) -> ConnectorSnapshot {
     }
 }
 
+/// Build + record the config snapshot for a run that finished cleanly, when a
+/// catalog is configured. Best-effort — never fails the run (mirrors
+/// [`super::record`]). This is the single place `run` / `replicate` /
+/// `schedule` funnel through, so the record logic is exercised by one test
+/// rather than three untested call sites.
+pub async fn record_if_ok(
+    catalog: Option<&super::CatalogHandle>,
+    pipeline: &str,
+    on_error: &str,
+    nodes: &[ExpandedNode],
+    succeeded: bool,
+    clock: DateTime<Utc>,
+) {
+    if !succeeded {
+        return;
+    }
+    let Some(handle) = catalog else {
+        return;
+    };
+    let snapshot = build_snapshot(pipeline.to_owned(), on_error, nodes, clock);
+    super::record_config_snapshot(handle, &snapshot).await;
+}
+
 /// Recursively replace every secret-sourced string in `value` with a stable
 /// `<secret:sha256:…>` token. Non-secret strings pass through verbatim, so real
 /// config changes (paths, table names, page sizes) stay visible in the diff.
@@ -493,5 +516,107 @@ mod tests {
         // Stable: same value → same token.
         let again = redact_value(&json!("supersecrettoken"));
         assert_eq!(again.as_str().unwrap(), token);
+    }
+
+    /// Write a config to a temp file and return (config, expanded nodes, path).
+    fn expand_config(
+        yaml: &str,
+    ) -> (
+        crate::config::PipelineConfig,
+        Vec<ExpandedNode>,
+        std::path::PathBuf,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("p.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        let cfg = crate::config::PipelineConfig::from_path_tolerating_secrets(&path, None).unwrap();
+        let nodes = crate::expand::expand(&cfg).unwrap();
+        std::mem::forget(dir); // keep the temp file alive for the returned path
+        (cfg, nodes, path)
+    }
+
+    const REST_TO_JSONL: &str = r#"
+version: 1
+name: mypipe
+pipeline:
+  source:
+    type: rest
+    config:
+      url: https://api.example.com/v1
+      auth: { type: bearer, config: { token: topsecretvalue12345 } }
+  sink:
+    type: jsonl
+    config:
+      path: out.jsonl
+  transforms:
+    - type: flatten
+      config: {}
+"#;
+
+    #[test]
+    fn build_snapshot_shapes_rows_and_redacts_secrets() {
+        crate::secrets::registry::register("topsecretvalue12345");
+        let (cfg, nodes, path) = expand_config(REST_TO_JSONL);
+        assert_eq!(resolve_name(&cfg, Some(&path)), "mypipe");
+        assert_eq!(on_error_str(&cfg.execution), "continue"); // default
+
+        let snap = build_snapshot(
+            resolve_name(&cfg, Some(&path)),
+            on_error_str(&cfg.execution),
+            &nodes,
+            Utc::now(),
+        );
+        assert_eq!(snap.pipeline, "mypipe");
+        let r = snap.rows.values().next().unwrap();
+        assert_eq!(r.source.kind, "rest");
+        assert_eq!(r.sink.kind, "jsonl");
+        assert_eq!(r.transforms.len(), 1);
+        let src = serde_json::to_string(&r.source.config).unwrap();
+        assert!(!src.contains("topsecretvalue12345"), "secret leaked: {src}");
+        assert!(src.contains("api.example.com"), "non-secret url must show");
+    }
+
+    #[test]
+    fn resolve_name_falls_back_to_file_stem_then_default() {
+        // No `name:` → file stem.
+        let (cfg, _n, path) = expand_config(
+            "version: 1\npipeline:\n  source: { type: rest, config: { url: https://x/y } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\n",
+        );
+        assert_eq!(resolve_name(&cfg, Some(&path)), "p"); // p.yaml
+        assert_eq!(resolve_name(&cfg, None), "pipeline"); // nothing → default
+    }
+
+    #[tokio::test]
+    async fn record_if_ok_records_only_on_success_with_a_catalog() {
+        let (_cfg, nodes, _p) = expand_config(REST_TO_JSONL);
+        let handle = crate::catalog::connect_from_spec(&crate::catalog::CatalogSpec {
+            url: "memory".into(),
+            sample_records: 10,
+        })
+        .await
+        .unwrap();
+
+        // Failure → nothing recorded.
+        record_if_ok(Some(&handle), "mypipe", "stop", &nodes, false, Utc::now()).await;
+        assert!(
+            handle
+                .store
+                .catalog_last_config_snapshot("mypipe")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        // No catalog → no-op (must not panic).
+        record_if_ok(None, "mypipe", "stop", &nodes, true, Utc::now()).await;
+        // Success + catalog → recorded.
+        record_if_ok(Some(&handle), "mypipe", "stop", &nodes, true, Utc::now()).await;
+        let got = handle
+            .store
+            .catalog_last_config_snapshot("mypipe")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.pipeline, "mypipe");
+        assert!(!got.rows.is_empty());
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -937,8 +937,13 @@ pub struct PlanArgs {
     /// Emit the plan as JSON.
     #[arg(long)]
     pub json: bool,
+    /// Show a `terraform plan`-style diff of the current config against the last
+    /// recorded run, instead of the resolved-pipeline preview (#374). Requires a
+    /// `catalog:` block. Resolves secrets so the diff matches what `run` records.
+    #[arg(long)]
+    pub diff: bool,
     /// Resolve secrets-manager directives (needs network/credentials). Off by
-    /// default so `plan` works offline like `faucet test`.
+    /// default so `plan` works offline like `faucet test`. Implied by `--diff`.
     #[arg(long)]
     pub resolve_secrets: bool,
     /// Select a `profiles:` overlay.

--- a/cli/src/commands/plan.rs
+++ b/cli/src/commands/plan.rs
@@ -217,6 +217,20 @@ fn render_delta(dest: &Value, inferred: &Value) -> SchemaDeltaReport {
 
 /// Execute the `plan` subcommand.
 pub async fn run(args: PlanArgs) -> CliResult<()> {
+    if args.diff {
+        #[cfg(feature = "catalog")]
+        {
+            return run_diff(args).await;
+        }
+        #[cfg(not(feature = "catalog"))]
+        {
+            return Err(CliError::Config(
+                "`faucet plan --diff` requires a binary built with the `catalog` feature \
+                 (e.g. `cargo install faucet-cli --features catalog`)"
+                    .into(),
+            ));
+        }
+    }
     let cwd = std::env::current_dir()?;
     let path = match &args.config {
         Some(p) => p.clone(),
@@ -394,6 +408,51 @@ fn render_human(r: &PlanReport) {
     println!("\n  (read-only — no sink was written)");
 }
 
+/// `faucet plan --diff` (#374): compare the current resolved+expanded config
+/// against the last snapshot recorded by a successful run. Secrets are resolved
+/// (so redaction matches the record side) and never printed.
+#[cfg(feature = "catalog")]
+async fn run_diff(args: PlanArgs) -> CliResult<()> {
+    use crate::catalog::snapshot;
+    let cwd = std::env::current_dir()?;
+    let path = match &args.config {
+        Some(p) => p.clone(),
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+    // Resolve secrets so the redacted current config matches what `run` stored.
+    let cfg =
+        crate::config::PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
+    let spec = cfg.catalog.as_ref().ok_or_else(|| {
+        CliError::Config(
+            "`faucet plan --diff` needs a `catalog:` block to read the last recorded run \
+             (see `faucet schema catalog`)"
+                .into(),
+        )
+    })?;
+    let nodes = expand::expand(&cfg)?;
+    let pipeline = snapshot::resolve_name(&cfg, Some(&path));
+    let current = snapshot::build_snapshot(
+        pipeline.clone(),
+        snapshot::on_error_str(&cfg.execution),
+        &nodes,
+        chrono::Utc::now(),
+    );
+    let handle = crate::catalog::connect_from_spec(spec).await?;
+    let previous = handle
+        .store
+        .catalog_last_config_snapshot(&pipeline)
+        .await
+        .map_err(|e| CliError::Config(format!("catalog read failed: {e}")))?;
+    let d = snapshot::diff(previous.as_ref(), &current);
+    if args.json {
+        let out = serde_json::to_string_pretty(&d).map_err(|e| CliError::Config(e.to_string()))?;
+        println!("{out}");
+    } else {
+        print!("{}", snapshot::render_human(&d));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -423,6 +482,7 @@ mod tests {
             live: false,
             limit: 10,
             json: false,
+            diff: false,
             resolve_secrets: false,
             profile: None,
         };

--- a/cli/src/commands/plan.rs
+++ b/cli/src/commands/plan.rs
@@ -510,4 +510,86 @@ mod tests {
         assert_eq!(report.sink, "jsonl");
         assert_eq!(report.write_mode, "append");
     }
+
+    /// `plan --diff` end-to-end over a real sqlite catalog: first run reports
+    /// first-run (nothing recorded), then after a snapshot is recorded the diff
+    /// compares against it. Exercises `run_diff` both branches.
+    #[cfg(all(feature = "catalog", feature = "serve-history-sqlite"))]
+    #[tokio::test]
+    async fn plan_diff_first_run_then_against_recorded_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("cat.db");
+        let cfg_path = dir.path().join("pipe.yaml");
+        std::fs::write(
+            &cfg_path,
+            format!(
+                "version: 1\nname: diffpipe\npipeline:\n  source:\n    type: csv\n    config:\n      path: in.csv\n  sink:\n    type: jsonl\n    config:\n      path: out.jsonl\ncatalog:\n  url: \"sqlite:{}\"\n",
+                db.display()
+            ),
+        )
+        .unwrap();
+
+        let mk_args = || PlanArgs {
+            config: Some(cfg_path.clone()),
+            row: None,
+            sample: None,
+            live: false,
+            limit: 10,
+            json: false,
+            diff: true,
+            resolve_secrets: false,
+            profile: None,
+        };
+
+        // 1. Nothing recorded yet → first-run path.
+        super::run(mk_args()).await.expect("first plan --diff");
+
+        // 2. Record a snapshot exactly as a successful run would.
+        let cfg = crate::config::PipelineConfig::from_path_async(&cfg_path, None)
+            .await
+            .unwrap();
+        let nodes = crate::expand::expand(&cfg).unwrap();
+        let handle = crate::catalog::connect_from_spec(cfg.catalog.as_ref().unwrap())
+            .await
+            .unwrap();
+        crate::catalog::snapshot::record_if_ok(
+            Some(&handle),
+            "diffpipe",
+            "continue",
+            &nodes,
+            true,
+            chrono::Utc::now(),
+        )
+        .await;
+
+        // 3. Now the diff compares against the recorded snapshot (unchanged).
+        super::run(mk_args()).await.expect("second plan --diff");
+    }
+
+    /// `plan --diff` on a config with no `catalog:` block is a clear error
+    /// (there is nothing to diff against).
+    #[cfg(feature = "catalog")]
+    #[tokio::test]
+    async fn plan_diff_without_catalog_block_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("p.yaml");
+        std::fs::write(
+            &cfg_path,
+            "version: 1\nname: nocat\npipeline:\n  source: { type: csv, config: { path: in.csv } }\n  sink: { type: jsonl, config: { path: out.jsonl } }\n",
+        )
+        .unwrap();
+        let args = PlanArgs {
+            config: Some(cfg_path),
+            row: None,
+            sample: None,
+            live: false,
+            limit: 10,
+            json: false,
+            diff: true,
+            resolve_secrets: false,
+            profile: None,
+        };
+        let err = super::run(args).await.unwrap_err();
+        assert!(err.to_string().contains("catalog:"), "{err}");
+    }
 }

--- a/cli/src/commands/replicate.rs
+++ b/cli/src/commands/replicate.rs
@@ -51,6 +51,23 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
         Some(spec) => Some(crate::catalog::connect_from_spec(spec).await?),
         None => None,
     };
+    // Config snapshot for `faucet plan --diff` (#374). Best-effort: skip if the
+    // config does not expand cleanly (some replication shapes are orchestration
+    // -only). Recorded after the replication run succeeds below.
+    #[cfg(feature = "catalog")]
+    let config_snapshot = catalog
+        .as_ref()
+        .and_then(|_| crate::expand::expand(&cfg).ok())
+        .map(|nodes| {
+            crate::catalog::snapshot::build_snapshot(
+                pipeline_name.clone(),
+                crate::catalog::snapshot::on_error_str(&cfg.execution),
+                &nodes,
+                chrono::Utc::now(),
+            )
+        });
+    #[cfg(feature = "catalog")]
+    let catalog_for_snapshot = catalog.clone();
 
     run_replication(
         &cfg,
@@ -69,6 +86,12 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
         },
     )
     .await?;
+
+    // Reached only on success (errors returned via `?` above).
+    #[cfg(feature = "catalog")]
+    if let (Some(handle), Some(snap)) = (catalog_for_snapshot, config_snapshot) {
+        crate::catalog::record_config_snapshot(&handle, &snap).await;
+    }
 
     // Flush any buffered OTLP telemetry before exiting (no-op without `otel`).
     faucet_core::shutdown_otel();

--- a/cli/src/commands/replicate.rs
+++ b/cli/src/commands/replicate.rs
@@ -55,19 +55,11 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
     // config does not expand cleanly (some replication shapes are orchestration
     // -only). Recorded after the replication run succeeds below.
     #[cfg(feature = "catalog")]
-    let config_snapshot = catalog
-        .as_ref()
-        .and_then(|_| crate::expand::expand(&cfg).ok())
-        .map(|nodes| {
-            crate::catalog::snapshot::build_snapshot(
-                pipeline_name.clone(),
-                crate::catalog::snapshot::on_error_str(&cfg.execution),
-                &nodes,
-                chrono::Utc::now(),
-            )
-        });
-    #[cfg(feature = "catalog")]
-    let catalog_for_snapshot = catalog.clone();
+    let snapshot_inputs = catalog.as_ref().and_then(|handle| {
+        crate::expand::expand(&cfg)
+            .ok()
+            .map(|nodes| (handle.clone(), nodes, pipeline_name.clone()))
+    });
 
     run_replication(
         &cfg,
@@ -89,8 +81,16 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
 
     // Reached only on success (errors returned via `?` above).
     #[cfg(feature = "catalog")]
-    if let (Some(handle), Some(snap)) = (catalog_for_snapshot, config_snapshot) {
-        crate::catalog::record_config_snapshot(&handle, &snap).await;
+    if let Some((handle, nodes, name)) = snapshot_inputs {
+        crate::catalog::snapshot::record_if_ok(
+            Some(&handle),
+            &name,
+            crate::catalog::snapshot::on_error_str(&cfg.execution),
+            &nodes,
+            true,
+            chrono::Utc::now(),
+        )
+        .await;
     }
 
     // Flush any buffered OTLP telemetry before exiting (no-op without `otel`).

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -114,6 +114,19 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         None => None,
     };
     let nodes = expand(&cfg)?;
+    // Build the config snapshot (#374) before `nodes`/`catalog` are moved into
+    // the executor. Pure + cheap; recorded after a fully-successful run below.
+    #[cfg(feature = "catalog")]
+    let config_snapshot = catalog.as_ref().map(|_| {
+        crate::catalog::snapshot::build_snapshot(
+            pipeline_name.clone(),
+            crate::catalog::snapshot::on_error_str(&cfg.execution),
+            &nodes,
+            chrono::Utc::now(),
+        )
+    });
+    #[cfg(feature = "catalog")]
+    let catalog_for_snapshot = catalog.clone();
     // The TUI wires `q` / Ctrl-C to this token: in-flight invocations stop at
     // their next page boundary and flush (#146 H16). Plain runs keep `None`.
     #[cfg(feature = "cli-tui")]
@@ -174,6 +187,15 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         .filter(|i| i.error.is_none())
         .count();
     let failed = summary.failure_count();
+
+    // Record the resolved config snapshot for `faucet plan --diff` on a fully
+    // successful run only (best-effort — never fails the run; #374 / #279).
+    #[cfg(feature = "catalog")]
+    if failed == 0
+        && let (Some(handle), Some(snap)) = (catalog_for_snapshot, config_snapshot)
+    {
+        crate::catalog::record_config_snapshot(&handle, &snap).await;
+    }
 
     tracing::info!(
         pipeline = %pipeline_name,

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -114,19 +114,12 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         None => None,
     };
     let nodes = expand(&cfg)?;
-    // Build the config snapshot (#374) before `nodes`/`catalog` are moved into
-    // the executor. Pure + cheap; recorded after a fully-successful run below.
+    // Capture the config-snapshot inputs (#374) before `nodes` / `catalog` are
+    // moved into the executor; recorded after a fully-successful run below.
     #[cfg(feature = "catalog")]
-    let config_snapshot = catalog.as_ref().map(|_| {
-        crate::catalog::snapshot::build_snapshot(
-            pipeline_name.clone(),
-            crate::catalog::snapshot::on_error_str(&cfg.execution),
-            &nodes,
-            chrono::Utc::now(),
-        )
-    });
-    #[cfg(feature = "catalog")]
-    let catalog_for_snapshot = catalog.clone();
+    let snapshot_inputs = catalog
+        .as_ref()
+        .map(|handle| (handle.clone(), nodes.clone(), pipeline_name.clone()));
     // The TUI wires `q` / Ctrl-C to this token: in-flight invocations stop at
     // their next page boundary and flush (#146 H16). Plain runs keep `None`.
     #[cfg(feature = "cli-tui")]
@@ -188,13 +181,19 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         .count();
     let failed = summary.failure_count();
 
-    // Record the resolved config snapshot for `faucet plan --diff` on a fully
-    // successful run only (best-effort — never fails the run; #374 / #279).
+    // Record the resolved config snapshot for `faucet plan --diff` (best-effort;
+    // #374 / #279) — only on a fully-successful run.
     #[cfg(feature = "catalog")]
-    if failed == 0
-        && let (Some(handle), Some(snap)) = (catalog_for_snapshot, config_snapshot)
-    {
-        crate::catalog::record_config_snapshot(&handle, &snap).await;
+    if let Some((handle, snap_nodes, name)) = snapshot_inputs {
+        crate::catalog::snapshot::record_if_ok(
+            Some(&handle),
+            &name,
+            crate::catalog::snapshot::on_error_str(&cfg.execution),
+            &snap_nodes,
+            failed == 0,
+            chrono::Utc::now(),
+        )
+        .await;
     }
 
     tracing::info!(

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -438,15 +438,15 @@ async fn run_once(
     // Record the config snapshot for `faucet plan --diff` after a clean tick
     // (best-effort; #374). Repeated identical ticks upsert harmlessly.
     #[cfg(feature = "catalog")]
-    if let Some(handle) = catalog {
-        let snap = crate::catalog::snapshot::build_snapshot(
-            pipeline_name.to_owned(),
-            crate::catalog::snapshot::on_error_str(execution),
-            nodes,
-            chrono::Utc::now(),
-        );
-        crate::catalog::record_config_snapshot(handle, &snap).await;
-    }
+    crate::catalog::snapshot::record_if_ok(
+        catalog.as_ref(),
+        pipeline_name,
+        crate::catalog::snapshot::on_error_str(execution),
+        nodes,
+        true,
+        chrono::Utc::now(),
+    )
+    .await;
     Ok(())
 }
 

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -435,6 +435,18 @@ async fn run_once(
             count: summary.failure_count(),
         });
     }
+    // Record the config snapshot for `faucet plan --diff` after a clean tick
+    // (best-effort; #374). Repeated identical ticks upsert harmlessly.
+    #[cfg(feature = "catalog")]
+    if let Some(handle) = catalog {
+        let snap = crate::catalog::snapshot::build_snapshot(
+            pipeline_name.to_owned(),
+            crate::catalog::snapshot::on_error_str(execution),
+            nodes,
+            chrono::Utc::now(),
+        );
+        crate::catalog::record_config_snapshot(handle, &snap).await;
+    }
     Ok(())
 }
 

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -28,7 +28,6 @@ use crate::expand::{ExpandedNode, NodeRole};
 use crate::interpolate::interpolate_record;
 use crate::registry::{build_sink, build_source};
 use crate::state::build_state_store;
-use crate::transforms::compile_transforms;
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset};
 use faucet_core::observability::Labels;
@@ -1020,23 +1019,40 @@ async fn run_one_invocation(
     //    transform's config first — exactly as for source/sink above — so e.g. a
     //    `set` transform stamping `${now.date}` writes the real date instead of
     //    the literal token string. Without this the token leaks into every record.
-    let stages = if node.transforms.is_empty() {
-        compile_transforms(&node.transforms)?
-    } else {
-        let mut transforms = node.transforms.clone();
-        for t in &mut transforms {
-            resolve_now_inplace(&mut t.config, opts.clock)?;
+    let mut transforms = node.transforms.clone();
+    for t in &mut transforms {
+        resolve_now_inplace(&mut t.config, opts.clock)?;
+    }
+    // With `arrow`, compile the columnar batch forms too so an all-columnar
+    // chain (e.g. `parquet → sql → parquet`) runs on the Arrow fast path; a
+    // `Value`-only stage in the chain leaves `batch_fns` with a `None` entry,
+    // which keeps the whole pipeline on the `Value` path (#375).
+    #[cfg(feature = "arrow")]
+    let source: Box<dyn Source> = {
+        let (stages, batch_fns) = crate::transforms::compile_transforms_columnar(&transforms)?;
+        if stages.is_empty() {
+            source
+        } else {
+            Box::new(faucet_core::TransformingSource::new_with_batches(
+                source,
+                stages,
+                batch_fns,
+                obs_labels.clone(),
+            )?)
         }
-        compile_transforms(&transforms)?
     };
-    let source: Box<dyn Source> = if stages.is_empty() {
-        source
-    } else {
-        Box::new(faucet_core::TransformingSource::new(
-            source,
-            stages,
-            obs_labels.clone(),
-        )?)
+    #[cfg(not(feature = "arrow"))]
+    let source: Box<dyn Source> = {
+        let stages = crate::transforms::compile_transforms(&transforms)?;
+        if stages.is_empty() {
+            source
+        } else {
+            Box::new(faucet_core::TransformingSource::new(
+                source,
+                stages,
+                obs_labels.clone(),
+            )?)
+        }
     };
 
     // 4) Build state store. If the source opts into state, wrap it so the

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -31,6 +31,16 @@ pub fn register(secret: &str) {
 
 /// Replace every registered secret value in `input` with `***`.
 pub fn redact(input: &str) -> Cow<'_, str> {
+    redact_with(input, |_| "***".to_owned())
+}
+
+/// Replace every registered secret value in `input` with a caller-supplied
+/// token. `token(secret)` receives the raw secret and returns its replacement;
+/// it is called only for secrets actually present in `input`. Used by the
+/// config-snapshot writer (#374) to swap secrets for stable `<secret:sha256:…>`
+/// tokens instead of `***`, so a rotation surfaces as a changed hash without
+/// ever persisting the secret. Same longest-first ordering as [`redact`].
+pub fn redact_with(input: &str, token: impl Fn(&str) -> String) -> Cow<'_, str> {
     let reg = registry().read().expect("secret registry lock poisoned");
     if reg.is_empty() {
         return Cow::Borrowed(input);
@@ -46,7 +56,7 @@ pub fn redact(input: &str) -> Cow<'_, str> {
     for secret in secrets {
         let current = out.as_deref().unwrap_or(input);
         if current.contains(secret) {
-            out = Some(current.replace(secret, "***"));
+            out = Some(current.replace(secret, &token(secret)));
         }
     }
     match out {

--- a/cli/src/serve/history/catalog.rs
+++ b/cli/src/serve/history/catalog.rs
@@ -80,6 +80,61 @@ pub struct CatalogUpdate {
     pub column_lineage: Option<Value>,
 }
 
+// ── Config snapshots (#374) ──────────────────────────────────────────────────
+//
+// A `faucet plan --diff`-able record of the *resolved + expanded* config as it
+// last ran. One snapshot per pipeline (latest wins); each carries a per-row,
+// secret-redacted view so the diff reflects real data-movement effects, never a
+// misleading raw-YAML text diff. Stored types only — the build-from-`ExpandedNode`
+// and diff/render logic lives in `cli/src/catalog/snapshot.rs` (a higher layer
+// that may depend on the CLI's expand types; this module must not).
+
+/// A redacted, resolved+expanded config snapshot recorded on a successful run.
+/// Diffed by `faucet plan --diff` against the current config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConfigSnapshot {
+    pub pipeline: String,
+    pub recorded_at: DateTime<Utc>,
+    /// `faucet` version that recorded the snapshot (informational).
+    pub faucet_version: String,
+    /// Expanded row id → row snapshot. `BTreeMap` so serialization and diffs are
+    /// deterministic regardless of expansion order.
+    pub rows: std::collections::BTreeMap<String, RowSnapshot>,
+}
+
+/// One expanded row (a single source→sink movement) as it last ran.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RowSnapshot {
+    pub source: ConnectorSnapshot,
+    pub sink: ConnectorSnapshot,
+    pub transforms: Vec<TransformSnapshot>,
+    /// Durable state key for this row, when a state store is configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+    /// End-to-end delivery guarantee (`Debug` of `DeliveryGuarantee`).
+    pub delivery_guarantee: String,
+    /// Pipeline-level `execution.on_error` (`"stop"` / `"continue"`).
+    pub on_error: String,
+    /// Whether a DLQ sink is attached to this row.
+    pub dlq: bool,
+}
+
+/// A connector (source or sink) with its **secret-redacted** resolved config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectorSnapshot {
+    pub kind: String,
+    /// Resolved config with every secret-sourced value replaced by a stable
+    /// `<secret:sha256:…>` token — no secret material is ever persisted.
+    pub config: Value,
+}
+
+/// A transform stage with its resolved (redacted) config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TransformSnapshot {
+    pub kind: String,
+    pub config: Value,
+}
+
 /// One catalogued dataset — the list element and the head of the detail view.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogDataset {

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -274,6 +274,18 @@ impl RunHistory for FallbackHistory {
     ) -> Result<Vec<crate::serve::history::catalog::CatalogLineageEdge>, HistoryError> {
         via!(self, p => p.catalog_lineage(root, depth), f => f.catalog_lineage(root, depth))
     }
+    async fn catalog_record_config_snapshot(
+        &self,
+        snapshot: &crate::serve::history::catalog::ConfigSnapshot,
+    ) -> Result<(), HistoryError> {
+        via!(self, p => p.catalog_record_config_snapshot(snapshot), f => f.catalog_record_config_snapshot(snapshot))
+    }
+    async fn catalog_last_config_snapshot(
+        &self,
+        pipeline: &str,
+    ) -> Result<Option<crate::serve::history::catalog::ConfigSnapshot>, HistoryError> {
+        via!(self, p => p.catalog_last_config_snapshot(pipeline), f => f.catalog_last_config_snapshot(pipeline))
+    }
 
     fn degraded(&self) -> bool {
         self.is_degraded()

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -39,6 +39,8 @@ struct CatalogState {
     stats: std::collections::HashMap<String, Vec<CatalogStatsPoint>>,
     /// (src id, dst id) → edge.
     edges: std::collections::HashMap<(String, String), CatalogLineageEdge>,
+    /// pipeline name → latest config snapshot (#374). Latest-wins.
+    config_snapshots: std::collections::HashMap<String, super::catalog::ConfigSnapshot>,
 }
 
 pub struct MemoryHistory {
@@ -351,6 +353,30 @@ impl RunHistory for MemoryHistory {
                 .then_with(|| (&a.src_id, &a.dst_id).cmp(&(&b.src_id, &b.dst_id)))
         });
         Ok(catalog::lineage_slice(edges, root, depth))
+    }
+
+    async fn catalog_record_config_snapshot(
+        &self,
+        snapshot: &catalog::ConfigSnapshot,
+    ) -> Result<(), HistoryError> {
+        let mut cat = self
+            .catalog
+            .lock()
+            .map_err(|_| HistoryError::Backend("catalog lock poisoned".into()))?;
+        cat.config_snapshots
+            .insert(snapshot.pipeline.clone(), snapshot.clone());
+        Ok(())
+    }
+
+    async fn catalog_last_config_snapshot(
+        &self,
+        pipeline: &str,
+    ) -> Result<Option<catalog::ConfigSnapshot>, HistoryError> {
+        let cat = self
+            .catalog
+            .lock()
+            .map_err(|_| HistoryError::Backend("catalog lock poisoned".into()))?;
+        Ok(cat.config_snapshots.get(pipeline).cloned())
     }
 
     fn degraded(&self) -> bool {
@@ -694,6 +720,34 @@ mod tests {
             },
             column_lineage: None,
         }
+    }
+
+    #[tokio::test]
+    async fn config_snapshot_roundtrips_latest_wins() {
+        use crate::serve::history::catalog::ConfigSnapshot;
+        use std::collections::BTreeMap;
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        assert!(
+            h.catalog_last_config_snapshot("p").await.unwrap().is_none(),
+            "no snapshot before any record"
+        );
+        let mk = |ver: &str| ConfigSnapshot {
+            pipeline: "p".into(),
+            recorded_at: Utc::now(),
+            faucet_version: ver.into(),
+            rows: BTreeMap::new(),
+        };
+        h.catalog_record_config_snapshot(&mk("1")).await.unwrap();
+        h.catalog_record_config_snapshot(&mk("2")).await.unwrap();
+        let got = h.catalog_last_config_snapshot("p").await.unwrap().unwrap();
+        assert_eq!(got.faucet_version, "2", "latest-wins upsert");
+        assert!(
+            h.catalog_last_config_snapshot("other")
+                .await
+                .unwrap()
+                .is_none(),
+            "snapshots are keyed per pipeline"
+        );
     }
 
     #[tokio::test]

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -606,6 +606,28 @@ pub trait RunHistory: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Record the latest resolved+expanded config snapshot for a pipeline
+    /// (#374). Latest-wins per pipeline (upsert). Best-effort at the call site —
+    /// recording never fails a run. Default: no-op.
+    async fn catalog_record_config_snapshot(
+        &self,
+        snapshot: &catalog::ConfigSnapshot,
+    ) -> Result<(), HistoryError> {
+        let _ = snapshot;
+        Ok(())
+    }
+
+    /// The most recently recorded config snapshot for `pipeline`, or `None` if
+    /// nothing has been recorded yet (a first `faucet plan --diff`). Default:
+    /// `None`.
+    async fn catalog_last_config_snapshot(
+        &self,
+        pipeline: &str,
+    ) -> Result<Option<catalog::ConfigSnapshot>, HistoryError> {
+        let _ = pipeline;
+        Ok(None)
+    }
+
     /// True when the backend is in fallback mode (drives `/readyz`). Always false
     /// for memory.
     fn degraded(&self) -> bool;

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -127,6 +127,14 @@ pub const DDL: &[&str] = &[
         run_id TEXT NOT NULL,\
         records TEXT NOT NULL,\
         PRIMARY KEY (dataset_id, recorded_at))",
+    // Resolved+expanded config snapshots for `faucet plan --diff` (#374). One
+    // row per pipeline (latest-wins upsert); `body` is the redacted
+    // `ConfigSnapshot` JSON — no secret material is ever stored.
+    "CREATE TABLE IF NOT EXISTS faucet_config_snapshots (\
+        pipeline TEXT PRIMARY KEY,\
+        recorded_at TEXT NOT NULL,\
+        faucet_version TEXT NOT NULL,\
+        body TEXT NOT NULL)",
 ];
 
 /// SQL placeholder dialect.
@@ -259,6 +267,11 @@ pub struct Stmts {
     /// Drop volume points beyond the newest `STATS_RETAIN` for one dataset.
     /// Params: dataset_id, dataset_id, keep-limit.
     pub catalog_prune_stats: String,
+    /// Upsert the latest config snapshot for a pipeline (#374).
+    /// Params: pipeline, recorded_at, faucet_version, body.
+    pub catalog_upsert_config_snapshot: String,
+    /// The latest config snapshot body for a pipeline. Param: pipeline.
+    pub catalog_select_config_snapshot: String,
 }
 
 impl Stmts {
@@ -477,6 +490,13 @@ impl Stmts {
                     SELECT recorded_at FROM faucet_catalog_stats WHERE dataset_id=$2 \
                     ORDER BY recorded_at DESC LIMIT $3)"
                 .into(),
+            catalog_upsert_config_snapshot: "INSERT INTO faucet_config_snapshots \
+                (pipeline, recorded_at, faucet_version, body) VALUES ($1,$2,$3,$4) \
+                ON CONFLICT (pipeline) DO UPDATE SET recorded_at=excluded.recorded_at, \
+                faucet_version=excluded.faucet_version, body=excluded.body"
+                .into(),
+            catalog_select_config_snapshot:
+                "SELECT body FROM faucet_config_snapshots WHERE pipeline=$1".into(),
         }
     }
 
@@ -680,6 +700,13 @@ impl Stmts {
                     SELECT recorded_at FROM faucet_catalog_stats WHERE dataset_id=? \
                     ORDER BY recorded_at DESC LIMIT ?)"
                 .into(),
+            catalog_upsert_config_snapshot: "INSERT INTO faucet_config_snapshots \
+                (pipeline, recorded_at, faucet_version, body) VALUES (?,?,?,?) \
+                ON CONFLICT (pipeline) DO UPDATE SET recorded_at=excluded.recorded_at, \
+                faucet_version=excluded.faucet_version, body=excluded.body"
+                .into(),
+            catalog_select_config_snapshot:
+                "SELECT body FROM faucet_config_snapshots WHERE pipeline=?".into(),
         }
     }
 }
@@ -2073,6 +2100,47 @@ macro_rules! impl_sql_history {
                 use $crate::serve::history::catalog;
                 let edges = self.catalog_all_edges().await?;
                 Ok(catalog::lineage_slice(edges, root, depth))
+            }
+
+            async fn catalog_record_config_snapshot(
+                &self,
+                snapshot: &$crate::serve::history::catalog::ConfigSnapshot,
+            ) -> Result<(), $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                sqlx::query(&self.stmts.catalog_upsert_config_snapshot)
+                    .bind(&snapshot.pipeline)
+                    .bind(sql::fmt_ts(snapshot.recorded_at))
+                    .bind(&snapshot.faucet_version)
+                    .bind(sql::encode_json(snapshot, "config snapshot")?)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                Ok(())
+            }
+
+            async fn catalog_last_config_snapshot(
+                &self,
+                pipeline: &str,
+            ) -> Result<
+                Option<$crate::serve::history::catalog::ConfigSnapshot>,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let Some(row) = sqlx::query(&self.stmts.catalog_select_config_snapshot)
+                    .bind(pipeline)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(backend)?
+                else {
+                    return Ok(None);
+                };
+                let body: String = row.try_get("body").map_err(backend)?;
+                Ok(Some(sql::decode_json(&body, "config snapshot")?))
             }
 
             fn degraded(&self) -> bool {

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -306,6 +306,38 @@ mod shard_tests {
     }
 
     #[tokio::test]
+    async fn config_snapshot_roundtrips_and_upserts_latest() {
+        use crate::serve::history::catalog::ConfigSnapshot;
+        use std::collections::BTreeMap;
+        let dir = tempfile::tempdir().unwrap();
+        let h = backend(&url_in(dir.path()), "a", Duration::from_secs(60)).await;
+        assert!(
+            h.catalog_last_config_snapshot("p").await.unwrap().is_none(),
+            "no snapshot before any record"
+        );
+        let mk = |ver: &str| ConfigSnapshot {
+            pipeline: "p".into(),
+            recorded_at: chrono::Utc::now(),
+            faucet_version: ver.into(),
+            rows: BTreeMap::new(),
+        };
+        h.catalog_record_config_snapshot(&mk("1")).await.unwrap();
+        h.catalog_record_config_snapshot(&mk("2")).await.unwrap();
+        let got = h.catalog_last_config_snapshot("p").await.unwrap().unwrap();
+        assert_eq!(
+            got.faucet_version, "2",
+            "latest-wins upsert on one pipeline"
+        );
+        assert!(
+            h.catalog_last_config_snapshot("nope")
+                .await
+                .unwrap()
+                .is_none(),
+            "keyed per pipeline"
+        );
+    }
+
+    #[tokio::test]
     async fn catalog_record_roundtrips_datasets_timeline_stats_and_edges() {
         use crate::serve::history::catalog::{
             self, CatalogListFilter, CatalogUpdate, DatasetObservation, DatasetRole,

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -978,7 +978,14 @@ mod tests {
         }];
         let out = compile_transforms(&specs).unwrap();
         assert_eq!(out.len(), 1);
-        assert!(matches!(out[0], faucet_core::TransformStage::PageFn(_)));
+        // The sql transform is Arrow-capable: it compiles to `PageFnColumnar`
+        // (a `PageFn` that also carries a `RecordBatch` form) so it can run on
+        // the columnar fast path (#375). `faucet-core/arrow` is always on when
+        // `transform-sql` is compiled.
+        assert!(matches!(
+            out[0],
+            faucet_core::TransformStage::PageFnColumnar { .. }
+        ));
     }
 
     #[cfg(feature = "transform-sql")]

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -477,6 +477,46 @@ fn compile_one(spec: &TransformSpec) -> CliResult<TransformStage> {
     }
 }
 
+/// Like [`compile_transforms`] but also returns each stage's Arrow
+/// `RecordBatch` form (parallel to the stages), so the executor can build a
+/// columnar-capable `TransformingSource` (#375). Only the `sql` transform
+/// supplies a batch form today; every other stage's entry is `None`, which
+/// keeps the whole chain on the `Value` path unless every stage is columnar.
+#[cfg(feature = "arrow")]
+pub fn compile_transforms_columnar(
+    specs: &[TransformSpec],
+) -> CliResult<(
+    Vec<TransformStage>,
+    Vec<Option<faucet_core::stage::PageFnBatchBox>>,
+)> {
+    let mut stages = Vec::with_capacity(specs.len());
+    let mut batches = Vec::with_capacity(specs.len());
+    for s in specs {
+        #[cfg(feature = "transform-sql")]
+        if s.kind == "sql" {
+            let cfg = decode_sql("sql", s.config.clone())?;
+            let transform = faucet_transform_sql::SqlTransform::compile(&cfg).map_err(|e| {
+                let message = match &e {
+                    faucet_core::FaucetError::Transform(m)
+                    | faucet_core::FaucetError::Config(m) => m.clone(),
+                    other => format!("{other}"),
+                };
+                CliError::InvalidTransform {
+                    name: "sql".to_owned(),
+                    message,
+                }
+            })?;
+            let (stage, batch) = transform.into_columnar_stage();
+            stages.push(stage);
+            batches.push(Some(batch));
+            continue;
+        }
+        stages.push(compile_one(s)?);
+        batches.push(None);
+    }
+    Ok((stages, batches))
+}
+
 /// One-line summary of every transform compiled into this build. Used by
 /// `faucet list`.
 pub fn transform_descriptions() -> Vec<(&'static str, &'static str)> {
@@ -978,14 +1018,7 @@ mod tests {
         }];
         let out = compile_transforms(&specs).unwrap();
         assert_eq!(out.len(), 1);
-        // The sql transform is Arrow-capable: it compiles to `PageFnColumnar`
-        // (a `PageFn` that also carries a `RecordBatch` form) so it can run on
-        // the columnar fast path (#375). `faucet-core/arrow` is always on when
-        // `transform-sql` is compiled.
-        assert!(matches!(
-            out[0],
-            faucet_core::TransformStage::PageFnColumnar { .. }
-        ));
+        assert!(matches!(out[0], faucet_core::TransformStage::PageFn(_)));
     }
 
     #[cfg(feature = "transform-sql")]

--- a/cli/tests/plan_diff_e2e.rs
+++ b/cli/tests/plan_diff_e2e.rs
@@ -1,0 +1,83 @@
+#![cfg(all(feature = "catalog", feature = "serve-history-sqlite"))]
+//! End-to-end for the config-change preview (#374): a successful `faucet run`
+//! with a `catalog:` block records a config snapshot, and `faucet plan --diff`
+//! then diffs the current config against it. Exercises the real command wiring
+//! (`run`'s record hook + `plan --diff`) over a sqlite catalog on local disk.
+
+use std::path::PathBuf;
+
+fn run_args(config: PathBuf) -> faucet_cli::cli::RunArgs {
+    faucet_cli::cli::RunArgs {
+        config: Some(config),
+        from_env: false,
+        env_file: None,
+        no_env_file: true,
+        dry_run: false,
+        limit: None,
+        state_path: None,
+        clock: None,
+        profile: None,
+        tui: false,
+    }
+}
+
+fn plan_diff_args(config: PathBuf) -> faucet_cli::cli::PlanArgs {
+    faucet_cli::cli::PlanArgs {
+        config: Some(config),
+        row: None,
+        sample: None,
+        live: false,
+        limit: 10,
+        json: false,
+        diff: true,
+        resolve_secrets: false,
+        profile: None,
+    }
+}
+
+#[tokio::test]
+async fn run_records_snapshot_then_plan_diff_reads_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    let db = dir.path().join("cat.db");
+    std::fs::write(&input, "id,name\n1,alice\n2,bob\n").unwrap();
+
+    let cfg_path = dir.path().join("pipeline.yaml");
+    std::fs::write(
+        &cfg_path,
+        format!(
+            "version: 1\nname: e2ediff\ncatalog:\n  url: \"sqlite:{db}\"\npipeline:\n  source: {{ type: csv, config: {{ path: {input} }} }}\n  sink: {{ type: jsonl, config: {{ path: {output} }} }}\n",
+            db = db.display(),
+            input = input.display(),
+            output = output.display(),
+        ),
+    )
+    .unwrap();
+
+    // A successful run must record a config snapshot (best-effort hook).
+    faucet_cli::commands::run::run(run_args(cfg_path.clone()))
+        .await
+        .expect("run");
+
+    let handle = faucet_cli::catalog::connect_from_spec(&faucet_cli::catalog::CatalogSpec {
+        url: format!("sqlite:{}", db.display()),
+        sample_records: 10,
+    })
+    .await
+    .unwrap();
+    let snap = handle
+        .store
+        .catalog_last_config_snapshot("e2ediff")
+        .await
+        .unwrap();
+    assert!(snap.is_some(), "run should have recorded a config snapshot");
+    let snap = snap.unwrap();
+    assert_eq!(snap.pipeline, "e2ediff");
+    assert!(!snap.rows.is_empty());
+
+    // `plan --diff` now compares the current config against the recorded run.
+    faucet_cli::commands::plan::run(plan_diff_args(cfg_path))
+        .await
+        .expect("plan --diff against recorded snapshot");
+}

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -66,16 +66,6 @@ pub enum TransformStage {
     /// sort, dedup, top-N). Dependency-free; built by connectors/CLI, not
     /// addressable as a per-record stage.
     PageFn(PageFnBox),
-    /// A [`PageFn`](Self::PageFn) that also carries an Arrow `RecordBatch →
-    /// RecordBatch` form, so the stage runs on the columnar fast path (#375)
-    /// when the source and sink are Arrow-native (e.g. `parquet → sql →
-    /// parquet`). `rows` drives the `Value` path; `batch` the columnar path —
-    /// they must be semantically identical.
-    #[cfg(feature = "arrow")]
-    PageFnColumnar {
-        rows: PageFnBox,
-        batch: PageFnBatchBox,
-    },
 }
 
 impl std::fmt::Debug for TransformStage {
@@ -90,8 +80,6 @@ impl std::fmt::Debug for TransformStage {
             Self::CdcUnwrap(s) => f.debug_tuple("CdcUnwrap").field(s).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
             Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
-            #[cfg(feature = "arrow")]
-            Self::PageFnColumnar { .. } => write!(f, "PageFnColumnar(<fn>)"),
         }
     }
 }
@@ -108,11 +96,6 @@ impl Clone for TransformStage {
             Self::CdcUnwrap(s) => Self::CdcUnwrap(s.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
             Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
-            #[cfg(feature = "arrow")]
-            Self::PageFnColumnar { rows, batch } => Self::PageFnColumnar {
-                rows: Arc::clone(rows),
-                batch: Arc::clone(batch),
-            },
         }
     }
 }
@@ -128,11 +111,6 @@ pub enum CompiledStage {
     CdcUnwrap(CompiledCdcUnwrap),
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
     PageFn(PageFnBox),
-    #[cfg(feature = "arrow")]
-    PageFnColumnar {
-        rows: PageFnBox,
-        batch: PageFnBatchBox,
-    },
 }
 
 impl std::fmt::Debug for CompiledStage {
@@ -147,8 +125,6 @@ impl std::fmt::Debug for CompiledStage {
             Self::CdcUnwrap(c) => f.debug_tuple("CdcUnwrap").field(c).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
             Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
-            #[cfg(feature = "arrow")]
-            Self::PageFnColumnar { .. } => write!(f, "PageFnColumnar(<fn>)"),
         }
     }
 }
@@ -174,25 +150,6 @@ impl Clone for CompiledStage {
             Self::CdcUnwrap(c) => Self::CdcUnwrap(c.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
             Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
-            #[cfg(feature = "arrow")]
-            Self::PageFnColumnar { rows, batch } => Self::PageFnColumnar {
-                rows: Arc::clone(rows),
-                batch: Arc::clone(batch),
-            },
-        }
-    }
-}
-
-impl CompiledStage {
-    /// The Arrow `RecordBatch → RecordBatch` form of this stage, if it has one
-    /// (only [`CompiledStage::PageFnColumnar`]). `TransformingSource` uses this
-    /// to run a stage on the columnar fast path; a stage without one keeps the
-    /// whole chain off the columnar path.
-    #[cfg(feature = "arrow")]
-    pub fn batch_fn(&self) -> Option<&PageFnBatchBox> {
-        match self {
-            Self::PageFnColumnar { batch, .. } => Some(batch),
-            _ => None,
         }
     }
 }
@@ -843,11 +800,6 @@ pub fn compile_stage(s: &TransformStage) -> Result<CompiledStage, FaucetError> {
         }
         TransformStage::Custom(f) => Ok(CompiledStage::Custom(Arc::clone(f))),
         TransformStage::PageFn(f) => Ok(CompiledStage::PageFn(Arc::clone(f))),
-        #[cfg(feature = "arrow")]
-        TransformStage::PageFnColumnar { rows, batch } => Ok(CompiledStage::PageFnColumnar {
-            rows: Arc::clone(rows),
-            batch: Arc::clone(batch),
-        }),
     }
 }
 
@@ -875,11 +827,6 @@ pub fn apply_stages_to_page(
         match stage {
             CompiledStage::PageFn(f) => {
                 records = f(records)?;
-            }
-            // On the `Value` path a columnar stage runs its `rows` form.
-            #[cfg(feature = "arrow")]
-            CompiledStage::PageFnColumnar { rows, .. } => {
-                records = rows(records)?;
             }
             per_record => {
                 let mut next = Vec::with_capacity(records.len());
@@ -914,12 +861,6 @@ fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, Fauc
         CompiledStage::Custom(f) => Ok(f(rec)),
         CompiledStage::PageFn(_) => Err(FaucetError::Transform(
             "PageFn is a page-level stage and cannot run in a per-record context; \
-             use apply_stages_to_page"
-                .to_owned(),
-        )),
-        #[cfg(feature = "arrow")]
-        CompiledStage::PageFnColumnar { .. } => Err(FaucetError::Transform(
-            "PageFnColumnar is a page-level stage and cannot run in a per-record context; \
              use apply_stages_to_page"
                 .to_owned(),
         )),

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -30,9 +30,11 @@ use std::sync::Arc;
 /// [`TransformStage::PageFn`] and [`CompiledStage::PageFn`].
 pub type PageFnBox = Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>;
 
-/// Type alias for the columnar (Arrow) page transform stored in
-/// [`TransformStage::PageFnColumnar`]. A `RecordBatch → RecordBatch` closure
-/// used on the opt-in columnar fast path (#375). Only present with `arrow`.
+/// Type alias for the columnar (Arrow) form of a page transform: a
+/// `RecordBatch → RecordBatch` closure carried alongside a stage via
+/// [`TransformingSource::new_with_batches`](crate::TransformingSource::new_with_batches)
+/// so the stage can run on the opt-in columnar fast path (#375). Only present
+/// with the `arrow` feature.
 #[cfg(feature = "arrow")]
 pub type PageFnBatchBox = Arc<
     dyn Fn(arrow::array::RecordBatch) -> Result<arrow::array::RecordBatch, FaucetError>

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -30,6 +30,16 @@ use std::sync::Arc;
 /// [`TransformStage::PageFn`] and [`CompiledStage::PageFn`].
 pub type PageFnBox = Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>;
 
+/// Type alias for the columnar (Arrow) page transform stored in
+/// [`TransformStage::PageFnColumnar`]. A `RecordBatch → RecordBatch` closure
+/// used on the opt-in columnar fast path (#375). Only present with `arrow`.
+#[cfg(feature = "arrow")]
+pub type PageFnBatchBox = Arc<
+    dyn Fn(arrow::array::RecordBatch) -> Result<arrow::array::RecordBatch, FaucetError>
+        + Send
+        + Sync,
+>;
+
 /// One stage in a transform pipeline.
 pub enum TransformStage {
     /// Existing 1→1 record transform. Wraps unchanged.
@@ -56,6 +66,16 @@ pub enum TransformStage {
     /// sort, dedup, top-N). Dependency-free; built by connectors/CLI, not
     /// addressable as a per-record stage.
     PageFn(PageFnBox),
+    /// A [`PageFn`](Self::PageFn) that also carries an Arrow `RecordBatch →
+    /// RecordBatch` form, so the stage runs on the columnar fast path (#375)
+    /// when the source and sink are Arrow-native (e.g. `parquet → sql →
+    /// parquet`). `rows` drives the `Value` path; `batch` the columnar path —
+    /// they must be semantically identical.
+    #[cfg(feature = "arrow")]
+    PageFnColumnar {
+        rows: PageFnBox,
+        batch: PageFnBatchBox,
+    },
 }
 
 impl std::fmt::Debug for TransformStage {
@@ -70,6 +90,8 @@ impl std::fmt::Debug for TransformStage {
             Self::CdcUnwrap(s) => f.debug_tuple("CdcUnwrap").field(s).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
             Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
+            #[cfg(feature = "arrow")]
+            Self::PageFnColumnar { .. } => write!(f, "PageFnColumnar(<fn>)"),
         }
     }
 }
@@ -86,6 +108,11 @@ impl Clone for TransformStage {
             Self::CdcUnwrap(s) => Self::CdcUnwrap(s.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
             Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
+            #[cfg(feature = "arrow")]
+            Self::PageFnColumnar { rows, batch } => Self::PageFnColumnar {
+                rows: Arc::clone(rows),
+                batch: Arc::clone(batch),
+            },
         }
     }
 }
@@ -101,6 +128,11 @@ pub enum CompiledStage {
     CdcUnwrap(CompiledCdcUnwrap),
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
     PageFn(PageFnBox),
+    #[cfg(feature = "arrow")]
+    PageFnColumnar {
+        rows: PageFnBox,
+        batch: PageFnBatchBox,
+    },
 }
 
 impl std::fmt::Debug for CompiledStage {
@@ -115,6 +147,8 @@ impl std::fmt::Debug for CompiledStage {
             Self::CdcUnwrap(c) => f.debug_tuple("CdcUnwrap").field(c).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
             Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
+            #[cfg(feature = "arrow")]
+            Self::PageFnColumnar { .. } => write!(f, "PageFnColumnar(<fn>)"),
         }
     }
 }
@@ -140,6 +174,25 @@ impl Clone for CompiledStage {
             Self::CdcUnwrap(c) => Self::CdcUnwrap(c.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
             Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
+            #[cfg(feature = "arrow")]
+            Self::PageFnColumnar { rows, batch } => Self::PageFnColumnar {
+                rows: Arc::clone(rows),
+                batch: Arc::clone(batch),
+            },
+        }
+    }
+}
+
+impl CompiledStage {
+    /// The Arrow `RecordBatch → RecordBatch` form of this stage, if it has one
+    /// (only [`CompiledStage::PageFnColumnar`]). `TransformingSource` uses this
+    /// to run a stage on the columnar fast path; a stage without one keeps the
+    /// whole chain off the columnar path.
+    #[cfg(feature = "arrow")]
+    pub fn batch_fn(&self) -> Option<&PageFnBatchBox> {
+        match self {
+            Self::PageFnColumnar { batch, .. } => Some(batch),
+            _ => None,
         }
     }
 }
@@ -790,6 +843,11 @@ pub fn compile_stage(s: &TransformStage) -> Result<CompiledStage, FaucetError> {
         }
         TransformStage::Custom(f) => Ok(CompiledStage::Custom(Arc::clone(f))),
         TransformStage::PageFn(f) => Ok(CompiledStage::PageFn(Arc::clone(f))),
+        #[cfg(feature = "arrow")]
+        TransformStage::PageFnColumnar { rows, batch } => Ok(CompiledStage::PageFnColumnar {
+            rows: Arc::clone(rows),
+            batch: Arc::clone(batch),
+        }),
     }
 }
 
@@ -817,6 +875,11 @@ pub fn apply_stages_to_page(
         match stage {
             CompiledStage::PageFn(f) => {
                 records = f(records)?;
+            }
+            // On the `Value` path a columnar stage runs its `rows` form.
+            #[cfg(feature = "arrow")]
+            CompiledStage::PageFnColumnar { rows, .. } => {
+                records = rows(records)?;
             }
             per_record => {
                 let mut next = Vec::with_capacity(records.len());
@@ -851,6 +914,12 @@ fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, Fauc
         CompiledStage::Custom(f) => Ok(f(rec)),
         CompiledStage::PageFn(_) => Err(FaucetError::Transform(
             "PageFn is a page-level stage and cannot run in a per-record context; \
+             use apply_stages_to_page"
+                .to_owned(),
+        )),
+        #[cfg(feature = "arrow")]
+        CompiledStage::PageFnColumnar { .. } => Err(FaucetError::Transform(
+            "PageFnColumnar is a page-level stage and cannot run in a per-record context; \
              use apply_stages_to_page"
                 .to_owned(),
         )),

--- a/crates/core/src/transforming_source.rs
+++ b/crates/core/src/transforming_source.rs
@@ -117,6 +117,40 @@ impl Source for TransformingSource {
         })
     }
 
+    /// Columnar only when the inner source is columnar **and** every stage has
+    /// an Arrow batch form (today: the SQL transform). Any `Value`-only stage
+    /// (`Map` / `Filter` / `Explode` / `CdcUnwrap` / `Custom` / plain `PageFn`)
+    /// keeps the whole chain on the `Value` path (#375).
+    #[cfg(feature = "arrow")]
+    fn supports_columnar(&self) -> bool {
+        self.inner.supports_columnar() && self.stages.iter().all(|s| s.batch_fn().is_some())
+    }
+
+    /// Stream the inner source's Arrow batches with every stage's batch form
+    /// applied in declared order — so `parquet → sql → parquet` runs Arrow
+    /// end-to-end. Only reached when [`supports_columnar`](Self::supports_columnar)
+    /// is `true`, i.e. every stage has a batch form.
+    #[cfg(feature = "arrow")]
+    fn stream_batches<'a>(
+        &'a self,
+        ctx: &'a HashMap<String, Value>,
+        batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<crate::columnar::ColumnarPage, FaucetError>> + Send + 'a>>
+    {
+        Box::pin(async_stream::try_stream! {
+            let mut pages = self.inner.stream_batches(ctx, batch_size);
+            while let Some(page) = pages.next().await {
+                let crate::columnar::ColumnarPage { mut batch, bookmark } = page?;
+                for stage in &self.stages {
+                    if let Some(bf) = stage.batch_fn() {
+                        batch = bf(batch)?;
+                    }
+                }
+                yield crate::columnar::ColumnarPage { batch, bookmark };
+            }
+        })
+    }
+
     fn state_key(&self) -> Option<String> {
         self.inner.state_key()
     }
@@ -583,5 +617,109 @@ mod tests {
         assert_eq!(sub_pages.len(), 1);
         assert!(sub_pages[0].records.is_empty());
         assert_eq!(sub_pages[0].bookmark, Some(json!("bm")));
+    }
+}
+
+#[cfg(all(test, feature = "arrow"))]
+mod columnar_tests {
+    use super::*;
+    use crate::columnar::{ColumnarPage, record_batch_to_values, values_to_record_batch_inferred};
+    use crate::stage::TransformStage;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    /// A source that emits one Arrow batch (columnar-capable).
+    struct ColumnarMock(Vec<Value>);
+    #[async_trait]
+    impl Source for ColumnarMock {
+        async fn fetch_with_context(
+            &self,
+            _ctx: &HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.0.clone())
+        }
+        fn supports_columnar(&self) -> bool {
+            true
+        }
+        fn stream_batches<'a>(
+            &'a self,
+            _ctx: &'a HashMap<String, Value>,
+            _bs: usize,
+        ) -> Pin<Box<dyn Stream<Item = Result<ColumnarPage, FaucetError>> + Send + 'a>> {
+            let batch = values_to_record_batch_inferred(&self.0).unwrap();
+            Box::pin(async_stream::stream! {
+                yield Ok(ColumnarPage { batch, bookmark: Some(json!("bm")) });
+            })
+        }
+    }
+
+    /// A source with no columnar support (default `supports_columnar` = false).
+    struct RowOnlyMock(Vec<Value>);
+    #[async_trait]
+    impl Source for RowOnlyMock {
+        async fn fetch_with_context(
+            &self,
+            _ctx: &HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// A columnar stage that appends `{"seen": true}`-style marker by identity
+    /// on rows and identity on batch — enough to exercise the wiring.
+    fn identity_columnar_stage() -> TransformStage {
+        TransformStage::PageFnColumnar {
+            rows: Arc::new(Ok),
+            batch: Arc::new(Ok),
+        }
+    }
+
+    #[tokio::test]
+    async fn columnar_inner_plus_columnar_stage_is_supported_and_streams() {
+        let inner: Box<dyn Source> =
+            Box::new(ColumnarMock(vec![json!({"id": 1}), json!({"id": 2})]));
+        let wrapped = TransformingSource::new(
+            inner,
+            vec![identity_columnar_stage()],
+            Labels::for_named("t"),
+        )
+        .unwrap();
+        assert!(wrapped.supports_columnar());
+        let ctx = HashMap::new();
+        let mut s = wrapped.stream_batches(&ctx, 0);
+        let page = s.next().await.unwrap().unwrap();
+        let rows = record_batch_to_values(&page.batch).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(page.bookmark, Some(json!("bm")));
+    }
+
+    #[tokio::test]
+    async fn value_only_stage_disables_columnar() {
+        // A `Map` stage has no Arrow batch form → the whole chain drops off the
+        // columnar path even though the inner source is columnar.
+        let inner: Box<dyn Source> = Box::new(ColumnarMock(vec![json!({"FooBar": 1})]));
+        let wrapped = TransformingSource::new(
+            inner,
+            vec![TransformStage::Map(
+                crate::transform::RecordTransform::KeysCase {
+                    mode: crate::transform::KeyCaseMode::Snake,
+                },
+            )],
+            Labels::for_named("t"),
+        )
+        .unwrap();
+        assert!(!wrapped.supports_columnar());
+    }
+
+    #[tokio::test]
+    async fn columnar_stage_over_row_only_inner_is_disabled() {
+        let inner: Box<dyn Source> = Box::new(RowOnlyMock(vec![json!({"id": 1})]));
+        let wrapped = TransformingSource::new(
+            inner,
+            vec![identity_columnar_stage()],
+            Labels::for_named("t"),
+        )
+        .unwrap();
+        assert!(!wrapped.supports_columnar(), "inner is not columnar");
     }
 }

--- a/crates/core/src/transforming_source.rs
+++ b/crates/core/src/transforming_source.rs
@@ -39,12 +39,20 @@ pub struct TransformingSource {
     inner: Box<dyn Source>,
     stages: Vec<CompiledStage>,
     labels: Labels,
+    /// Optional Arrow `RecordBatch → RecordBatch` form for each stage, parallel
+    /// to `stages` (#375). `Some` only for columnar-capable stages (today the
+    /// SQL transform, supplied via [`new_with_batches`](Self::new_with_batches));
+    /// `None` for `Value`-only stages. When every entry is `Some` and the inner
+    /// source is columnar, the whole chain runs on the columnar fast path.
+    #[cfg(feature = "arrow")]
+    batch_fns: Vec<Option<crate::stage::PageFnBatchBox>>,
 }
 
 impl TransformingSource {
     /// Compile `stages` and wrap `inner`. Returns
     /// [`FaucetError::Transform`] if any stage's compilation fails (e.g.
-    /// invalid regex in `RenameKeys`).
+    /// invalid regex in `RenameKeys`). The chain stays on the `Value` path
+    /// (no columnar batch forms).
     pub fn new(
         inner: Box<dyn Source>,
         stages: Vec<TransformStage>,
@@ -54,10 +62,44 @@ impl TransformingSource {
             .iter()
             .map(compile_stage)
             .collect::<Result<Vec<_>, _>>()?;
+        #[cfg(feature = "arrow")]
+        let n = compiled.len();
         Ok(Self {
             inner,
             stages: compiled,
             labels,
+            #[cfg(feature = "arrow")]
+            batch_fns: vec![None; n],
+        })
+    }
+
+    /// Like [`new`](Self::new), but each stage may carry an Arrow `RecordBatch`
+    /// form (`batch_fns[i]` parallels `stages[i]`), so the chain can run on the
+    /// columnar fast path (#375) when the inner source and sink are Arrow-native
+    /// and **every** stage supplies one. Used by the CLI for `sql` transforms.
+    #[cfg(feature = "arrow")]
+    pub fn new_with_batches(
+        inner: Box<dyn Source>,
+        stages: Vec<TransformStage>,
+        batch_fns: Vec<Option<crate::stage::PageFnBatchBox>>,
+        labels: Labels,
+    ) -> Result<Self, FaucetError> {
+        if batch_fns.len() != stages.len() {
+            return Err(FaucetError::Transform(format!(
+                "TransformingSource::new_with_batches: {} batch fns for {} stages",
+                batch_fns.len(),
+                stages.len()
+            )));
+        }
+        let compiled = stages
+            .iter()
+            .map(compile_stage)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            inner,
+            stages: compiled,
+            labels,
+            batch_fns,
         })
     }
 }
@@ -123,7 +165,9 @@ impl Source for TransformingSource {
     /// keeps the whole chain on the `Value` path (#375).
     #[cfg(feature = "arrow")]
     fn supports_columnar(&self) -> bool {
-        self.inner.supports_columnar() && self.stages.iter().all(|s| s.batch_fn().is_some())
+        self.inner.supports_columnar()
+            && !self.batch_fns.is_empty()
+            && self.batch_fns.iter().all(Option::is_some)
     }
 
     /// Stream the inner source's Arrow batches with every stage's batch form
@@ -141,10 +185,8 @@ impl Source for TransformingSource {
             let mut pages = self.inner.stream_batches(ctx, batch_size);
             while let Some(page) = pages.next().await {
                 let crate::columnar::ColumnarPage { mut batch, bookmark } = page?;
-                for stage in &self.stages {
-                    if let Some(bf) = stage.batch_fn() {
-                        batch = bf(batch)?;
-                    }
+                for bf in self.batch_fns.iter().flatten() {
+                    batch = bf(batch)?;
                 }
                 yield crate::columnar::ColumnarPage { batch, bookmark };
             }
@@ -665,22 +707,23 @@ mod columnar_tests {
         }
     }
 
-    /// A columnar stage that appends `{"seen": true}`-style marker by identity
-    /// on rows and identity on batch — enough to exercise the wiring.
-    fn identity_columnar_stage() -> TransformStage {
-        TransformStage::PageFnColumnar {
-            rows: Arc::new(Ok),
-            batch: Arc::new(Ok),
-        }
+    /// An identity page stage + its identity batch form — enough to exercise
+    /// the columnar wiring.
+    fn identity_stage() -> (TransformStage, Option<crate::stage::PageFnBatchBox>) {
+        let rows: crate::stage::PageFnBox = Arc::new(Ok);
+        let batch: crate::stage::PageFnBatchBox = Arc::new(Ok);
+        (TransformStage::PageFn(rows), Some(batch))
     }
 
     #[tokio::test]
     async fn columnar_inner_plus_columnar_stage_is_supported_and_streams() {
         let inner: Box<dyn Source> =
             Box::new(ColumnarMock(vec![json!({"id": 1}), json!({"id": 2})]));
-        let wrapped = TransformingSource::new(
+        let (stage, batch) = identity_stage();
+        let wrapped = TransformingSource::new_with_batches(
             inner,
-            vec![identity_columnar_stage()],
+            vec![stage],
+            vec![batch],
             Labels::for_named("t"),
         )
         .unwrap();
@@ -695,8 +738,8 @@ mod columnar_tests {
 
     #[tokio::test]
     async fn value_only_stage_disables_columnar() {
-        // A `Map` stage has no Arrow batch form → the whole chain drops off the
-        // columnar path even though the inner source is columnar.
+        // A `Map` stage has no Arrow batch form (batch_fn None) → the whole
+        // chain drops off the columnar path even though the inner is columnar.
         let inner: Box<dyn Source> = Box::new(ColumnarMock(vec![json!({"FooBar": 1})]));
         let wrapped = TransformingSource::new(
             inner,
@@ -714,9 +757,11 @@ mod columnar_tests {
     #[tokio::test]
     async fn columnar_stage_over_row_only_inner_is_disabled() {
         let inner: Box<dyn Source> = Box::new(RowOnlyMock(vec![json!({"id": 1})]));
-        let wrapped = TransformingSource::new(
+        let (stage, batch) = identity_stage();
+        let wrapped = TransformingSource::new_with_batches(
             inner,
-            vec![identity_columnar_stage()],
+            vec![stage],
+            vec![batch],
             Labels::for_named("t"),
         )
         .unwrap();

--- a/crates/sink/delta/Cargo.toml
+++ b/crates/sink/delta/Cargo.toml
@@ -15,6 +15,9 @@ default = []
 s3 = ["faucet-common-delta/s3"]
 azure = ["faucet-common-delta/azure"]
 gcs = ["faucet-common-delta/gcs"]
+# Opt-in Arrow columnar fast path (#375): consume `RecordBatch`es so a
+# `parquet → delta` / `delta → delta` chain skips `Value` materialization.
+arrow = ["faucet-core/arrow"]
 
 [dependencies]
 faucet-core.workspace = true
@@ -33,7 +36,10 @@ arrow-json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tempfile = "3"
 faucet-conformance.workspace = true
-faucet-source-delta.workspace = true
+# `arrow` on the source dev-dep so the columnar round-trip test can read the
+# table back via `stream_batches` (gated on the source's own `arrow` feature).
+faucet-source-delta = { workspace = true, features = ["arrow"] }
+futures.workspace = true
 serde_json.workspace = true
 schemars.workspace = true
 

--- a/crates/sink/delta/README.md
+++ b/crates/sink/delta/README.md
@@ -34,6 +34,11 @@ running/billed compute and no Python.
 
 Cloud backends require the matching crate feature: `s3`, `azure`, `gcs`.
 
+The **`arrow`** feature opts this sink into the columnar fast path (#375): when
+the source is also Arrow-capable (e.g. `faucet-source-parquet` /
+`faucet-source-delta`), batches are written straight through delta-rs's
+`RecordBatchWriter` with no `serde_json::Value` materialization.
+
 ```yaml
 pipeline:
   sink:

--- a/crates/sink/delta/src/sink.rs
+++ b/crates/sink/delta/src/sink.rs
@@ -97,9 +97,21 @@ impl DeltaSink {
             state.schema = Some(schema);
         }
         let schema = state.schema.clone().expect("schema set above");
+        self.ensure_table_writer(state, &schema).await
+    }
 
+    /// Establish the table + record-batch writer for an already-locked `schema`.
+    /// Shared by the JSON path ([`ensure_open`](Self::ensure_open), which infers
+    /// the schema from records) and the columnar path
+    /// ([`write_batch_columnar`](faucet_core::Sink::write_batch_columnar), which
+    /// takes it from the incoming `RecordBatch`).
+    async fn ensure_table_writer(
+        &self,
+        state: &mut SinkState,
+        schema: &SchemaRef,
+    ) -> Result<(), FaucetError> {
         if state.table.is_none() {
-            let table = self.open_or_create(&schema).await?;
+            let table = self.open_or_create(schema).await?;
             state.table = Some(table);
         }
         if state.writer.is_none() {
@@ -268,6 +280,40 @@ impl faucet_core::Sink for DeltaSink {
             }
         }
         Ok(total)
+    }
+
+    /// delta-rs writes via `RecordBatchWriter`, so the sink consumes Arrow
+    /// batches natively (#375): a `parquet → delta` / `delta → delta` chain
+    /// never materializes `Value`.
+    #[cfg(feature = "arrow")]
+    fn supports_columnar(&self) -> bool {
+        true
+    }
+
+    /// Write an Arrow batch straight into the buffered `RecordBatchWriter`,
+    /// skipping the `Value → RecordBatch` encode. The schema is locked from the
+    /// first batch's own schema (the columnar analogue of inferring it from the
+    /// first records); partition columns must be present in the batch (the Delta
+    /// source appends them), matching the JSON path's create-table contract.
+    #[cfg(feature = "arrow")]
+    async fn write_batch_columnar(&self, batch: &RecordBatch) -> Result<usize, FaucetError> {
+        if batch.num_rows() == 0 {
+            return Ok(0);
+        }
+        let mut state = self.state.lock().await;
+        if state.schema.is_none() {
+            state.schema = Some(batch.schema());
+        }
+        let schema = state.schema.clone().expect("schema set above");
+        self.ensure_table_writer(&mut state, &schema).await?;
+        let rows = batch.num_rows();
+        let writer = state.writer.as_mut().expect("writer set");
+        writer
+            .write(batch.clone())
+            .await
+            .map_err(|e| FaucetError::Sink(format!("delta: columnar write failed: {e}")))?;
+        state.pending = true;
+        Ok(rows)
     }
 
     async fn flush(&self) -> Result<(), FaucetError> {

--- a/crates/sink/delta/tests/roundtrip.rs
+++ b/crates/sink/delta/tests/roundtrip.rs
@@ -262,6 +262,99 @@ async fn invalid_timestamp_errors() {
     );
 }
 
+/// Read a table back through the source's **columnar** (`stream_batches`) path,
+/// converting each `RecordBatch` to JSON for assertions.
+#[cfg(feature = "arrow")]
+async fn read_all_columnar(uri: &str, cfg: impl FnOnce(&mut DeltaSourceConfig)) -> Vec<Value> {
+    use futures::StreamExt;
+    let mut sc = DeltaSourceConfig::new(uri);
+    cfg(&mut sc);
+    let source = DeltaSource::new(sc).await.expect("source");
+    assert!(
+        source.supports_columnar(),
+        "delta source is columnar-capable"
+    );
+    let ctx = HashMap::new();
+    let mut stream = source.stream_batches(&ctx, 0);
+    let mut out = Vec::new();
+    while let Some(page) = stream.next().await {
+        let page = page.expect("columnar page");
+        out.extend(
+            faucet_core::columnar::record_batch_to_values(&page.batch).expect("batch to values"),
+        );
+    }
+    out
+}
+
+/// Arrow end-to-end: write a `RecordBatch` via `write_batch_columnar` and read
+/// it back via `stream_batches` — no `Value` materialization on either side.
+#[cfg(feature = "arrow")]
+#[tokio::test]
+async fn columnar_round_trip_unpartitioned() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "colz");
+
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    assert!(sink.supports_columnar(), "delta sink is columnar-capable");
+    let batch = faucet_core::columnar::values_to_record_batch_inferred(&[
+        json!({"id": 1, "name": "alice"}),
+        json!({"id": 2, "name": "bob"}),
+    ])
+    .unwrap();
+    let n = sink.write_batch_columnar(&batch).await.unwrap();
+    assert_eq!(n, 2);
+    sink.flush().await.unwrap();
+
+    let rows = read_all_columnar(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 2);
+    let ids: Vec<i64> = rows.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert!(ids.contains(&1) && ids.contains(&2));
+    assert_eq!(
+        rows.iter().find(|r| r["id"] == json!(1)).unwrap()["name"],
+        json!("alice")
+    );
+}
+
+/// Columnar path over a partitioned table: the partition column lives in the
+/// file path, so the source must re-append it as a constant Arrow column
+/// (`append_partition_columns`) for the columnar output to match the row path.
+#[cfg(feature = "arrow")]
+#[tokio::test]
+async fn columnar_round_trip_partitioned() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "colzpart");
+
+    let mut cfg = DeltaSinkConfig::new(&uri);
+    cfg.partition_by = vec!["region".into()];
+    let sink = DeltaSink::new(cfg).await.unwrap();
+    let batch = faucet_core::columnar::values_to_record_batch_inferred(&[
+        json!({"id": 1, "region": "us"}),
+        json!({"id": 2, "region": "eu"}),
+        json!({"id": 3, "region": "us"}),
+    ])
+    .unwrap();
+    sink.write_batch_columnar(&batch).await.unwrap();
+    sink.flush().await.unwrap();
+
+    let rows = read_all_columnar(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 3);
+    // Partition column reconstructed into the columnar batch.
+    assert_eq!(
+        rows.iter().filter(|r| r["region"] == json!("us")).count(),
+        2
+    );
+    assert_eq!(
+        rows.iter().filter(|r| r["region"] == json!("eu")).count(),
+        1
+    );
+    // And a projection that includes the partition column still works.
+    let only = read_all_columnar(&uri, |c| c.columns = vec!["region".into()]).await;
+    assert!(
+        only.iter()
+            .all(|r| r.get("id").is_none() && r.get("region").is_some())
+    );
+}
+
 #[tokio::test]
 async fn unknown_field_is_dropped_not_fatal() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/source/delta/Cargo.toml
+++ b/crates/source/delta/Cargo.toml
@@ -15,6 +15,9 @@ default = []
 s3 = ["faucet-common-delta/s3"]
 azure = ["faucet-common-delta/azure"]
 gcs = ["faucet-common-delta/gcs"]
+# Opt-in Arrow columnar fast path (#375): emit `ColumnarPage`s so a
+# `delta → parquet` / `delta → delta` chain skips `Value` materialization.
+arrow = ["faucet-core/arrow"]
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/delta/README.md
+++ b/crates/source/delta/README.md
@@ -32,6 +32,12 @@ Fabric) write.
 
 Cloud backends require the matching crate feature: `s3`, `azure`, `gcs`.
 
+The **`arrow`** feature opts this source into the columnar fast path (#375): when
+the sink is also Arrow-capable (e.g. `faucet-sink-parquet` /
+`faucet-sink-delta`), it emits Arrow `RecordBatch` pages directly (Hive
+partition columns re-appended as constant columns) with no `serde_json::Value`
+materialization.
+
 ```yaml
 pipeline:
   source:

--- a/crates/source/delta/src/stream.rs
+++ b/crates/source/delta/src/stream.rs
@@ -232,6 +232,122 @@ impl faucet_core::Source for DeltaSource {
             }
         })
     }
+
+    /// Delta reads are natively Arrow (each data file is a parquet stream), so
+    /// the source participates in the opt-in columnar fast path (#375): a
+    /// `delta → parquet` / `delta → delta` chain never materializes `Value`.
+    #[cfg(feature = "arrow")]
+    fn supports_columnar(&self) -> bool {
+        true
+    }
+
+    /// Stream the table as Arrow [`ColumnarPage`](faucet_core::ColumnarPage)s.
+    /// Mirrors [`stream_pages`](Self::stream_pages) but yields each parquet
+    /// `RecordBatch` directly; Hive partition-column values (which live in the
+    /// file path, not the parquet data) are appended as constant Arrow columns
+    /// so the columnar output matches the row-wise output field-for-field.
+    #[cfg(feature = "arrow")]
+    fn stream_batches<'a>(
+        &'a self,
+        _context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<faucet_core::ColumnarPage, FaucetError>> + Send + 'a>>
+    {
+        Box::pin(async_stream::try_stream! {
+            let table = self.open().await?;
+            let (files, schema, partition_cols) = self.resolve(&table).await?;
+            let store = table.object_store();
+            let data_projection = self.data_projection(&partition_cols);
+            let requested: Option<&[String]> =
+                if self.config.columns.is_empty() { None } else { Some(&self.config.columns) };
+
+            for file in &files {
+                let reader = ParquetObjectReader::new(store.clone(), file.path.clone());
+                let mut builder = ParquetRecordBatchStreamBuilder::new(reader).await.map_err(|e| {
+                    FaucetError::Source(format!("delta: could not open data file '{}': {e}", file.path))
+                })?;
+                if self.config.batch_size > 0 {
+                    builder = builder.with_batch_size(self.config.batch_size);
+                }
+                if let Some(cols) = &data_projection {
+                    let pq = builder.parquet_schema();
+                    let present: Vec<&str> = cols
+                        .iter()
+                        .filter(|c| pq.columns().iter().any(|col| col.name() == c.as_str()))
+                        .map(String::as_str)
+                        .collect();
+                    let mask = ProjectionMask::columns(pq, present.iter().copied());
+                    builder = builder.with_projection(mask);
+                }
+                let mut batches = builder.build().map_err(|e| {
+                    FaucetError::Source(format!("delta: could not build reader for '{}': {e}", file.path))
+                })?;
+                while let Some(batch) = batches.next().await {
+                    let batch = batch.map_err(|e| {
+                        FaucetError::Source(format!("delta: read error in '{}': {e}", file.path))
+                    })?;
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+                    let batch = append_partition_columns(batch, &file.partitions, &schema, requested)?;
+                    yield faucet_core::ColumnarPage { batch, bookmark: None };
+                }
+            }
+        })
+    }
+}
+
+/// Append Hive partition columns to a data-file `RecordBatch` as constant
+/// columns, honoring the same `requested`-projection semantics as
+/// [`merge_partitions`] (add a partition column only when unprojected-away, and
+/// never shadow a real data column of the same name). Each constant column is
+/// built through the core `Value → RecordBatch` shim with the table's declared
+/// Arrow type, so a partition value round-trips identically to the row path.
+#[cfg(feature = "arrow")]
+fn append_partition_columns(
+    batch: arrow::array::RecordBatch,
+    partitions: &HashMap<String, Value>,
+    table_schema: &SchemaRef,
+    requested: Option<&[String]>,
+) -> Result<arrow::array::RecordBatch, FaucetError> {
+    use arrow::datatypes::{Field, Schema};
+    use std::sync::Arc;
+
+    if partitions.is_empty() {
+        return Ok(batch);
+    }
+    let in_schema = batch.schema();
+    let n = batch.num_rows();
+    let mut fields: Vec<Arc<Field>> = in_schema.fields().iter().cloned().collect();
+    let mut columns = batch.columns().to_vec();
+
+    // Deterministic order so the output schema is stable run-to-run.
+    let mut keys: Vec<&String> = partitions.keys().collect();
+    keys.sort();
+    for k in keys {
+        if let Some(cols) = requested
+            && !cols.iter().any(|c| c == k)
+        {
+            continue;
+        }
+        if in_schema.field_with_name(k).is_ok() {
+            continue; // a real data column of this name wins (merge_partitions)
+        }
+        let field = table_schema
+            .field_with_name(k)
+            .cloned()
+            .unwrap_or_else(|_| Field::new(k, arrow::datatypes::DataType::Utf8, true));
+        let one_schema = Arc::new(Schema::new(vec![field.clone().with_nullable(true)]));
+        let mut obj = serde_json::Map::new();
+        obj.insert(k.clone(), partitions[k].clone());
+        let rows = vec![Value::Object(obj); n];
+        let col_batch = faucet_core::values_to_record_batch(&rows, one_schema)?;
+        fields.push(Arc::new(field));
+        columns.push(col_batch.column(0).clone());
+    }
+
+    arrow::array::RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+        .map_err(|e| FaucetError::Source(format!("delta: assembling columnar batch failed: {e}")))
 }
 
 /// Parse Hive-style `col=value` segments out of a data file path, typing each

--- a/crates/source/delta/src/stream.rs
+++ b/crates/source/delta/src/stream.rs
@@ -242,7 +242,7 @@ impl faucet_core::Source for DeltaSource {
     }
 
     /// Stream the table as Arrow [`ColumnarPage`](faucet_core::ColumnarPage)s.
-    /// Mirrors [`stream_pages`](Self::stream_pages) but yields each parquet
+    /// Mirrors `stream_pages` but yields each parquet
     /// `RecordBatch` directly; Hive partition-column values (which live in the
     /// file path, not the parquet data) are appended as constant Arrow columns
     /// so the columnar output matches the row-wise output field-for-field.

--- a/crates/transform-sql/Cargo.toml
+++ b/crates/transform-sql/Cargo.toml
@@ -12,7 +12,7 @@ description = "SQL-as-transform for faucet-stream — run DuckDB SQL over each p
 
 [dependencies]
 # `arrow` so the SQL stage can expose its Arrow `RecordBatch` form
-# (`TransformStage::PageFnColumnar`) — transform-sql is Arrow-native anyway.
+# (via `into_columnar_stage`) — transform-sql is Arrow-native anyway.
 faucet-core = { workspace = true, features = ["arrow"] }
 duckdb = { workspace = true, features = ["bundled", "vtab-arrow"] }
 arrow.workspace = true

--- a/crates/transform-sql/Cargo.toml
+++ b/crates/transform-sql/Cargo.toml
@@ -11,7 +11,9 @@ keywords = ["sql", "duckdb", "transform", "pipeline", "etl"]
 description = "SQL-as-transform for faucet-stream — run DuckDB SQL over each pipeline page (the `batch` relation)."
 
 [dependencies]
-faucet-core.workspace = true
+# `arrow` so the SQL stage can expose its Arrow `RecordBatch` form
+# (`TransformStage::PageFnColumnar`) — transform-sql is Arrow-native anyway.
+faucet-core = { workspace = true, features = ["arrow"] }
 duckdb = { workspace = true, features = ["bundled", "vtab-arrow"] }
 arrow.workspace = true
 arrow-json.workspace = true
@@ -27,6 +29,10 @@ tempfile.workspace = true
 # round-trip the Value-tax measurement attributes against. Bench-only.
 parquet.workspace = true
 bytes.workspace = true
+# Columnar pipeline acceptance test (#375): drive a Pipeline over a columnar
+# source → sql → columnar sink and assert the columnar path is taken.
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+futures.workspace = true
 
 [[bench]]
 name = "sql_transform"

--- a/crates/transform-sql/src/runtime.rs
+++ b/crates/transform-sql/src/runtime.rs
@@ -56,43 +56,38 @@ impl SqlTransform {
         })
     }
 
-    /// Consume into a page-level transform stage.
+    /// Consume into a page-level transform stage. The stage carries **both** a
+    /// `Value` page fn and an Arrow `RecordBatch` fn (they share one DuckDB
+    /// connection), so a `parquet → sql → parquet` chain runs on the columnar
+    /// fast path (#375) while any other chain uses the `Value` path — see
+    /// [`faucet_core::stage::TransformStage::PageFnColumnar`].
     pub fn into_page_stage(self) -> TransformStage {
-        let state = self.state;
-        TransformStage::PageFn(Arc::new(move |records: Vec<Value>| {
-            let mut st = state.lock().unwrap_or_else(|e| e.into_inner());
-            execute_page(&mut st, records)
-        }))
+        let rows_state = self.state.clone();
+        let batch_state = self.state;
+        TransformStage::PageFnColumnar {
+            rows: Arc::new(move |records: Vec<Value>| {
+                let mut st = rows_state.lock().unwrap_or_else(|e| e.into_inner());
+                execute_page(&mut st, records)
+            }),
+            batch: Arc::new(move |batch: RecordBatch| {
+                let mut st = batch_state.lock().unwrap_or_else(|e| e.into_inner());
+                execute_batch(&mut st, batch)
+            }),
+        }
     }
 }
 
-fn execute_page(st: &mut State, records: Vec<Value>) -> Result<Vec<Value>, FaucetError> {
-    if records.is_empty() {
-        return Ok(Vec::new());
-    }
+/// Register `batch` into DuckDB and run the query, returning the raw Arrow
+/// result batches. Shared by the `Value` path ([`execute_page`]) and the
+/// columnar path ([`execute_batch`]) so both use the same #372 chunked
+/// registration and the same per-page aggregation-warning state.
+fn run_query_batches(st: &mut State, batch: RecordBatch) -> Result<Vec<RecordBatch>, FaucetError> {
     reload_relations(st)?;
-
-    // Schema cache: infer once per page, reuse the cached schema on a match,
-    // otherwise adopt the freshly inferred one (first page or drift).
-    let fresh = infer_schema(&records)?;
-    let schema = match &st.cached_schema {
-        Some(s) if schema_eq(s, &fresh) => s.clone(),
-        _ => {
-            st.cached_schema = Some(fresh.clone());
-            fresh
-        }
-    };
-    let batch = json_to_record_batch(&records, schema)?;
     // DuckDB's arrow vtab copies each arrow array into a `DataChunk` whose
     // capacity is `STANDARD_VECTOR_SIZE` (2048); handing it a single batch with
-    // more rows than that trips `assert(array.len() <= out.capacity())` in
-    // duckdb-rs and **aborts the process** (#372) — reachable whenever a page
-    // larger than 2048 rows reaches the transform (`batch_size` > 2048 or
-    // `batch_size: 0`). Register the batch in <=2048-row slices instead: CREATE
-    // from the first slice, INSERT the rest into the same temp table. All slices
-    // land in one `batch` relation, so query semantics (incl. GROUP BY / window
-    // aggregation over the whole page) are unchanged; a <=2048-row page still
-    // takes exactly one CREATE, identical to before.
+    // more rows than that aborts the process (#372). `register_batch_chunked`
+    // slices to <=2048 rows into one `batch` relation, so query semantics are
+    // unchanged.
     register_batch_chunked(st, batch)?;
 
     // First-page aggregation detection (now that `batch` exists).
@@ -109,18 +104,53 @@ fn execute_page(st: &mut State, records: Vec<Value>) -> Result<Vec<Value>, Fauce
         );
     }
 
-    let out = {
-        let mut stmt = st
-            .conn
-            .prepare(&st.query)
-            .map_err(|e| FaucetError::Transform(format!("sql transform: prepare: {e}")))?;
-        let batches: Vec<RecordBatch> = stmt
-            .query_arrow([])
-            .map_err(|e| FaucetError::Transform(format!("sql transform: execute: {e}")))?
-            .collect();
-        record_batches_to_json(&batches)?
+    let mut stmt = st
+        .conn
+        .prepare(&st.query)
+        .map_err(|e| FaucetError::Transform(format!("sql transform: prepare: {e}")))?;
+    let batches: Vec<RecordBatch> = stmt
+        .query_arrow([])
+        .map_err(|e| FaucetError::Transform(format!("sql transform: execute: {e}")))?
+        .collect();
+    Ok(batches)
+}
+
+fn execute_page(st: &mut State, records: Vec<Value>) -> Result<Vec<Value>, FaucetError> {
+    if records.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Schema cache: infer once per page, reuse the cached schema on a match,
+    // otherwise adopt the freshly inferred one (first page or drift).
+    let fresh = infer_schema(&records)?;
+    let schema = match &st.cached_schema {
+        Some(s) if schema_eq(s, &fresh) => s.clone(),
+        _ => {
+            st.cached_schema = Some(fresh.clone());
+            fresh
+        }
     };
-    Ok(out)
+    let batch = json_to_record_batch(&records, schema)?;
+    let batches = run_query_batches(st, batch)?;
+    record_batches_to_json(&batches)
+}
+
+/// The columnar analogue of [`execute_page`]: feed an Arrow `RecordBatch`
+/// straight to DuckDB and return the result as one `RecordBatch`, with no
+/// `Value` materialization on either side.
+fn execute_batch(st: &mut State, batch: RecordBatch) -> Result<RecordBatch, FaucetError> {
+    if batch.num_rows() == 0 {
+        // Empty page: pass through unchanged (the sink skips 0-row batches).
+        return Ok(batch);
+    }
+    let batches = run_query_batches(st, batch)?;
+    if batches.is_empty() {
+        return Ok(RecordBatch::new_empty(std::sync::Arc::new(
+            arrow::datatypes::Schema::empty(),
+        )));
+    }
+    let schema = batches[0].schema();
+    arrow::compute::concat_batches(&schema, &batches)
+        .map_err(|e| FaucetError::Transform(format!("sql transform: concat result batches: {e}")))
 }
 
 /// DuckDB's fixed vector size — the maximum rows a single arrow array may carry
@@ -259,5 +289,54 @@ mod tests {
         );
         assert_eq!(out.len(), 2);
         assert_eq!(out[0]["id"], json!(1));
+    }
+
+    /// The columnar (#375) form: feed an Arrow `RecordBatch` straight in and get
+    /// one back, with no `Value` on either side. The batch fn shares the DuckDB
+    /// connection with the row fn (same `into_page_stage`).
+    fn compiled(query: &str) -> TransformStage {
+        let cfg = SqlTransformConfig {
+            query: query.into(),
+            relations: vec![],
+            memory_limit: None,
+            threads: Some(1),
+        };
+        SqlTransform::compile(&cfg).unwrap().into_page_stage()
+    }
+
+    fn batch_fn(stage: &TransformStage) -> faucet_core::stage::PageFnBatchBox {
+        match stage {
+            TransformStage::PageFnColumnar { batch, .. } => batch.clone(),
+            other => panic!("sql transform must compile to PageFnColumnar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn columnar_batch_fn_transforms_record_batch() {
+        let stage = compiled("SELECT id, v * 2 AS doubled FROM batch WHERE id >= 1 ORDER BY id");
+        let bf = batch_fn(&stage);
+        let input = faucet_core::columnar::values_to_record_batch_inferred(&[
+            json!({"id": 0, "v": 5}),
+            json!({"id": 1, "v": 10}),
+            json!({"id": 2, "v": 20}),
+        ])
+        .unwrap();
+        let out = bf(input).unwrap();
+        let rows = faucet_core::columnar::record_batch_to_values(&out).unwrap();
+        assert_eq!(rows.len(), 2, "WHERE id >= 1 keeps two rows");
+        assert_eq!(rows[0]["id"], json!(1));
+        assert_eq!(rows[0]["doubled"], json!(20));
+        assert_eq!(rows[1]["doubled"], json!(40));
+    }
+
+    // #372 on the columnar path: a >2048-row inbound batch must not abort.
+    #[test]
+    fn columnar_batch_fn_handles_large_batch() {
+        let stage = compiled("SELECT * FROM batch");
+        let bf = batch_fn(&stage);
+        let recs: Vec<Value> = (0..5_000).map(|i| json!({"id": i})).collect();
+        let input = faucet_core::columnar::values_to_record_batch_inferred(&recs).unwrap();
+        let out = bf(input).unwrap();
+        assert_eq!(out.num_rows(), 5_000);
     }
 }

--- a/crates/transform-sql/src/runtime.rs
+++ b/crates/transform-sql/src/runtime.rs
@@ -56,24 +56,32 @@ impl SqlTransform {
         })
     }
 
-    /// Consume into a page-level transform stage. The stage carries **both** a
-    /// `Value` page fn and an Arrow `RecordBatch` fn (they share one DuckDB
-    /// connection), so a `parquet → sql → parquet` chain runs on the columnar
-    /// fast path (#375) while any other chain uses the `Value` path — see
-    /// [`faucet_core::stage::TransformStage::PageFnColumnar`].
+    /// Consume into a page-level `Value` transform stage.
     pub fn into_page_stage(self) -> TransformStage {
+        let state = self.state;
+        TransformStage::PageFn(Arc::new(move |records: Vec<Value>| {
+            let mut st = state.lock().unwrap_or_else(|e| e.into_inner());
+            execute_page(&mut st, records)
+        }))
+    }
+
+    /// Consume into a `Value` page stage **plus** an Arrow `RecordBatch → Record
+    /// Batch` form that shares the same DuckDB connection (#375). The CLI passes
+    /// the batch fn to `TransformingSource::new_with_batches`, so a `parquet →
+    /// sql → parquet` chain runs Arrow end-to-end (no `Value` materialization)
+    /// while any other chain keeps using the `Value` page stage.
+    pub fn into_columnar_stage(self) -> (TransformStage, faucet_core::stage::PageFnBatchBox) {
         let rows_state = self.state.clone();
         let batch_state = self.state;
-        TransformStage::PageFnColumnar {
-            rows: Arc::new(move |records: Vec<Value>| {
-                let mut st = rows_state.lock().unwrap_or_else(|e| e.into_inner());
-                execute_page(&mut st, records)
-            }),
-            batch: Arc::new(move |batch: RecordBatch| {
-                let mut st = batch_state.lock().unwrap_or_else(|e| e.into_inner());
-                execute_batch(&mut st, batch)
-            }),
-        }
+        let stage = TransformStage::PageFn(Arc::new(move |records: Vec<Value>| {
+            let mut st = rows_state.lock().unwrap_or_else(|e| e.into_inner());
+            execute_page(&mut st, records)
+        }));
+        let batch: faucet_core::stage::PageFnBatchBox = Arc::new(move |batch: RecordBatch| {
+            let mut st = batch_state.lock().unwrap_or_else(|e| e.into_inner());
+            execute_batch(&mut st, batch)
+        });
+        (stage, batch)
     }
 }
 
@@ -291,30 +299,24 @@ mod tests {
         assert_eq!(out[0]["id"], json!(1));
     }
 
-    /// The columnar (#375) form: feed an Arrow `RecordBatch` straight in and get
-    /// one back, with no `Value` on either side. The batch fn shares the DuckDB
-    /// connection with the row fn (same `into_page_stage`).
-    fn compiled(query: &str) -> TransformStage {
+    /// The columnar (#375) form: `into_columnar_stage` yields a `RecordBatch →
+    /// RecordBatch` fn; feed a batch straight in and get one back, no `Value`.
+    fn batch_fn(query: &str) -> faucet_core::stage::PageFnBatchBox {
         let cfg = SqlTransformConfig {
             query: query.into(),
             relations: vec![],
             memory_limit: None,
             threads: Some(1),
         };
-        SqlTransform::compile(&cfg).unwrap().into_page_stage()
-    }
-
-    fn batch_fn(stage: &TransformStage) -> faucet_core::stage::PageFnBatchBox {
-        match stage {
-            TransformStage::PageFnColumnar { batch, .. } => batch.clone(),
-            other => panic!("sql transform must compile to PageFnColumnar, got {other:?}"),
-        }
+        let (stage, batch) = SqlTransform::compile(&cfg).unwrap().into_columnar_stage();
+        // The row form is a plain page stage; the batch form is what we test.
+        assert!(matches!(stage, TransformStage::PageFn(_)));
+        batch
     }
 
     #[test]
     fn columnar_batch_fn_transforms_record_batch() {
-        let stage = compiled("SELECT id, v * 2 AS doubled FROM batch WHERE id >= 1 ORDER BY id");
-        let bf = batch_fn(&stage);
+        let bf = batch_fn("SELECT id, v * 2 AS doubled FROM batch WHERE id >= 1 ORDER BY id");
         let input = faucet_core::columnar::values_to_record_batch_inferred(&[
             json!({"id": 0, "v": 5}),
             json!({"id": 1, "v": 10}),
@@ -332,8 +334,7 @@ mod tests {
     // #372 on the columnar path: a >2048-row inbound batch must not abort.
     #[test]
     fn columnar_batch_fn_handles_large_batch() {
-        let stage = compiled("SELECT * FROM batch");
-        let bf = batch_fn(&stage);
+        let bf = batch_fn("SELECT * FROM batch");
         let recs: Vec<Value> = (0..5_000).map(|i| json!({"id": i})).collect();
         let input = faucet_core::columnar::values_to_record_batch_inferred(&recs).unwrap();
         let out = bf(input).unwrap();

--- a/crates/transform-sql/tests/columnar_pipeline.rs
+++ b/crates/transform-sql/tests/columnar_pipeline.rs
@@ -1,0 +1,123 @@
+//! Acceptance test for the SQL transform on the columnar fast path (#375).
+//!
+//! The parquet source/sink columnar impls are covered in their own crates; here
+//! we prove the **pipeline** runs a SQL transform end-to-end on Arrow batches:
+//! a columnar source wrapped in `TransformingSource([sql])` feeds a columnar
+//! sink's `write_batch_columnar` — never the `Value` `write_batch` — so a
+//! `parquet → sql → parquet`-shaped chain never materializes `serde_json::Value`.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use arrow::array::RecordBatch;
+use faucet_core::async_trait;
+use faucet_core::columnar::{
+    ColumnarPage, record_batch_to_values, values_to_record_batch_inferred,
+};
+use faucet_core::observability::Labels;
+use faucet_core::{FaucetError, Pipeline, Sink, Source, Stream, TransformingSource};
+use faucet_transform_sql::{SqlTransform, SqlTransformConfig};
+use serde_json::{Value, json};
+
+/// A columnar-capable source that emits its records as a single Arrow batch.
+struct ColumnarSource(Vec<Value>);
+
+#[async_trait]
+impl Source for ColumnarSource {
+    async fn fetch_with_context(
+        &self,
+        _ctx: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(self.0.clone())
+    }
+    fn supports_columnar(&self) -> bool {
+        true
+    }
+    fn stream_batches<'a>(
+        &'a self,
+        _ctx: &'a HashMap<String, Value>,
+        _bs: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<ColumnarPage, FaucetError>> + Send + 'a>> {
+        let batch = values_to_record_batch_inferred(&self.0).unwrap();
+        Box::pin(futures::stream::once(async move {
+            Ok(ColumnarPage {
+                batch,
+                bookmark: None,
+            })
+        }))
+    }
+}
+
+/// A sink that records which path was used: columnar batches vs `Value` rows.
+#[derive(Default)]
+struct PathRecordingSink {
+    columnar_batches: Mutex<Vec<RecordBatch>>,
+    value_rows: Mutex<usize>,
+}
+
+#[async_trait]
+impl Sink for PathRecordingSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        *self.value_rows.lock().unwrap() += records.len();
+        Ok(records.len())
+    }
+    fn supports_columnar(&self) -> bool {
+        true
+    }
+    async fn write_batch_columnar(&self, batch: &RecordBatch) -> Result<usize, FaucetError> {
+        let n = batch.num_rows();
+        self.columnar_batches.lock().unwrap().push(batch.clone());
+        Ok(n)
+    }
+    async fn flush(&self) -> Result<(), FaucetError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn sql_transform_runs_on_the_columnar_path_end_to_end() {
+    let source = ColumnarSource(vec![
+        json!({"id": 1, "v": 10}),
+        json!({"id": 2, "v": 20}),
+        json!({"id": 3, "v": 30}),
+    ]);
+    let sql = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT id, v * 2 AS doubled FROM batch WHERE id <= 2 ORDER BY id".into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: Some(1),
+    })
+    .unwrap();
+    let wrapped = TransformingSource::new(
+        Box::new(source),
+        vec![sql.into_page_stage()],
+        Labels::for_named("sql"),
+    )
+    .unwrap();
+    // The chain (columnar source + sql stage) must advertise columnar support.
+    assert!(wrapped.supports_columnar());
+
+    let sink = PathRecordingSink::default();
+    let result = Pipeline::new(&wrapped, &sink).run().await.unwrap();
+    assert_eq!(result.records_written, 2, "WHERE id <= 2 keeps two rows");
+
+    // The columnar path was taken: batches went through write_batch_columnar,
+    // and the Value write_batch was never called.
+    assert_eq!(
+        *sink.value_rows.lock().unwrap(),
+        0,
+        "Value path must not run — no serde_json::Value materialization"
+    );
+    let batches = sink.columnar_batches.lock().unwrap();
+    assert_eq!(
+        batches.len(),
+        1,
+        "one transformed columnar page reached the sink"
+    );
+    let rows = record_batch_to_values(&batches[0]).unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["id"], json!(1));
+    assert_eq!(rows[0]["doubled"], json!(20));
+    assert_eq!(rows[1]["doubled"], json!(40));
+}

--- a/crates/transform-sql/tests/columnar_pipeline.rs
+++ b/crates/transform-sql/tests/columnar_pipeline.rs
@@ -89,9 +89,11 @@ async fn sql_transform_runs_on_the_columnar_path_end_to_end() {
         threads: Some(1),
     })
     .unwrap();
-    let wrapped = TransformingSource::new(
+    let (stage, batch) = sql.into_columnar_stage();
+    let wrapped = TransformingSource::new_with_batches(
         Box::new(source),
-        vec![sql.into_page_stage()],
+        vec![stage],
+        vec![Some(batch)],
         Labels::for_named("sql"),
     )
     .unwrap();

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -150,6 +150,8 @@ to any sink**.
 faucet plan pipeline.yaml
 faucet plan pipeline.yaml --sample fixtures.jsonl        # preview output schema/volume offline
 faucet plan pipeline.yaml --live --limit 20 --json       # capped read-only source pull, JSON out
+faucet plan pipeline.yaml --diff                         # config-change diff vs the last run
+faucet plan pipeline.yaml --diff --json                  # machine-readable diff (CI gate)
 ```
 
 Reports, for the selected row (`--row`, default the first root): the resolved
@@ -162,6 +164,38 @@ output schema, the sink schema delta (adds / widenings / incompatible via
 otherwise), and a volume estimate. The data pass runs through the offline
 harness, so no sink is ever written. Offline by default; `--resolve-secrets`
 opts into the real secrets path.
+
+### `plan --diff` — config-change preview (#374)
+
+A `terraform plan`-style diff of the current config against **what last ran**.
+On every successful `faucet run` / `replicate` / `schedule --once`, a redacted
+snapshot of the *resolved + expanded* config is recorded into the catalog store
+(best-effort — recording never fails a run). `faucet plan --diff` re-expands the
+current config, loads the last snapshot, and renders a per-row semantic diff:
+
+```text
+Pipeline: hibob   (last run 2026-07-18 09:12 UTC)
+
+  + people             NEW ROW — will be created
+  ~ payroll            CHANGED
+      source.config.page_size      100  ->  500
+      source.config.path           /v1/pay  ->  /v1/payroll
+  ~ timeoff            CHANGED
+      source.config.token          (secret rotated)
+  - benefits           REMOVED — no longer in the run set
+  = employees          unchanged
+
+Summary: 1 to create, 2 to change, 1 removed, 1 unchanged.
+```
+
+Because the diff operates on the **resolved + expanded** model, a one-line
+`${vars.x}` edit that fans out across many rows shows up as the real per-row
+effect, and two textually-different files that resolve to the same movement show
+no diff. Requires a `catalog:` block (`faucet schema catalog`) and the `catalog`
+build feature. `--diff` resolves secrets so the diff matches what `run` recorded;
+every secret-sourced value is stored only as a stable `<secret:sha256:…>` token,
+so a rotated credential surfaces as "secret rotated" and no secret is ever
+persisted. On a first run (nothing recorded yet) every row is reported as new.
 
 ## `dev`
 

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -107,6 +107,8 @@ arrow = [
     "faucet-core/arrow",
     "faucet-source-parquet?/arrow",
     "faucet-sink-parquet?/arrow",
+    "faucet-source-delta?/arrow",
+    "faucet-sink-delta?/arrow",
 ]
 ## Shared, single-flight auth providers (OAuth2 client-credentials / refresh,
 ## token-endpoint) usable across connectors via `auth: { ref }`.


### PR DESCRIPTION
Closes #374.

## Summary

Adds a `terraform plan`-style **config-change preview**. On every successful `faucet run` / `replicate` / `schedule --once`, a redacted snapshot of the *resolved + expanded* config is recorded into the catalog store (best-effort — recording never fails a run, per #279). `faucet plan --diff` re-expands the current config, loads the last snapshot, and renders a **per-matrix-row semantic diff** — rows created / changed / removed, and within each changed row the exact dotted-path fields that differ.

```text
Pipeline: hibob   (last run 2026-07-18 09:12 UTC)

  + people             NEW ROW — will be created
  ~ payroll            CHANGED
      source.config.page_size      100  ->  500
      source.config.path           /v1/pay  ->  /v1/payroll
  ~ timeoff            CHANGED
      source.config.token          (secret rotated)
  - benefits           REMOVED — no longer in the run set
  = employees          unchanged

Summary: 1 to create, 2 to change, 1 removed, 1 unchanged.
```

## What's included

- **Snapshot storage on the catalog store.** New `ConfigSnapshot` / `RowSnapshot` / `ConnectorSnapshot` / `TransformSnapshot` types; two new `RunHistory` methods (`catalog_record_config_snapshot` / `catalog_last_config_snapshot`) defaulted inert, implemented by the memory + SQL backends, forwarded by `FallbackHistory`. New `faucet_config_snapshots` table (latest-wins upsert per pipeline) on both SQLite and Postgres.
- **Resolved, not textual.** The diff is built from the expanded nodes (post `extends`/`vars`/`${env:}` interpolation + matrix fan-out), so a one-line `${vars.x}` edit shows its real per-row effect and textually-different files that resolve identically show no diff.
- **Secret-safe (mandatory).** New `secrets::registry::redact_with` (a generic sibling of `redact`) swaps every secret-sourced value for a stable `<secret:sha256:…>` token before storage. No secret material is ever persisted; a rotated credential surfaces as "secret rotated" rather than printing either value.
- **`faucet plan --diff` / `--json`.** Requires a `catalog:` block + the `catalog` build feature. First run (nothing recorded) reports every row as new.

## Tests

- `catalog::snapshot`: first-run-all-new, added/removed/changed/unchanged detection with field-level deltas, secret-rotation surfacing (no hash printed), stable-token redaction.
- Backend roundtrips: memory + SQLite (latest-wins upsert, per-pipeline keying).
- `cargo fmt --all --check`, `cargo clippy -p faucet-cli --features catalog --all-targets` clean; default (catalog-off) build byte-compatible.

## Out of scope (follow-ups)

- `--against <snapshot-id>` (requires snapshot history — MVP keeps latest-per-pipeline).
- Continuous-scheduler per-tick recording (`run` / `replicate` / `schedule --once` covered).
- Folding the schema-drift delta `plan` already computes into the diff view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCvd78Tv4af3HgjhrJAa4i