### PR TITLE
feat(cli): shell tab-completion — `faucet completions` + dynamic (registry/config-aware) completion (#383)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -2389,6 +2389,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -3793,6 +3805,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "clap_complete",
  "croner",
  "dashmap",
  "dotenvy",
@@ -7235,6 +7248,15 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -11450,6 +11472,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sigchld"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -382,6 +382,12 @@ faucet-lineage = { workspace = true, optional = true }
 faucet-transform-sql = { workspace = true, optional = true }
 
 clap = { version = "4", features = ["derive", "env"] }
+# Shell tab-completion (#383): static script generation + dynamic
+# (registry/config-aware) completion via `CompleteEnv`. `unstable-dynamic`
+# is what enables the runtime candidate providers (connector kinds, matrix
+# row ids); it is an unstable API surface, kept contained to the completions
+# module + a few `#[arg(add = …)]` attributes.
+clap_complete = { version = "4", features = ["unstable-dynamic"] }
 dotenvy = "0.15"
 schemars.workspace = true
 serde.workspace = true

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,7 @@ cargo install faucet-cli --no-default-features \
 | `faucet backfill <config> --from A --to B [--window W] [--resume]` | Replay a bounded historical window as resumable, bookmark-isolated window units (`${backfill.*}` tokens scope the source; durable progress marker; `--dry-run` to preview; bookmark mode via `--from-bookmark`). `faucet schema backfill` prints the defaults-block schema. Exits with the failed-unit count. |
 | `faucet schedule <config> [--once]` | Run a pipeline on a cron schedule (long-running foreground process). Requires a `schedule:` block. |
 | `faucet catalog datasets\|show\|lineage [--config C] [--json]` | Browse the Data Movement Catalog accumulated by a config's `catalog:` store: dataset list, per-dataset schema timeline / volume / edges, and the lineage graph. Requires the `catalog` build feature. `faucet schema catalog` prints the block's JSON Schema. |
+| `faucet completions <bash\|zsh\|fish\|powershell\|elvish>` | Print a shell tab-completion script. For registry- and config-aware **dynamic** completion, enable the `COMPLETE` hook instead (see [`faucet completions`](#faucet-completions)). |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
 
@@ -402,6 +403,36 @@ regardless of `--no-ui`.
 
 See the [web console guide](https://pawansikawat.github.io/faucet-stream/cookbook/web-console.html)
 for the full walkthrough.
+
+### `faucet completions`
+
+`faucet completions <shell>` prints a static tab-completion script for `bash`,
+`zsh`, `fish`, `powershell`, or `elvish`:
+
+```bash
+faucet completions zsh > ~/.zfunc/_faucet     # then ensure ~/.zfunc is on $fpath
+faucet completions bash > /etc/bash_completion.d/faucet
+```
+
+For **dynamic** completion — computed by the binary at completion time, so it
+reflects the connectors compiled into *this* build and reads the local config —
+enable the `COMPLETE` hook instead of installing a static script:
+
+```bash
+echo 'source <(COMPLETE=zsh  faucet)' >> ~/.zshrc      # zsh
+echo 'source <(COMPLETE=bash faucet)' >> ~/.bashrc     # bash
+echo 'COMPLETE=fish faucet | source'  >> ~/.config/fish/config.fish
+```
+
+Dynamic completion then offers runtime-aware candidates:
+
+- `faucet schema source|sink|transform <TAB>` — the connectors/transforms in this build.
+- `faucet run --select|--only|--skip <TAB>` — matrix row ids from the `faucet.yaml` in the cwd.
+- `faucet run --status <TAB>` — the readiness ladder; `--tag <TAB>` — the config's tags.
+
+The config-aware providers are read-only and best-effort: they parse + expand
+the local config but never resolve secrets, touch the network, or open a
+connector, and yield no suggestions when no config is present.
 
 ### `faucet init`
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,6 +1,8 @@
 //! Argument parser shared by `main.rs` and the integration tests.
 
+use crate::commands::completions;
 use clap::{Args, Parser, Subcommand};
+use clap_complete::engine::ArgValueCandidates;
 use std::path::PathBuf;
 
 /// Runtime matrix-row selection flags, shared by `run`/`validate`/`preview`/
@@ -11,29 +13,34 @@ pub struct SelectionArgs {
     /// Run only matrix rows whose id exactly matches. Repeatable and/or
     /// comma-joined (`--select people --select time_off` or `--select a,b`).
     /// Force-includes by name, bypassing the `status` gate. (#370)
-    #[arg(long = "select", value_delimiter = ',', env = "FAUCET_SELECT")]
+    #[arg(long = "select", value_delimiter = ',', env = "FAUCET_SELECT",
+          add = ArgValueCandidates::new(completions::matrix_id_candidates))]
     pub select: Vec<String>,
 
     /// Like `--select` but glob-matched against row ids (`--only 'timeoff_*'`).
     /// Also bypasses the `status` gate. Repeatable / comma-joined. (#370)
-    #[arg(long = "only", value_delimiter = ',')]
+    #[arg(long = "only", value_delimiter = ',',
+          add = ArgValueCandidates::new(completions::matrix_id_candidates))]
     pub only: Vec<String>,
 
     /// Remove matching rows (exact id or glob) from the run set, applied last.
     /// A `mandatory` row is removable only by an exact `--skip <id>`. (#370)
-    #[arg(long = "skip", value_delimiter = ',', env = "FAUCET_SKIP")]
+    #[arg(long = "skip", value_delimiter = ',', env = "FAUCET_SKIP",
+          add = ArgValueCandidates::new(completions::matrix_id_candidates))]
     pub skip: Vec<String>,
 
     /// Additively include a readiness tier beyond the default
     /// `{mandatory, active}` set: `available` / `draft` / `archived`.
     /// Repeatable / comma-joined. (#371)
-    #[arg(long = "status", value_delimiter = ',', env = "FAUCET_STATUS")]
+    #[arg(long = "status", value_delimiter = ',', env = "FAUCET_STATUS",
+          add = ArgValueCandidates::new(completions::status_candidates))]
     pub status: Vec<String>,
 
     /// Narrow the eligible set to rows carrying any listed tag (union).
     /// Cannot resurrect a non-eligible row — raise `--status` for that.
     /// Repeatable / comma-joined. (#376)
-    #[arg(long = "tag", value_delimiter = ',', env = "FAUCET_TAGS")]
+    #[arg(long = "tag", value_delimiter = ',', env = "FAUCET_TAGS",
+          add = ArgValueCandidates::new(completions::tag_candidates))]
     pub tags: Vec<String>,
 
     /// How a selected row's `parent:` / `depends_on:` ancestors are resolved
@@ -132,6 +139,17 @@ pub enum Command {
     /// store — datasets, schema timelines, volume/freshness, lineage.
     #[cfg(feature = "catalog")]
     Catalog(CatalogArgs),
+    /// Generate a shell tab-completion script (bash / zsh / fish / powershell /
+    /// elvish). For registry- and config-aware *dynamic* completion, enable the
+    /// `COMPLETE` hook instead, e.g. `source <(COMPLETE=zsh faucet)`.
+    Completions(CompletionsArgs),
+}
+
+/// `faucet completions` arguments.
+#[derive(Debug, Args)]
+pub struct CompletionsArgs {
+    /// Target shell.
+    pub shell: clap_complete::aot::Shell,
 }
 
 /// `faucet catalog` arguments.
@@ -840,17 +858,20 @@ pub enum SchemaTarget {
     /// JSON Schema for a source connector config.
     Source {
         /// Connector name (e.g. `rest`, `graphql`, `postgres`).
+        #[arg(add = ArgValueCandidates::new(completions::source_kind_candidates))]
         name: String,
     },
     /// JSON Schema for a sink connector config.
     Sink {
         /// Connector name (e.g. `jsonl`, `bigquery`, `postgres`).
+        #[arg(add = ArgValueCandidates::new(completions::sink_kind_candidates))]
         name: String,
     },
     /// JSON Schema for a transform's inline config.
     Transform {
         /// Transform name (e.g. `flatten`, `keys_case`, `cast`).
         /// Run `faucet list` to see what is compiled in.
+        #[arg(add = ArgValueCandidates::new(completions::transform_candidates))]
         name: String,
     },
     /// JSON Schema for the DLQ (Dead Letter Queue) specification.

--- a/cli/src/commands/completions.rs
+++ b/cli/src/commands/completions.rs
@@ -30,9 +30,15 @@ use std::io;
 
 /// Emit a static completion script for `shell` to stdout.
 pub fn run(shell: Shell) -> CliResult<()> {
-    let mut cmd = Cli::command();
-    generate(shell, &mut cmd, "faucet", &mut io::stdout());
+    write_completions(shell, &mut io::stdout());
     Ok(())
+}
+
+/// Write the completion script for `shell` into `out`. Split from [`run`] so it
+/// is testable against an in-memory buffer (rather than the process's stdout).
+fn write_completions(shell: Shell, out: &mut impl io::Write) {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "faucet", out);
 }
 
 // ── Dynamic candidate providers ─────────────────────────────────────────────
@@ -205,7 +211,8 @@ matrix:
 
     #[test]
     fn static_generation_produces_a_nonempty_script() {
-        // Exercise the static generator for every supported shell.
+        // Exercise the static generator for every supported shell, into a
+        // buffer (no stdout), via the same helper `run` delegates to.
         for shell in [
             Shell::Bash,
             Shell::Zsh,
@@ -213,9 +220,8 @@ matrix:
             Shell::PowerShell,
             Shell::Elvish,
         ] {
-            let mut cmd = Cli::command();
             let mut buf: Vec<u8> = Vec::new();
-            generate(shell, &mut cmd, "faucet", &mut buf);
+            write_completions(shell, &mut buf);
             let script = String::from_utf8(buf).expect("utf8 script");
             assert!(
                 script.contains("faucet"),
@@ -223,5 +229,25 @@ matrix:
             );
             assert!(!script.is_empty());
         }
+    }
+
+    #[test]
+    fn run_emits_a_script_and_succeeds() {
+        // Covers the stdout wrapper `run` itself; the script is written to the
+        // test harness's captured stdout.
+        run(Shell::Bash).expect("completions run should succeed");
+    }
+
+    #[test]
+    fn cwd_providers_are_best_effort_and_never_panic() {
+        // The public providers read the process's current directory. From an
+        // arbitrary cwd (no fixture) they must return a (possibly empty)
+        // candidate list without panicking — exercising the `current_dir()`
+        // path + the map that `#[arg(add = …)]` calls at completion time.
+        // Running these to completion without panicking IS the assertion (the
+        // documented best-effort contract); binding the results keeps the calls
+        // from being optimized away.
+        let _ids = matrix_id_candidates();
+        let _tags = tag_candidates();
     }
 }

--- a/cli/src/commands/completions.rs
+++ b/cli/src/commands/completions.rs
@@ -1,0 +1,227 @@
+//! `faucet completions <shell>` — emit a static shell-completion script — plus
+//! the **dynamic** (runtime) candidate providers used by `clap_complete`'s
+//! `CompleteEnv` hook (#383).
+//!
+//! Two layers:
+//!
+//! - **Static**: [`run`] writes a completion script for the requested shell to
+//!   stdout via [`clap_complete::aot::generate`]. It covers subcommand names,
+//!   flag names, fixed-choice value enums, and file-path arguments.
+//! - **Dynamic**: the `*_candidates` functions are attached to specific args
+//!   with `#[arg(add = ArgValueCandidates::new(...))]` in [`crate::cli`]. When
+//!   the shell calls back into the binary at completion time (the `COMPLETE`
+//!   env hook wired in [`crate::run_main`]), these compute candidates from the
+//!   **compiled registry** (connector kinds) and the **config on disk** (matrix
+//!   row ids / tags).
+//!
+//! **Safety contract:** every dynamic provider must be fast, panic-free, and
+//! side-effect-free — no network, no state writes, no connector construction.
+//! Connector kinds are compile-time. The config-derived providers only *read*
+//! the local config and run the pure [`crate::expand::expand`] pass (which does
+//! not build sources or resolve `${secret:}` / `${env:}` directives), returning
+//! an empty list on any error.
+
+use crate::CliResult;
+use crate::cli::Cli;
+use clap::CommandFactory;
+use clap_complete::aot::{Shell, generate};
+use clap_complete::engine::CompletionCandidate;
+use std::io;
+
+/// Emit a static completion script for `shell` to stdout.
+pub fn run(shell: Shell) -> CliResult<()> {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "faucet", &mut io::stdout());
+    Ok(())
+}
+
+// ── Dynamic candidate providers ─────────────────────────────────────────────
+
+/// Compiled-in source connector kinds (e.g. `rest`, `postgres`, `s3`).
+pub(crate) fn source_kind_candidates() -> Vec<CompletionCandidate> {
+    crate::registry::source_kinds()
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Compiled-in sink connector kinds (e.g. `jsonl`, `bigquery`, `s3`).
+pub(crate) fn sink_kind_candidates() -> Vec<CompletionCandidate> {
+    crate::registry::sink_kinds()
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Compiled-in transform kinds, with their one-line descriptions as help.
+pub(crate) fn transform_candidates() -> Vec<CompletionCandidate> {
+    crate::transforms::transform_descriptions()
+        .into_iter()
+        .map(|(kind, desc)| CompletionCandidate::new(kind).help(Some(desc.into())))
+        .collect()
+}
+
+/// The source-readiness ladder used by `--status` (#371).
+pub(crate) fn status_candidates() -> Vec<CompletionCandidate> {
+    ["mandatory", "active", "available", "draft", "archived"]
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Matrix row ids from the config discovered in the current directory, for
+/// `--select` / `--only` / `--skip`. Empty when no config is found or it does
+/// not parse/expand.
+pub(crate) fn matrix_id_candidates() -> Vec<CompletionCandidate> {
+    let dir = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+    expanded_ids_from_dir(&dir)
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Distinct tags present across the discovered config's rows, for `--tag`
+/// (#376). Empty when no config is found or it does not parse/expand.
+pub(crate) fn tag_candidates() -> Vec<CompletionCandidate> {
+    let dir = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+    expanded_tags_from_dir(&dir)
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Best-effort: discover + parse + expand the config in `dir` and return its
+/// node ids. Any failure (no config, parse error, expand error) yields an empty
+/// list — completion must never error.
+fn expanded_ids_from_dir(dir: &std::path::Path) -> Vec<String> {
+    load_expanded_from_dir(dir)
+        .map(|nodes| nodes.into_iter().map(|n| n.id).collect())
+        .unwrap_or_default()
+}
+
+/// Best-effort distinct, sorted tags across `dir`'s config rows.
+fn expanded_tags_from_dir(dir: &std::path::Path) -> Vec<String> {
+    let mut tags: Vec<String> = load_expanded_from_dir(dir)
+        .map(|nodes| nodes.into_iter().flat_map(|n| n.tags).collect())
+        .unwrap_or_default();
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+/// Discover the config in `dir`, parse it, and run the pure expansion pass.
+/// Returns `None` on any error (completion is best-effort). Does no I/O beyond
+/// reading the config file and does not resolve secrets/env or build sources.
+///
+/// Takes an explicit `dir` (rather than reading `$PWD` internally) so it is
+/// testable without mutating the process-global current directory.
+fn load_expanded_from_dir(dir: &std::path::Path) -> Option<Vec<crate::expand::ExpandedNode>> {
+    let path = crate::env_loader::discover_config_path(dir)?;
+    let text = std::fs::read_to_string(&path).ok()?;
+    let cfg = crate::config::PipelineConfig::from_text(&text, &path).ok()?;
+    crate::expand::expand(&cfg).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(cands: &[CompletionCandidate]) -> Vec<String> {
+        cands
+            .iter()
+            .map(|c| c.get_value().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn source_and_sink_kinds_match_registry() {
+        let src = labels(&source_kind_candidates());
+        assert_eq!(src, crate::registry::source_kinds());
+        let sink = labels(&sink_kind_candidates());
+        assert_eq!(sink, crate::registry::sink_kinds());
+        // The default build always compiles the REST source + jsonl sink.
+        assert!(src.contains(&"rest".to_string()));
+        assert!(sink.contains(&"jsonl".to_string()));
+    }
+
+    #[test]
+    fn transform_candidates_cover_registry() {
+        let got = labels(&transform_candidates());
+        let expected: Vec<String> = crate::transforms::transform_descriptions()
+            .into_iter()
+            .map(|(k, _)| k.to_string())
+            .collect();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn status_candidates_are_the_readiness_ladder() {
+        assert_eq!(
+            labels(&status_candidates()),
+            vec!["mandatory", "active", "available", "draft", "archived"]
+        );
+    }
+
+    #[test]
+    fn config_providers_are_empty_without_a_config() {
+        // A scratch dir with no faucet.{yaml,yml,json}: both config-derived
+        // providers return empty rather than erroring. Uses an explicit dir
+        // (not `set_current_dir`) so it is race-free under parallel tests.
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(expanded_ids_from_dir(dir.path()).is_empty());
+        assert!(expanded_tags_from_dir(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn matrix_ids_and_tags_from_a_config_fixture() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = r#"
+version: 1
+name: demo
+pipeline:
+  source: { type: rest, config: { url: "https://example.com" } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+matrix:
+  - id: alpha
+    tags: [daily, us]
+  - id: beta
+    tags: [daily]
+"#;
+        std::fs::write(dir.path().join("faucet.yaml"), cfg).expect("write cfg");
+        let ids = expanded_ids_from_dir(dir.path());
+        let tags = expanded_tags_from_dir(dir.path());
+
+        assert!(ids.contains(&"alpha".to_string()), "ids: {ids:?}");
+        assert!(ids.contains(&"beta".to_string()), "ids: {ids:?}");
+        // Tags are the distinct, sorted union across rows.
+        assert_eq!(tags, vec!["daily", "us"]);
+    }
+
+    #[test]
+    fn static_generation_produces_a_nonempty_script() {
+        // Exercise the static generator for every supported shell.
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ] {
+            let mut cmd = Cli::command();
+            let mut buf: Vec<u8> = Vec::new();
+            generate(shell, &mut cmd, "faucet", &mut buf);
+            let script = String::from_utf8(buf).expect("utf8 script");
+            assert!(
+                script.contains("faucet"),
+                "{shell} script should mention the binary name"
+            );
+            assert!(!script.is_empty());
+        }
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 pub mod backfill;
 #[cfg(feature = "catalog")]
 pub mod catalog;
+pub mod completions;
 pub mod conformance;
 #[cfg(feature = "contract")]
 pub mod contract;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -90,7 +90,8 @@ pub fn run_main(registry: PluginRegistry) -> std::process::ExitCode {
     // `COMPLETE` env var set, compute and print candidates, then exit — before
     // any normal parsing/tracing/runtime setup. A no-op otherwise. The registry
     // is installed above so connector-kind candidates reflect the live binary.
-    clap_complete::env::CompleteEnv::with_factory(<Cli as clap::CommandFactory>::command).complete();
+    clap_complete::env::CompleteEnv::with_factory(<Cli as clap::CommandFactory>::command)
+        .complete();
 
     let cli = Cli::parse();
     #[cfg(feature = "serve")]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -85,6 +85,13 @@ pub fn run_main(registry: PluginRegistry) -> std::process::ExitCode {
         commands::report(&err);
         return ExitCode::from(1);
     }
+
+    // Dynamic shell completion (#383): when the shell invokes us with the
+    // `COMPLETE` env var set, compute and print candidates, then exit — before
+    // any normal parsing/tracing/runtime setup. A no-op otherwise. The registry
+    // is installed above so connector-kind candidates reflect the live binary.
+    clap_complete::env::CompleteEnv::with_factory(<Cli as clap::CommandFactory>::command).complete();
+
     let cli = Cli::parse();
     #[cfg(feature = "serve")]
     let is_serve = matches!(cli.command, Command::Serve(_));
@@ -172,6 +179,7 @@ pub async fn run_command(cli: Cli) -> CliResult<()> {
         Command::Notify(args) => commands::notify::run(args).await,
         #[cfg(feature = "catalog")]
         Command::Catalog(args) => commands::catalog::run(args).await,
+        Command::Completions(args) => commands::completions::run(args.shell),
     }
 }
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -22,6 +22,7 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet replicate [config]` | Bulk-snapshot a table, then hand off to CDC for a gap-free mirror. |
 | `faucet schedule [config]` | Run a pipeline on a cron schedule (long-running foreground process). |
 | `faucet serve` | Run a long-running HTTP control plane: submit / poll / cancel pipeline runs over REST. |
+| `faucet completions <shell>` | Print a shell tab-completion script (bash / zsh / fish / powershell / elvish). |
 
 `[config]` is optional for `run` / `validate` / `preview` / `doctor` / `replicate` / `schedule`: if
 omitted, faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
@@ -742,3 +743,43 @@ environment. Nested/tagged-enum fields use a `*_JSON` suffix.
 
 > The complete config grammar (matrix, templates, vars, execution) lives in
 > [`cli/README.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/README.md).
+
+## Shell completions
+
+`faucet` supports tab-completion in two ways.
+
+**Static script** — generate a completion script for your shell and install it
+the way that shell expects:
+
+```bash
+faucet completions bash   > /etc/bash_completion.d/faucet     # bash
+faucet completions zsh    > ~/.zfunc/_faucet                  # zsh (dir on $fpath)
+faucet completions fish   > ~/.config/fish/completions/faucet.fish
+faucet completions powershell >> $PROFILE                     # powershell
+```
+
+This completes subcommand names, flags, fixed-choice values, and file paths.
+
+**Dynamic (recommended)** — let the binary compute completions at completion
+time, so it stays in sync with the build and becomes **config-aware**. Add one
+line to your shell rc:
+
+```bash
+echo 'source <(COMPLETE=bash faucet)' >> ~/.bashrc     # bash
+echo 'source <(COMPLETE=zsh  faucet)' >> ~/.zshrc      # zsh
+echo 'COMPLETE=fish faucet | source'  >> ~/.config/fish/config.fish
+```
+
+With the dynamic hook enabled you get runtime-aware candidates:
+
+- `faucet schema source <TAB>` / `sink` / `transform` — the connectors and
+  transforms **compiled into this binary** (a slim build lists only its own).
+- `faucet run --select <TAB>` / `--only` / `--skip` — the **matrix row ids**
+  from the `faucet.yaml` in the current directory.
+- `faucet run --status <TAB>` — the readiness ladder
+  (`mandatory active available draft archived`).
+- `faucet run --tag <TAB>` — the tags present in the current config.
+
+The config-aware providers are best-effort and read-only: they parse and expand
+the local config but never resolve secrets, hit the network, or open a
+connector, and fall back to no suggestions if no config is present.


### PR DESCRIPTION
Closes #383. Adds shell tab-completion to the `faucet` CLI in two additive layers — no run-path change, default behavior unchanged.

## What's new

**Static — `faucet completions <shell>`** (bash / zsh / fish / powershell / elvish): emits a completion script via `clap_complete`, covering subcommand names, flags, fixed-choice value enums, and file paths.

**Dynamic — `CompleteEnv` hook** (`source <(COMPLETE=zsh faucet)`): the binary computes candidates at completion time, so they reflect the actual build and the local config:

| Type | Completes to |
|---|---|
| `faucet schema source\|sink\|transform <TAB>` | the connectors/transforms **compiled into this binary** (`registry::source_kinds`/`sink_kinds` + `transform_descriptions`) |
| `faucet run --select\|--only\|--skip <TAB>` | **matrix row ids** parsed + expanded from the `faucet.yaml` in the cwd |
| `faucet run --status <TAB>` | the readiness ladder (`mandatory active available draft archived`) |
| `faucet run --tag <TAB>` | the tags present in the current config |

## Design & safety

- The config-aware providers are **read-only, best-effort, side-effect-free**: they discover + parse + run the pure `expand()` pass, and **never** resolve `${secret:}`/`${env:}`, hit the network, or construct a connector. Any error → empty candidates (completion never fails). Verified: `from_text` does no secret/env interpolation (that's a separate load stage).
- `CompleteEnv` runs at the very top of `run_main`, before parsing/tracing/runtime setup; a no-op when `COMPLETE` is unset.
- `unstable-dynamic` is contained to the completions module + a few `#[arg(add = …)]` attributes, so a future `clap_complete` bump is a localized change; static generation is stable API.

## Testing

- Unit tests: kind/transform providers match the registry; `--status` ladder; matrix-id + tag extraction from a config fixture using an **explicit dir** (no `set_current_dir`, so race-free under parallel tests); providers return empty with no config; static generation produces a non-empty script for every shell.
- Manually verified end-to-end against the dynamic protocol: `schema source <TAB>` lists real source kinds, `schema transform <TAB>` lists transforms, `faucet <TAB>` lists subcommands (incl. `completions`), and `run --select <TAB>` lists a fixture config's `alpha`/`beta` rows.
- `cargo clippy -p faucet-cli --all-targets` clean; `cargo fmt --check` clean.

## Docs

`cli/README.md` and `docs/book/src/reference/cli.md` gain a "Shell completions" section documenting both the static and dynamic install paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)