### PR TITLE
feat(cli): `faucet migrate` + `doctor --offline` config linter (#388, #392)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -43,6 +43,8 @@ cargo install faucet-cli --no-default-features \
 | `faucet schedule <config> [--once]` | Run a pipeline on a cron schedule (long-running foreground process). Requires a `schedule:` block. |
 | `faucet catalog datasets\|show\|lineage [--config C] [--json]` | Browse the Data Movement Catalog accumulated by a config's `catalog:` store: dataset list, per-dataset schema timeline / volume / edges, and the lineage graph. Requires the `catalog` build feature. `faucet schema catalog` prints the block's JSON Schema. |
 | `faucet completions <bash\|zsh\|fish\|powershell\|elvish>` | Print a shell tab-completion script. For registry- and config-aware **dynamic** completion, enable the `COMPLETE` hook instead (see [`faucet completions`](#faucet-completions)). |
+| `faucet migrate [config] [--check\|--stdout]` | Upgrade an old-grammar config to the current shape in place (idempotent): wraps top-level `source:`/`sink:` into `pipeline:`, folds legacy `auth`/`credentials` into `{ type, config }`. `--check` exits non-zero if a migration is needed (CI); `--stdout` previews without writing. |
+| `faucet doctor --offline [config]` | Static, credential-free config lints (no network): dangling / unreferenced `auth:` providers, unused `vars:`, no-op sink `batch_size: 0`. Exits non-zero on any lint error. |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -143,6 +143,26 @@ pub enum Command {
     /// elvish). For registry- and config-aware *dynamic* completion, enable the
     /// `COMPLETE` hook instead, e.g. `source <(COMPLETE=zsh faucet)`.
     Completions(CompletionsArgs),
+    /// Upgrade a config written against an older `faucet` grammar to the current
+    /// shape (e.g. pre-`pipeline:` top-level source/sink, legacy inline auth).
+    /// Idempotent; rewrites in place unless `--check` / `--stdout`.
+    Migrate(MigrateArgs),
+}
+
+/// `faucet migrate` arguments.
+#[derive(Debug, Args)]
+pub struct MigrateArgs {
+    /// Config file to migrate. Auto-discovered (`faucet.yaml` → `.yml` →
+    /// `.json`) when omitted.
+    #[arg(value_hint = clap::ValueHint::FilePath)]
+    pub config: Option<PathBuf>,
+    /// Report whether a migration is needed without writing (exits non-zero if
+    /// the config is not current). For CI / pre-upgrade checks.
+    #[arg(long)]
+    pub check: bool,
+    /// Write the migrated config to stdout instead of rewriting the file.
+    #[arg(long, conflicts_with = "check")]
+    pub stdout: bool,
 }
 
 /// `faucet completions` arguments.
@@ -440,6 +460,12 @@ pub struct DoctorArgs {
     /// Emit machine-readable JSON instead of the human checklist.
     #[arg(long)]
     pub json: bool,
+    /// Run only the offline static config lints (no network probes): dangling /
+    /// unreferenced `auth:` providers, unused `vars:`, and no-op sink
+    /// `batch_size: 0`. Fast and credential-free — ideal for CI. Exits non-zero
+    /// on any lint *error* (warnings don't fail).
+    #[arg(long)]
+    pub offline: bool,
     /// Select a named overlay from the config's `profiles:` block and deep-merge
     /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
     #[arg(long, env = "FAUCET_PROFILE")]

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -809,7 +809,46 @@ pipeline:
             LintFinding::error("dangling-auth-ref", "x".into(), "h"),
             LintFinding::warning("unused-var", "y".into(), "h"),
         ];
-        let errs = render_lints(Path::new("faucet.yaml"), &findings, true);
-        assert_eq!(errs, 1);
+        // JSON branch.
+        assert_eq!(render_lints(Path::new("faucet.yaml"), &findings, true), 1);
+        // Human branch (also exercises the empty-findings path).
+        assert_eq!(render_lints(Path::new("faucet.yaml"), &findings, false), 1);
+        assert_eq!(render_lints(Path::new("faucet.yaml"), &[], false), 0);
+    }
+
+    fn write_cfg(body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("faucet.yaml");
+        std::fs::write(&path, body).expect("write");
+        (dir, path)
+    }
+
+    fn offline_args(path: std::path::PathBuf) -> DoctorArgs {
+        DoctorArgs {
+            config: Some(path),
+            env_file: None,
+            no_env_file: true,
+            timeout_secs: 5,
+            json: false,
+            offline: true,
+            profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn offline_run_ok_on_clean_config() {
+        let (_d, path) = write_cfg(
+            "version: 1\npipeline:\n  source: { type: rest, config: { base_url: x } }\n  sink: { type: jsonl, config: { path: o } }\n",
+        );
+        super::run(offline_args(path)).await.expect("clean lint ok");
+    }
+
+    #[tokio::test]
+    async fn offline_run_errors_on_dangling_auth_ref() {
+        let (_d, path) = write_cfg(
+            "version: 1\npipeline:\n  source: { type: rest, config: { base_url: x, auth: { ref: nope } } }\n  sink: { type: jsonl, config: { path: o } }\n",
+        );
+        let err = super::run(offline_args(path)).await;
+        assert!(matches!(err, Err(CliError::DoctorFailed { failed }) if failed >= 1));
     }
 }

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -85,6 +85,19 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
     let cfg_ms = t_cfg.elapsed().as_millis();
 
     let nodes = expand(&cfg)?;
+
+    // `--offline`: run only the static config lints — no connectors built, no
+    // network, no credentials. Fast, CI-friendly, and credential-free.
+    if args.offline {
+        let raw = std::fs::read_to_string(&path).unwrap_or_default();
+        let findings = lint_config(&cfg, &nodes, &raw);
+        let errors = render_lints(&path, &findings, args.json);
+        if errors > 0 {
+            return Err(CliError::DoctorFailed { failed: errors });
+        }
+        return Ok(());
+    }
+
     let auth = build_auth_catalog(cfg.auth.as_ref())?;
     let ctx = CheckContext {
         timeout: Duration::from_secs(args.timeout_secs),
@@ -417,6 +430,172 @@ fn render_human(
     );
 }
 
+// ── Offline config linter (#392) ─────────────────────────────────────────────
+
+/// Severity of a static config-lint finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LintSeverity {
+    /// A likely-broken config; counts toward the non-zero exit code.
+    Error,
+    /// A smell worth flagging; does not fail the lint.
+    Warning,
+}
+
+/// One static-lint finding: a severity, a short stable `code`, a message, and a
+/// fix hint.
+#[derive(Debug, Clone, Serialize)]
+pub struct LintFinding {
+    pub severity: LintSeverity,
+    pub code: &'static str,
+    pub message: String,
+    pub hint: String,
+}
+
+impl LintFinding {
+    fn error(code: &'static str, message: String, hint: impl Into<String>) -> Self {
+        Self {
+            severity: LintSeverity::Error,
+            code,
+            message,
+            hint: hint.into(),
+        }
+    }
+    fn warning(code: &'static str, message: String, hint: impl Into<String>) -> Self {
+        Self {
+            severity: LintSeverity::Warning,
+            code,
+            message,
+            hint: hint.into(),
+        }
+    }
+}
+
+/// File/append sinks where `batch_size` is a documented no-op (they write
+/// per-record regardless).
+const NO_OP_BATCH_SINKS: [&str; 3] = ["jsonl", "csv", "stdout"];
+
+/// Run the offline static lints over a resolved config + its expanded nodes.
+/// Pure: no I/O beyond the `raw` config text passed in for `${vars.*}` usage
+/// scanning. Reused by `faucet doctor --offline`.
+pub(crate) fn lint_config(
+    cfg: &PipelineConfig,
+    nodes: &[ExpandedNode],
+    raw: &str,
+) -> Vec<LintFinding> {
+    let mut out = Vec::new();
+
+    // Every `auth: { ref: NAME }` referenced by any node's source or sink.
+    let mut referenced: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for n in nodes {
+        for spec in [&n.source, &n.sink] {
+            if let Some(name) = crate::auth_catalog::auth_ref(&spec.config) {
+                referenced.insert(name);
+            }
+        }
+    }
+    let catalog: std::collections::BTreeSet<String> = cfg
+        .auth
+        .as_ref()
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default();
+
+    // (1) Dangling auth ref — a connector references a provider not in `auth:`.
+    for name in &referenced {
+        if !catalog.contains(name) {
+            out.push(LintFinding::error(
+                "dangling-auth-ref",
+                format!("a connector references auth provider '{name}', which is not defined in the top-level `auth:` catalog"),
+                format!("add an `auth:` entry named '{name}', or fix the `auth: {{ ref: … }}` to match an existing provider"),
+            ));
+        }
+    }
+
+    // (2) Unreferenced auth provider — a catalog entry no connector uses.
+    for name in &catalog {
+        if !referenced.contains(name) {
+            out.push(LintFinding::warning(
+                "unreferenced-auth-provider",
+                format!("auth provider '{name}' is defined in `auth:` but never referenced by any connector"),
+                format!("reference it with `auth: {{ ref: {name} }}` on a connector, or remove the unused entry"),
+            ));
+        }
+    }
+
+    // (3) Unused vars — a `vars:` key never interpolated as `${vars.KEY}`.
+    if let Some(vars) = &cfg.vars {
+        for key in vars.keys() {
+            let token = format!("${{vars.{key}}}");
+            if !raw.contains(&token) {
+                out.push(LintFinding::warning(
+                    "unused-var",
+                    format!("`vars.{key}` is defined but never used (no `${{vars.{key}}}` reference found)"),
+                    "remove the unused variable, or reference it where intended",
+                ));
+            }
+        }
+    }
+
+    // (4) No-op sink `batch_size: 0` on file/append sinks.
+    for n in nodes {
+        if NO_OP_BATCH_SINKS.contains(&n.sink.kind.as_str())
+            && n.sink.config.get("batch_size").and_then(|v| v.as_u64()) == Some(0)
+        {
+            out.push(LintFinding::warning(
+                "noop-batch-size",
+                format!(
+                    "row '{}': sink `{}` sets `batch_size: 0`, which has no effect (this sink writes per-record)",
+                    n.id, n.sink.kind
+                ),
+                "drop `batch_size` from this sink — it only matters for batching sinks (databases, object stores, bulk APIs)",
+            ));
+        }
+    }
+
+    out
+}
+
+/// Render lint findings (human or `--json`) and return the number of *errors*
+/// (warnings don't count toward the exit code).
+fn render_lints(path: &Path, findings: &[LintFinding], json: bool) -> usize {
+    let errors = findings
+        .iter()
+        .filter(|f| f.severity == LintSeverity::Error)
+        .count();
+    let warnings = findings.len() - errors;
+
+    if json {
+        let v = serde_json::json!({
+            "config": path.display().to_string(),
+            "errors": errors,
+            "warnings": warnings,
+            "findings": findings,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).expect("lint json serializes")
+        );
+        return errors;
+    }
+
+    println!("Config lint: {}", path.display());
+    if findings.is_empty() {
+        println!("  ✓ no issues found");
+        return 0;
+    }
+    for f in findings {
+        let tag = match f.severity {
+            LintSeverity::Error => "error",
+            LintSeverity::Warning => "warn",
+        };
+        println!("  [{tag}] {} — {}", f.code, f.message);
+        println!("         hint: {}", f.hint);
+    }
+    println!();
+    println!("Lint: {errors} error(s), {warnings} warning(s)");
+    errors
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,5 +705,111 @@ mod tests {
             )]),
         ];
         assert_eq!(count_failures(&invs), 2);
+    }
+
+    // ── Offline linter (#392) ────────────────────────────────────────────────
+
+    /// Parse a YAML config, expand it, and run the offline lints.
+    fn lint_yaml(text: &str) -> Vec<LintFinding> {
+        let cfg = crate::config::parse_with_extension(text, "yaml").expect("config parses");
+        let nodes = expand(&cfg).expect("config expands");
+        lint_config(&cfg, &nodes, text)
+    }
+
+    fn has(findings: &[LintFinding], code: &str) -> bool {
+        findings.iter().any(|f| f.code == code)
+    }
+
+    #[test]
+    fn clean_config_has_no_findings() {
+        let cfg = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x", auth: { ref: idp } } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+auth:
+  idp: { type: static, config: { token: "${env:T}" } }
+"#;
+        assert!(lint_yaml(cfg).is_empty(), "{:?}", lint_yaml(cfg));
+    }
+
+    #[test]
+    fn flags_dangling_auth_ref_as_error() {
+        let cfg = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x", auth: { ref: missing } } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+"#;
+        let f = lint_yaml(cfg);
+        assert!(has(&f, "dangling-auth-ref"));
+        assert!(
+            f.iter()
+                .any(|x| x.code == "dangling-auth-ref" && x.severity == LintSeverity::Error)
+        );
+    }
+
+    #[test]
+    fn flags_unreferenced_auth_provider_as_warning() {
+        let cfg = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x" } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+auth:
+  unused_idp: { type: static, config: { token: "t" } }
+"#;
+        let f = lint_yaml(cfg);
+        let p = f.iter().find(|x| x.code == "unreferenced-auth-provider");
+        assert!(p.is_some());
+        assert_eq!(p.unwrap().severity, LintSeverity::Warning);
+    }
+
+    #[test]
+    fn flags_unused_var() {
+        let cfg = r#"
+version: 1
+vars:
+  used: "https://x"
+  never: 5
+pipeline:
+  source: { type: rest, config: { base_url: "${vars.used}" } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+"#;
+        let f = lint_yaml(cfg);
+        assert!(has(&f, "unused-var"));
+        // Only `never` is flagged — `used` is referenced.
+        assert!(
+            f.iter()
+                .any(|x| x.code == "unused-var" && x.message.contains("never"))
+        );
+        assert!(
+            !f.iter()
+                .any(|x| x.code == "unused-var" && x.message.contains("vars.used"))
+        );
+    }
+
+    #[test]
+    fn flags_noop_batch_size_on_file_sink() {
+        let cfg = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x" } }
+  sink: { type: jsonl, config: { path: out.jsonl, batch_size: 0 } }
+"#;
+        let f = lint_yaml(cfg);
+        let p = f.iter().find(|x| x.code == "noop-batch-size");
+        assert!(p.is_some());
+        assert_eq!(p.unwrap().severity, LintSeverity::Warning);
+    }
+
+    #[test]
+    fn render_lints_counts_errors_only() {
+        let findings = vec![
+            LintFinding::error("dangling-auth-ref", "x".into(), "h"),
+            LintFinding::warning("unused-var", "y".into(), "h"),
+        ];
+        let errs = render_lints(Path::new("faucet.yaml"), &findings, true);
+        assert_eq!(errs, 1);
     }
 }

--- a/cli/src/commands/migrate.rs
+++ b/cli/src/commands/migrate.rs
@@ -1,0 +1,360 @@
+//! `faucet migrate` — upgrade a config written against an older `faucet`
+//! grammar to the current shape (#388).
+//!
+//! Each migration is a **pure** `serde_json::Value → serde_json::Value`
+//! transform with a before/after unit test. The command reads a config, applies
+//! every rule, and (unless `--check`) rewrites it in place, printing which rules
+//! fired. Migrations are **idempotent**: running `migrate` on an already-current
+//! config changes nothing and exits 0.
+//!
+//! Two rules ship today:
+//!
+//! 1. **Top-level `source:` / `sink:` → `pipeline.source` / `pipeline.sink`**
+//!    (the pre-#54 shape). If the document has top-level `source`/`sink` keys
+//!    and no `pipeline`, they move under a new `pipeline:` map.
+//! 2. **Legacy auth → adjacently-tagged `{ type, config }`** (the pre-#113
+//!    shape). Any `auth:` / `credentials:` object carrying a `type` string plus
+//!    sibling fields but no `config` has those siblings folded into `config`.
+//!
+//! Comments are not preserved (the config is parsed and re-serialized) — the
+//! same limitation `faucet fmt` documents.
+
+use crate::cli::MigrateArgs;
+use crate::error::{CliError, CliResult};
+use serde_json::{Map, Value};
+use std::path::Path;
+
+/// Execute the `migrate` subcommand.
+pub async fn run(args: MigrateArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let path = match args.config.clone() {
+        Some(p) => p,
+        None => crate::env_loader::discover_config_path(&cwd)
+            .ok_or_else(|| CliError::Config("no config file found to migrate".into()))?,
+    };
+
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| CliError::Config(format!("cannot read '{}': {e}", path.display())))?;
+    let format = ConfigFormat::from_path(&path)?;
+    let mut value = format.parse(&text, &path)?;
+
+    let applied = migrate_value(&mut value);
+
+    if applied.is_empty() {
+        println!("{}: already current — no migration needed", path.display());
+        return Ok(());
+    }
+
+    let rendered = format.render(&value, &path)?;
+
+    if args.check {
+        eprintln!(
+            "{}: migration needed ({} rule{}):",
+            path.display(),
+            applied.len(),
+            if applied.len() == 1 { "" } else { "s" }
+        );
+        for rule in &applied {
+            eprintln!("  - {rule}");
+        }
+        return Err(CliError::Config(format!(
+            "{} is not up to date; run `faucet migrate` to upgrade it",
+            path.display()
+        )));
+    }
+
+    if args.stdout {
+        print!("{rendered}");
+        return Ok(());
+    }
+
+    std::fs::write(&path, rendered)
+        .map_err(|e| CliError::Config(format!("cannot write '{}': {e}", path.display())))?;
+    println!(
+        "{}: migrated ({} rule{} applied):",
+        path.display(),
+        applied.len(),
+        if applied.len() == 1 { "" } else { "s" }
+    );
+    for rule in &applied {
+        println!("  - {rule}");
+    }
+    Ok(())
+}
+
+/// The on-disk serialization of a config file.
+#[derive(Clone, Copy)]
+enum ConfigFormat {
+    Yaml,
+    Json,
+}
+
+impl ConfigFormat {
+    fn from_path(path: &Path) -> CliResult<Self> {
+        match path.extension().and_then(|e| e.to_str()) {
+            Some("yaml") | Some("yml") => Ok(ConfigFormat::Yaml),
+            Some("json") => Ok(ConfigFormat::Json),
+            _ => Err(CliError::Config(format!(
+                "unsupported config extension for '{}' (expected .yaml/.yml/.json)",
+                path.display()
+            ))),
+        }
+    }
+
+    fn parse(self, text: &str, path: &Path) -> CliResult<Value> {
+        let err = |e: String| CliError::Config(format!("cannot parse '{}': {e}", path.display()));
+        match self {
+            ConfigFormat::Yaml => serde_yaml::from_str(text).map_err(|e| err(e.to_string())),
+            ConfigFormat::Json => serde_json::from_str(text).map_err(|e| err(e.to_string())),
+        }
+    }
+
+    fn render(self, value: &Value, path: &Path) -> CliResult<String> {
+        let err =
+            |e: String| CliError::Config(format!("cannot serialize '{}': {e}", path.display()));
+        match self {
+            ConfigFormat::Yaml => serde_yaml::to_string(value).map_err(|e| err(e.to_string())),
+            ConfigFormat::Json => {
+                let mut s = serde_json::to_string_pretty(value).map_err(|e| err(e.to_string()))?;
+                s.push('\n');
+                Ok(s)
+            }
+        }
+    }
+}
+
+/// Apply every migration rule in order, returning a human description of each
+/// rule that actually changed the document. An empty result means the config is
+/// already current. Pure and idempotent.
+pub(crate) fn migrate_value(value: &mut Value) -> Vec<String> {
+    let mut applied = Vec::new();
+    if migrate_toplevel_source_sink(value) {
+        applied.push(
+            "wrapped top-level `source:` / `sink:` in a `pipeline:` block (pre-#54 shape)".into(),
+        );
+    }
+    let n = migrate_legacy_auth(value);
+    if n > 0 {
+        applied.push(format!(
+            "folded {n} legacy `auth`/`credentials` block{} into `{{ type, config }}` (pre-#113 shape)",
+            if n == 1 { "" } else { "s" }
+        ));
+    }
+    applied
+}
+
+/// Rule 1: move top-level `source:` / `sink:` under a new `pipeline:` map.
+/// No-op if there is already a `pipeline:` key or neither top-level key exists.
+fn migrate_toplevel_source_sink(value: &mut Value) -> bool {
+    let Value::Object(root) = value else {
+        return false;
+    };
+    if root.contains_key("pipeline") {
+        return false;
+    }
+    let has_source = root.contains_key("source");
+    let has_sink = root.contains_key("sink");
+    if !has_source && !has_sink {
+        return false;
+    }
+    let mut pipeline = Map::new();
+    if let Some(s) = root.remove("source") {
+        pipeline.insert("source".into(), s);
+    }
+    if let Some(s) = root.remove("sink") {
+        pipeline.insert("sink".into(), s);
+    }
+    // Also relocate the sibling `transforms:` / `state:` blocks, which lived at
+    // the top level alongside the old `source:`/`sink:`.
+    for key in ["transforms", "state"] {
+        if let Some(v) = root.remove(key) {
+            pipeline.insert(key.into(), v);
+        }
+    }
+    root.insert("pipeline".into(), Value::Object(pipeline));
+    true
+}
+
+/// Rule 2: fold a legacy `auth`/`credentials` object of the shape
+/// `{ type: X, <field>: … }` into `{ type: X, config: { <field>: … } }`.
+/// Recurses through the whole document. Returns the number of blocks migrated.
+///
+/// Only objects reached under a key literally named `auth` or `credentials` are
+/// considered, and only when they carry a `type` string, at least one other
+/// field, and no existing `config` — so it never touches an already-migrated
+/// block or an unrelated object that happens to have a `type` field.
+fn migrate_legacy_auth(value: &mut Value) -> usize {
+    let mut count = 0;
+    walk_auth(value, false, &mut count);
+    count
+}
+
+fn walk_auth(value: &mut Value, under_auth_key: bool, count: &mut usize) {
+    match value {
+        Value::Object(map) => {
+            if under_auth_key && is_legacy_auth(map) {
+                fold_auth_config(map);
+                *count += 1;
+            }
+            for (k, v) in map.iter_mut() {
+                let child_is_auth = k == "auth" || k == "credentials";
+                walk_auth(v, child_is_auth, count);
+            }
+        }
+        Value::Array(items) => {
+            for v in items.iter_mut() {
+                // Array elements are not themselves "under" the auth key name.
+                walk_auth(v, false, count);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A map is the legacy auth shape if it has a string `type`, no `config`, and at
+/// least one field besides `type`.
+fn is_legacy_auth(map: &Map<String, Value>) -> bool {
+    map.get("type").is_some_and(Value::is_string)
+        && !map.contains_key("config")
+        && map.keys().any(|k| k != "type")
+}
+
+/// Move every field except `type` into a nested `config` object.
+fn fold_auth_config(map: &mut Map<String, Value>) {
+    let type_val = map.remove("type");
+    let mut config = Map::new();
+    let keys: Vec<String> = map.keys().cloned().collect();
+    for k in keys {
+        if let Some(v) = map.remove(&k) {
+            config.insert(k, v);
+        }
+    }
+    map.clear();
+    if let Some(t) = type_val {
+        map.insert("type".into(), t);
+    }
+    map.insert("config".into(), Value::Object(config));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn wraps_toplevel_source_sink_into_pipeline() {
+        let mut v = json!({
+            "version": 1,
+            "source": { "type": "rest", "config": { "url": "x" } },
+            "sink": { "type": "jsonl", "config": { "path": "o.jsonl" } },
+            "transforms": [{ "flatten": {} }]
+        });
+        let applied = migrate_value(&mut v);
+        assert_eq!(applied.len(), 1);
+        assert!(v.get("source").is_none());
+        assert!(v.get("sink").is_none());
+        let p = v.get("pipeline").unwrap();
+        assert_eq!(p["source"]["type"], "rest");
+        assert_eq!(p["sink"]["type"], "jsonl");
+        assert!(p.get("transforms").is_some());
+    }
+
+    #[test]
+    fn toplevel_rule_is_noop_when_pipeline_present() {
+        let mut v = json!({
+            "version": 1,
+            "pipeline": { "source": { "type": "rest" }, "sink": { "type": "jsonl" } }
+        });
+        assert!(migrate_value(&mut v).is_empty());
+    }
+
+    #[test]
+    fn folds_legacy_auth_into_type_config() {
+        let mut v = json!({
+            "version": 1,
+            "pipeline": {
+                "source": {
+                    "type": "rest",
+                    "config": {
+                        "url": "x",
+                        "auth": { "type": "bearer", "token": "${env:TOK}" }
+                    }
+                },
+                "sink": { "type": "jsonl", "config": { "path": "o.jsonl" } }
+            }
+        });
+        let applied = migrate_value(&mut v);
+        assert_eq!(applied.len(), 1);
+        let auth = &v["pipeline"]["source"]["config"]["auth"];
+        assert_eq!(auth["type"], "bearer");
+        assert_eq!(auth["config"]["token"], "${env:TOK}");
+        // No stray sibling left behind.
+        assert!(auth.get("token").is_none());
+    }
+
+    #[test]
+    fn auth_rule_is_idempotent_and_skips_current_shape() {
+        let v = json!({
+            "pipeline": { "source": { "type": "rest", "config": {
+                "auth": { "type": "bearer", "config": { "token": "t" } }
+            }}}
+        });
+        // Already `{type, config}` → untouched.
+        assert!(migrate_value(&mut v.clone()).is_empty());
+        // And running twice is a no-op on the second pass.
+        let mut once = v.clone();
+        migrate_value(&mut once);
+        let mut twice = once.clone();
+        assert!(migrate_value(&mut twice).is_empty());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn does_not_touch_non_auth_objects_with_a_type_field() {
+        // A `source: { type, config }` has a `type` but is NOT under an
+        // auth/credentials key, so it must be left alone.
+        let mut v = json!({
+            "pipeline": {
+                "source": { "type": "rest", "url": "x" },
+                "sink": { "type": "jsonl" }
+            }
+        });
+        let before = v.clone();
+        migrate_value(&mut v);
+        // The source's `url` sibling is NOT folded into a config (it's not auth).
+        assert_eq!(v["pipeline"]["source"], before["pipeline"]["source"]);
+    }
+
+    #[test]
+    fn both_rules_compose() {
+        let mut v = json!({
+            "source": { "type": "rest", "config": {
+                "auth": { "type": "basic", "user": "u", "pass": "p" }
+            }},
+            "sink": { "type": "jsonl", "config": { "path": "o" } }
+        });
+        let applied = migrate_value(&mut v);
+        assert_eq!(
+            applied.len(),
+            2,
+            "both the source/sink wrap and the auth fold fire"
+        );
+        let auth = &v["pipeline"]["source"]["config"]["auth"];
+        assert_eq!(auth["type"], "basic");
+        assert_eq!(auth["config"]["user"], "u");
+        assert_eq!(auth["config"]["pass"], "p");
+    }
+
+    #[test]
+    fn fully_current_config_needs_no_migration() {
+        let mut v = json!({
+            "version": 1,
+            "pipeline": {
+                "source": { "type": "rest", "config": { "url": "x",
+                    "auth": { "type": "bearer", "config": { "token": "t" } } } },
+                "sink": { "type": "jsonl", "config": { "path": "o.jsonl" } }
+            }
+        });
+        assert!(migrate_value(&mut v).is_empty());
+    }
+}

--- a/cli/src/commands/migrate.rs
+++ b/cli/src/commands/migrate.rs
@@ -357,4 +357,112 @@ mod tests {
         });
         assert!(migrate_value(&mut v).is_empty());
     }
+
+    // ── ConfigFormat + the `run` command flow ────────────────────────────────
+
+    #[test]
+    fn config_format_from_path() {
+        assert!(matches!(
+            ConfigFormat::from_path(Path::new("a.yaml")),
+            Ok(ConfigFormat::Yaml)
+        ));
+        assert!(matches!(
+            ConfigFormat::from_path(Path::new("a.yml")),
+            Ok(ConfigFormat::Yaml)
+        ));
+        assert!(matches!(
+            ConfigFormat::from_path(Path::new("a.json")),
+            Ok(ConfigFormat::Json)
+        ));
+        assert!(ConfigFormat::from_path(Path::new("a.toml")).is_err());
+    }
+
+    #[test]
+    fn config_format_parse_render_roundtrip() {
+        let p = Path::new("f.yaml");
+        let v = ConfigFormat::Yaml
+            .parse("version: 1\nname: demo\n", p)
+            .unwrap();
+        assert_eq!(v["name"], "demo");
+        let s = ConfigFormat::Yaml.render(&v, p).unwrap();
+        assert!(s.contains("name: demo"));
+
+        let pj = Path::new("f.json");
+        let vj = ConfigFormat::Json.parse(r#"{"version":1}"#, pj).unwrap();
+        let sj = ConfigFormat::Json.render(&vj, pj).unwrap();
+        assert!(sj.ends_with('\n') && sj.contains("\"version\""));
+    }
+
+    const LEGACY_YAML: &str = "version: 1\n\
+source:\n  type: rest\n  config:\n    base_url: https://x\n    auth: { type: bearer, token: t }\n\
+sink:\n  type: jsonl\n  config: { path: out.jsonl }\n";
+
+    fn write_tmp(name: &str, body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).expect("write");
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn run_rewrites_legacy_file_in_place() {
+        let (_d, path) = write_tmp("old.yaml", LEGACY_YAML);
+        run(MigrateArgs {
+            config: Some(path.clone()),
+            check: false,
+            stdout: false,
+        })
+        .await
+        .unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains("pipeline:"), "{after}");
+        assert!(after.contains("config:"));
+        // Idempotent: a second migrate reports no change and leaves the file.
+        let before2 = std::fs::read_to_string(&path).unwrap();
+        run(MigrateArgs {
+            config: Some(path.clone()),
+            check: false,
+            stdout: false,
+        })
+        .await
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before2);
+    }
+
+    #[tokio::test]
+    async fn run_check_errors_on_legacy_and_passes_on_current() {
+        let (_d, legacy) = write_tmp("old.yaml", LEGACY_YAML);
+        let err = run(MigrateArgs {
+            config: Some(legacy),
+            check: true,
+            stdout: false,
+        })
+        .await;
+        assert!(err.is_err(), "--check must fail on a legacy config");
+
+        let current = "version: 1\npipeline:\n  source: { type: rest, config: { base_url: x } }\n  sink: { type: jsonl, config: { path: o } }\n";
+        let (_d2, cur) = write_tmp("cur.yaml", current);
+        run(MigrateArgs {
+            config: Some(cur),
+            check: true,
+            stdout: false,
+        })
+        .await
+        .expect("--check passes on a current config");
+    }
+
+    #[tokio::test]
+    async fn run_stdout_does_not_write_the_file() {
+        let (_d, path) = write_tmp("old.yaml", LEGACY_YAML);
+        let original = std::fs::read_to_string(&path).unwrap();
+        run(MigrateArgs {
+            config: Some(path.clone()),
+            check: false,
+            stdout: true,
+        })
+        .await
+        .unwrap();
+        // --stdout prints the migrated config but leaves the file untouched.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod install;
 pub mod list;
 #[cfg(feature = "masking")]
 pub mod masking;
+pub mod migrate;
 pub mod new;
 #[cfg(feature = "notify")]
 pub mod notify;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -181,6 +181,7 @@ pub async fn run_command(cli: Cli) -> CliResult<()> {
         #[cfg(feature = "catalog")]
         Command::Catalog(args) => commands::catalog::run(args).await,
         Command::Completions(args) => commands::completions::run(args.shell),
+        Command::Migrate(args) => commands::migrate::run(args).await,
     }
 }
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -23,6 +23,8 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet schedule [config]` | Run a pipeline on a cron schedule (long-running foreground process). |
 | `faucet serve` | Run a long-running HTTP control plane: submit / poll / cancel pipeline runs over REST. |
 | `faucet completions <shell>` | Print a shell tab-completion script (bash / zsh / fish / powershell / elvish). |
+| `faucet migrate [config]` | Upgrade a config written against an older grammar to the current shape (idempotent). |
+| `faucet doctor --offline [config]` | Static, credential-free config lints (no network) — dangling/unused auth, unused vars, no-op sink `batch_size`. |
 
 `[config]` is optional for `run` / `validate` / `preview` / `doctor` / `replicate` / `schedule`: if
 omitted, faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
@@ -783,3 +785,45 @@ With the dynamic hook enabled you get runtime-aware candidates:
 The config-aware providers are best-effort and read-only: they parse and expand
 the local config but never resolve secrets, hit the network, or open a
 connector, and fall back to no suggestions if no config is present.
+
+## `migrate`
+
+`faucet migrate [config]` upgrades a config written against an older `faucet`
+grammar to the current shape, in place. It is **idempotent** — running it on an
+already-current config changes nothing.
+
+```bash
+faucet migrate                 # migrate the discovered faucet.yaml
+faucet migrate old.yaml        # migrate a specific file (rewrites it)
+faucet migrate old.yaml --stdout   # print the migrated config, don't write
+faucet migrate --check         # exit non-zero if a migration is needed (CI)
+```
+
+Rules applied today:
+
+- **Top-level `source:` / `sink:` → `pipeline:`** — the pre-`pipeline` block
+  shape is wrapped into a `pipeline:` map (moving `transforms:` / `state:` too).
+- **Legacy auth → `{ type, config }`** — an `auth:` / `credentials:` block of
+  the old `{ type, <fields…> }` shape has its fields folded into a `config:`
+  sub-map, matching the current adjacently-tagged form.
+
+Each rule is a pure, unit-tested transform. Comments are not preserved (the
+config is parsed and re-serialized).
+
+## `doctor --offline`
+
+Beyond its connectivity probes, `faucet doctor` can run a **static, offline**
+config lint — no network, no credentials — ideal for CI:
+
+```bash
+faucet doctor --offline            # lint the discovered config
+faucet doctor --offline --json     # machine-readable findings
+```
+
+It flags: a connector `auth: { ref }` that points at a provider missing from the
+`auth:` catalog (**error**); an `auth:` provider nothing references (**warning**);
+a `vars:` entry never interpolated (**warning**); and a file/append sink
+(`jsonl`/`csv`/`stdout`) with `batch_size: 0`, which is a no-op (**warning**).
+The command exits non-zero on any lint *error* (warnings don't fail). Secret and
+`${env:…}` resolution is validated separately at config load (and by
+`faucet validate`).


### PR DESCRIPTION
Batches the self-contained **tier-2 CLI ergonomics** issues. Closes #388 and #392.

## `faucet migrate` (#388)
Upgrade a config written against an older grammar to the current shape — in place, idempotent.

- **Rule 1**: top-level `source:`/`sink:` (+ `transforms:`/`state:`) → wrapped in a `pipeline:` block (pre-#54).
- **Rule 2**: legacy `auth`/`credentials` `{ type, <fields…> }` → `{ type, config: { <fields…> } }` (pre-#113), recursively, only under `auth`/`credentials` keys carrying a `type` and no `config` (never touches an already-migrated block or an unrelated object with a `type` field).
- Modes: default rewrites in place; `--check` exits non-zero if a migration is needed (CI); `--stdout` previews. Each rule is a pure, unit-tested `Value → Value` transform; running twice is a no-op.

```bash
faucet migrate old.yaml --stdout   # preview the upgrade
faucet migrate --check             # CI gate
```

## `faucet doctor --offline` (#392)
A static, credential-free config linter (no network, no connectors built) — ideal for CI. Default `doctor` behavior is unchanged; lints are gated behind `--offline`.

| Lint | Severity |
|---|---|
| connector `auth: { ref: X }` where `X` isn't in the `auth:` catalog | **error** |
| `auth:` provider nothing references | warning |
| `vars:` entry never interpolated (`${vars.K}`) | warning |
| file/append sink (`jsonl`/`csv`/`stdout`) with `batch_size: 0` (no-op) | warning |

Exits non-zero on any lint **error**; warnings don't fail. `--json` for machine output. Secret/`${env:}` resolution is validated at config load and by `faucet validate`, so it's covered elsewhere.

## Scope notes
- **#386** (`run --limit`/`--dry-run`) was **already implemented** on `main` (no-op `CountingSink` for dry-run, truncating `LimitedSink` for limit, `ReadOnlyStateStore` so no bookmark advances) — closed as done.
- **#385** (live progress on `run`) is **deferred to its own PR**: a correct implementation reuses the `--tui` Prometheus-metrics sampling and is materially larger/riskier than these two — kept out to keep this batch clean through CI.

## Testing
- `migrate`: 7 unit tests (both rules, idempotency, non-auth `type` objects left alone, composition, already-current). Verified functionally on a legacy config.
- `doctor --offline`: unit tests for each lint + the error/warning exit-code split. Verified functionally (dangling ref → exit 1).
- `cargo clippy -p faucet-cli --all-targets` clean; `cargo fmt --check` clean. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)