### PR TITLE
feat(cli): tier-3 commands — fmt, explain, history, run --output json (#387,#389,#390,#391)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -45,6 +45,10 @@ cargo install faucet-cli --no-default-features \
 | `faucet completions <bash\|zsh\|fish\|powershell\|elvish>` | Print a shell tab-completion script. For registry- and config-aware **dynamic** completion, enable the `COMPLETE` hook instead (see [`faucet completions`](#faucet-completions)). |
 | `faucet migrate [config] [--check\|--stdout]` | Upgrade an old-grammar config to the current shape in place (idempotent): wraps top-level `source:`/`sink:` into `pipeline:`, folds legacy `auth`/`credentials` into `{ type, config }`. `--check` exits non-zero if a migration is needed (CI); `--stdout` previews without writing. |
 | `faucet doctor --offline [config]` | Static, credential-free config lints (no network): dangling / unreferenced `auth:` providers, unused `vars:`, no-op sink `batch_size: 0`. Exits non-zero on any lint error. |
+| `faucet fmt [config] [--check\|--stdout]` | Canonicalize a config in place (stable key order); idempotent. `--check` is a CI gate (non-zero if not canonical); `--stdout` previews. Comments are not preserved. |
+| `faucet explain [config] [--json\|--rows]` | Plain-English narration of a pipeline (source → transforms → sink, matrix, delivery). Fully offline; never prints secrets. |
+| `faucet history [config] [--limit N\|--row R\|--json]` | Terminal view of the run history in the config's `catalog:` store (status/duration/throughput), newest first. Read-only; requires the `catalog` feature. |
+| `faucet run … --output <text\|json\|ndjson>` | End-of-run summary format. `json`/`ndjson` emit a machine-readable per-row + totals summary (clean stdout, logs on stderr) for CI/cron/Slack. |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -147,6 +147,19 @@ pub enum Command {
     /// shape (e.g. pre-`pipeline:` top-level source/sink, legacy inline auth).
     /// Idempotent; rewrites in place unless `--check` / `--stdout`.
     Migrate(MigrateArgs),
+    /// Canonicalize a config: stable key order, normalized style. Idempotent;
+    /// rewrites in place unless `--check` / `--stdout`. Comments are not
+    /// preserved (the config is parsed and re-serialized).
+    Fmt(FmtArgs),
+    /// Explain, in plain English, what a pipeline config does — source →
+    /// transforms → sink, matrix expansion, replication, delivery guarantee,
+    /// and state store. Read-only and fully offline (no source is touched).
+    Explain(ExplainArgs),
+    /// Show recent run history recorded in a config's `catalog:` store —
+    /// status, duration, throughput, and bookmark. Read-only; requires the
+    /// `catalog` build feature.
+    #[cfg(feature = "catalog")]
+    History(HistoryArgs),
 }
 
 /// `faucet migrate` arguments.
@@ -163,6 +176,71 @@ pub struct MigrateArgs {
     /// Write the migrated config to stdout instead of rewriting the file.
     #[arg(long, conflicts_with = "check")]
     pub stdout: bool,
+}
+
+/// `faucet fmt` arguments.
+#[derive(Debug, Args)]
+pub struct FmtArgs {
+    /// Config file(s) to format. Auto-discovered (`faucet.yaml` → `.yml` →
+    /// `.json`) when none are given.
+    #[arg(value_hint = clap::ValueHint::FilePath)]
+    pub configs: Vec<PathBuf>,
+    /// Report whether each file is already canonical without writing (exits
+    /// non-zero and prints a unified diff for any file that is not). For CI.
+    #[arg(long)]
+    pub check: bool,
+    /// Write the formatted result to stdout instead of rewriting the file(s).
+    #[arg(long, conflicts_with = "check")]
+    pub stdout: bool,
+}
+
+/// `faucet explain` arguments.
+#[derive(Debug, Args)]
+pub struct ExplainArgs {
+    /// Path to a `.yaml`/`.yml`/`.json` config (auto-discovered if omitted).
+    pub config: Option<PathBuf>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation.
+    /// Defaults to `.env` in cwd if present.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Select a named overlay from the config's `profiles:` block.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
+    /// Emit the narration as structured JSON instead of prose.
+    #[arg(long)]
+    pub json: bool,
+    /// Narrate every matrix row instead of summarizing a large matrix.
+    #[arg(long)]
+    pub rows: bool,
+}
+
+/// `faucet history` arguments.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Args)]
+pub struct HistoryArgs {
+    /// Path to a config carrying a `catalog:` block (auto-discovered if omitted).
+    pub config: Option<PathBuf>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Select a named overlay from the config's `profiles:` block.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
+    /// Maximum number of runs to show, newest first.
+    #[arg(long, default_value_t = 20)]
+    pub limit: usize,
+    /// Show only runs that contain an invocation for this matrix row id.
+    #[arg(long)]
+    pub row: Option<String>,
+    /// Emit the history as JSON instead of a table.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// `faucet completions` arguments.
@@ -694,10 +772,29 @@ pub struct RunArgs {
     #[arg(long)]
     pub tui: bool,
 
+    /// Format for the end-of-run summary printed to stdout: `text` (default,
+    /// human), `json` (a single machine-readable document), or `ndjson` (one
+    /// JSON object per matrix row). With `json`/`ndjson`, stdout carries only
+    /// the summary — logs stay on stderr — so `faucet run` is scriptable.
+    #[arg(long, value_enum, default_value_t = RunOutput::Text)]
+    pub output: RunOutput,
+
     /// Runtime matrix-row selection (`--select`/`--only`/`--skip`/`--status`/
     /// `--tag`/`--include-parents`).
     #[command(flatten)]
     pub selection: SelectionArgs,
+}
+
+/// Format for `faucet run`'s end-of-run summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum RunOutput {
+    /// Human-readable one-line summary (default).
+    #[default]
+    Text,
+    /// A single machine-readable JSON document with per-row + total stats.
+    Json,
+    /// One JSON object per matrix row (newline-delimited) for streaming consumers.
+    Ndjson,
 }
 
 /// `faucet backfill` arguments.

--- a/cli/src/commands/explain.rs
+++ b/cli/src/commands/explain.rs
@@ -1,0 +1,446 @@
+//! `faucet explain` — plain-English narration of what a pipeline does (#389).
+//!
+//! Where `faucet plan` is structured and machine-oriented, `explain` reads like
+//! prose: "Reads `orders` from S3 → applies `flatten`, `rename_keys` → writes to
+//! BigQuery with upsert on `id`. Expands to 4 matrix rows; delivery:
+//! effectively-once." It is built entirely from the already-resolved
+//! [`ExpandedNode`]s — **fully offline, zero I/O, no source is touched.**
+//!
+//! Secrets are never printed: connectors are described by their kind plus a
+//! curated allowlist of structural, non-secret fields (table, path, topic, …).
+//! `url` / `connection_url` / `auth` and friends are deliberately excluded, and
+//! the rendered output is run through the secret scrubber as a backstop.
+
+use crate::cli::ExplainArgs;
+use crate::config::PipelineConfig;
+use crate::error::{CliError, CliResult};
+use crate::expand::{ExpandedNode, NodeRole, expand};
+use serde::Serialize;
+use serde_json::Value;
+
+/// Structural connector fields that are safe to surface in a narration — never
+/// credentials or endpoints that can embed them. `url` / `base_url` /
+/// `connection_url` are intentionally absent (they routinely carry `user:pass@`).
+const SAFE_DESCRIPTOR_KEYS: &[&str] = &[
+    "table_name",
+    "table",
+    "path",
+    "topic",
+    "topics",
+    "index",
+    "bucket",
+    "prefix",
+    "database",
+    "collection",
+    "dataset",
+    "stream",
+    "key_pattern",
+    "pattern",
+    "query",
+];
+
+/// Config keys that mark a source as doing incremental (bookmark-based) reads.
+const INCREMENTAL_KEYS: &[&str] = &[
+    "replication",
+    "incremental",
+    "cursor_field",
+    "replication_key",
+    "start_replication_value",
+    "bookmark_key",
+];
+
+/// Above this many matrix rows, prose output summarizes with counts instead of
+/// narrating every row (override with `--rows`).
+const SUMMARIZE_THRESHOLD: usize = 8;
+
+/// Execute the `explain` subcommand.
+pub async fn run(args: ExplainArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+
+    let path = match args.config {
+        Some(p) => p,
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+
+    // Offline: tolerate (do not fetch) secret-manager directives — `explain`
+    // never touches the network. `${env:…}` is resolved at load time, so the
+    // narration only ever surfaces the safe allowlist below, never raw config.
+    let cfg = PipelineConfig::from_path_tolerating_secrets(&path, args.profile.as_deref())?;
+    let nodes = expand(&cfg)?;
+    let report = build_report(&cfg, &nodes);
+
+    if args.json {
+        let json = serde_json::to_string_pretty(&report)
+            .map_err(|e| CliError::Config(format!("cannot serialize explanation: {e}")))?;
+        println!("{}", crate::secrets::registry::redact(&json));
+    } else {
+        let prose = render_prose(&report, args.rows);
+        print!("{}", crate::secrets::registry::redact(&prose));
+    }
+    Ok(())
+}
+
+/// A machine-readable explanation (`--json`) and the source for the prose.
+#[derive(Debug, Serialize)]
+pub(crate) struct Explanation {
+    pub pipeline: String,
+    pub rows_total: usize,
+    pub roots: usize,
+    pub children: usize,
+    pub incremental_rows: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replication: Option<String>,
+    pub rows: Vec<RowExplanation>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RowExplanation {
+    pub id: String,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    pub source: String,
+    pub transforms: Vec<String>,
+    pub sink: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub write_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    pub delivery_guarantee: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    pub incremental: bool,
+}
+
+/// Build the full explanation from the resolved config + expanded nodes.
+pub(crate) fn build_report(cfg: &PipelineConfig, nodes: &[ExpandedNode]) -> Explanation {
+    let roots = nodes
+        .iter()
+        .filter(|n| matches!(n.role, NodeRole::Root))
+        .count();
+    let rows: Vec<RowExplanation> = nodes.iter().map(row_explanation).collect();
+    let incremental_rows = rows.iter().filter(|r| r.incremental).count();
+    Explanation {
+        pipeline: cfg.name.clone().unwrap_or_else(|| "(unnamed)".to_string()),
+        rows_total: nodes.len(),
+        roots,
+        children: nodes.len() - roots,
+        incremental_rows,
+        replication: cfg
+            .replication
+            .as_ref()
+            .map(|r| format!("{:?}", r.mode).to_lowercase()),
+        rows,
+    }
+}
+
+fn row_explanation(node: &ExpandedNode) -> RowExplanation {
+    let (role, parent) = match &node.role {
+        NodeRole::Root => ("root".to_string(), None),
+        NodeRole::Child { parent_id, .. } => ("child".to_string(), Some(parent_id.clone())),
+    };
+    RowExplanation {
+        id: node.id.clone(),
+        role,
+        parent,
+        source: describe_connector(&node.source.kind, &node.source.config),
+        transforms: node.transforms.iter().map(|t| t.kind.clone()).collect(),
+        sink: describe_connector(&node.sink.kind, &node.sink.config),
+        write_mode: string_field(&node.sink.config, "write_mode"),
+        key: key_field(&node.sink.config),
+        delivery_guarantee: node.delivery_guarantee.to_string(),
+        state: node.state.as_ref().map(|s| s.kind.clone()),
+        incremental: INCREMENTAL_KEYS
+            .iter()
+            .any(|k| node.source.config.get(*k).is_some()),
+    }
+}
+
+/// `kind (field=value, …)` using only the safe descriptor allowlist. Falls back
+/// to bare `kind` when no allowlisted field is present.
+fn describe_connector(kind: &str, config: &Value) -> String {
+    let Some(obj) = config.as_object() else {
+        return kind.to_string();
+    };
+    let mut parts = Vec::new();
+    for k in SAFE_DESCRIPTOR_KEYS {
+        if let Some(v) = obj.get(*k) {
+            parts.push(format!("{k}={}", scalar_str(v)));
+            if parts.len() == 2 {
+                break; // two identifying fields is plenty for a narration
+            }
+        }
+    }
+    if parts.is_empty() {
+        kind.to_string()
+    } else {
+        format!("{kind} ({})", parts.join(", "))
+    }
+}
+
+/// A compact, non-secret rendering of a scalar (or a shape hint for containers).
+fn scalar_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Array(a) => format!("[{} item(s)]", a.len()),
+        Value::Object(_) => "{…}".to_string(),
+        Value::Null => "null".to_string(),
+    }
+}
+
+fn string_field(config: &Value, key: &str) -> Option<String> {
+    config
+        .get(key)
+        .and_then(Value::as_str)
+        .map(|s| s.to_string())
+}
+
+/// Render a `key` field that may be a string or an array of column names.
+fn key_field(config: &Value) -> Option<String> {
+    match config.get("key") {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(Value::Array(a)) => {
+            let cols: Vec<String> = a
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|s| s.to_string())
+                .collect();
+            (!cols.is_empty()).then(|| cols.join(", "))
+        }
+        _ => None,
+    }
+}
+
+/// Render the explanation as prose. Large matrices are summarized unless
+/// `show_all` (`--rows`) is set.
+pub(crate) fn render_prose(r: &Explanation, show_all: bool) -> String {
+    let mut out = String::new();
+    if r.rows_total == 0 {
+        out.push_str(&format!(
+            "Pipeline '{}' has no runnable rows.\n",
+            r.pipeline
+        ));
+        return out;
+    }
+
+    // Intro line: expansion shape.
+    if r.rows_total == 1 {
+        out.push_str(&format!("Pipeline '{}' is a single pipeline.\n", r.pipeline));
+    } else {
+        out.push_str(&format!(
+            "Pipeline '{}' expands to {} rows ({} root{}, {} child{}).",
+            r.pipeline,
+            r.rows_total,
+            r.roots,
+            if r.roots == 1 { "" } else { "s" },
+            r.children,
+            if r.children == 1 { "" } else { "ren" },
+        ));
+        if r.incremental_rows > 0 {
+            out.push_str(&format!(
+                " {} row{} incremental.",
+                r.incremental_rows,
+                if r.incremental_rows == 1 {
+                    " is"
+                } else {
+                    "s are"
+                }
+            ));
+        }
+        out.push('\n');
+    }
+    if let Some(mode) = &r.replication {
+        out.push_str(&format!("Replication mode: {mode}.\n"));
+    }
+    out.push('\n');
+
+    let summarize = !show_all && r.rows_total > SUMMARIZE_THRESHOLD;
+    let shown = if summarize {
+        SUMMARIZE_THRESHOLD
+    } else {
+        r.rows.len()
+    };
+    for row in r.rows.iter().take(shown) {
+        out.push_str(&narrate_row(row));
+    }
+    if summarize {
+        out.push_str(&format!(
+            "… and {} more row(s). Pass --rows to narrate every row.\n",
+            r.rows_total - shown
+        ));
+    }
+    out
+}
+
+fn narrate_row(row: &RowExplanation) -> String {
+    let lineage = if row.transforms.is_empty() {
+        " → ".to_string()
+    } else {
+        format!(" → applies {} → ", row.transforms.join(", "))
+    };
+    let parent = match &row.parent {
+        Some(p) => format!(" (per record from '{p}')"),
+        None => String::new(),
+    };
+    let write = match (&row.write_mode, &row.key) {
+        (Some(mode), Some(key)) => format!(" [{mode} on {key}]"),
+        (Some(mode), None) => format!(" [{mode}]"),
+        _ => String::new(),
+    };
+    let state = match &row.state {
+        Some(s) => format!(", state: {s}"),
+        None => String::new(),
+    };
+    format!(
+        "• {}{}: reads from {}{}writes to {}{}. delivery: {}{}.\n",
+        row.id,
+        parent,
+        row.source,
+        lineage,
+        row.sink,
+        write,
+        row.delivery_guarantee,
+        state,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::parse_with_extension;
+
+    fn explain_yaml(yaml: &str) -> Explanation {
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        build_report(&cfg, &nodes)
+    }
+
+    #[test]
+    fn describe_connector_uses_only_safe_fields() {
+        let cfg = serde_json::json!({
+            "table_name": "orders",
+            "connection_url": "postgres://user:secret@host/db",
+            "auth": { "token": "hunter2" }
+        });
+        let d = describe_connector("postgres", &cfg);
+        assert!(d.contains("table_name=orders"), "{d}");
+        assert!(!d.contains("secret"), "must not leak connection_url: {d}");
+        assert!(!d.contains("hunter2"), "must not leak auth: {d}");
+    }
+
+    #[test]
+    fn single_pipeline_prose_names_source_and_sink() {
+        let r = explain_yaml(
+            r#"
+version: 1
+name: demo
+pipeline:
+  source: { type: rest, config: { path: /events } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+  transforms:
+    - { type: flatten }
+"#,
+        );
+        assert_eq!(r.rows_total, 1);
+        let prose = render_prose(&r, false);
+        assert!(prose.contains("reads from rest"), "{prose}");
+        assert!(prose.contains("applies flatten"), "{prose}");
+        assert!(prose.contains("writes to jsonl"), "{prose}");
+        assert!(prose.contains("delivery:"), "{prose}");
+    }
+
+    #[test]
+    fn matrix_expansion_and_upsert_are_reported() {
+        let r = explain_yaml(
+            r#"
+version: 1
+name: fan
+pipeline:
+  source: { type: rest, config: {} }
+  sink:
+    type: postgres
+    config:
+      connection_url: "postgres://localhost/db"
+      table_name: t
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+matrix:
+  - id: us
+  - id: eu
+"#,
+        );
+        assert_eq!(r.rows_total, 2);
+        assert_eq!(r.roots, 2);
+        let row = &r.rows[0];
+        assert_eq!(row.write_mode.as_deref(), Some("upsert"));
+        assert_eq!(row.key.as_deref(), Some("id"));
+        assert!(row.delivery_guarantee.contains("effectively-once"));
+        let prose = render_prose(&r, false);
+        assert!(prose.contains("expands to 2 rows"), "{prose}");
+        assert!(prose.contains("[upsert on id]"), "{prose}");
+    }
+
+    #[test]
+    fn parent_child_matrix_describes_fan_out() {
+        let r = explain_yaml(
+            r#"
+version: 1
+name: pc
+pipeline:
+  source: { type: rest, config: {} }
+  sink: { type: jsonl, config: { path: o } }
+matrix:
+  - id: dims
+  - id: facts
+    parent: dims
+    parent_key: id
+"#,
+        );
+        assert_eq!(r.roots, 1);
+        assert_eq!(r.children, 1);
+        let child = r.rows.iter().find(|x| x.id == "facts").unwrap();
+        assert_eq!(child.parent.as_deref(), Some("dims"));
+        let prose = render_prose(&r, true);
+        assert!(prose.contains("per record from 'dims'"), "{prose}");
+    }
+
+    #[test]
+    fn large_matrix_summarizes_without_rows_flag() {
+        let mut yaml = String::from(
+            "version: 1\nname: big\npipeline:\n  source: { type: rest, config: {} }\n  sink: { type: jsonl, config: { path: o } }\nmatrix:\n",
+        );
+        for i in 0..20 {
+            yaml.push_str(&format!("  - id: r{i}\n"));
+        }
+        let r = explain_yaml(&yaml);
+        let summarized = render_prose(&r, false);
+        assert!(summarized.contains("and 12 more row(s)"), "{summarized}");
+        let full = render_prose(&r, true);
+        assert!(!full.contains("more row(s)"), "--rows narrates all");
+    }
+
+    #[test]
+    fn json_output_is_serializable_and_deterministic() {
+        let r = explain_yaml(
+            r#"
+version: 1
+name: j
+pipeline:
+  source: { type: rest, config: { path: /x } }
+  sink: { type: jsonl, config: { path: o } }
+"#,
+        );
+        let a = serde_json::to_string(&r).unwrap();
+        let b = serde_json::to_string(&explain_yaml(
+            "version: 1\nname: j\npipeline:\n  source: { type: rest, config: { path: /x } }\n  sink: { type: jsonl, config: { path: o } }\n",
+        ))
+        .unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/cli/src/commands/explain.rs
+++ b/cli/src/commands/explain.rs
@@ -230,7 +230,10 @@ pub(crate) fn render_prose(r: &Explanation, show_all: bool) -> String {
 
     // Intro line: expansion shape.
     if r.rows_total == 1 {
-        out.push_str(&format!("Pipeline '{}' is a single pipeline.\n", r.pipeline));
+        out.push_str(&format!(
+            "Pipeline '{}' is a single pipeline.\n",
+            r.pipeline
+        ));
     } else {
         out.push_str(&format!(
             "Pipeline '{}' expands to {} rows ({} root{}, {} child{}).",
@@ -298,14 +301,7 @@ fn narrate_row(row: &RowExplanation) -> String {
     };
     format!(
         "• {}{}: reads from {}{}writes to {}{}. delivery: {}{}.\n",
-        row.id,
-        parent,
-        row.source,
-        lineage,
-        row.sink,
-        write,
-        row.delivery_guarantee,
-        state,
+        row.id, parent, row.source, lineage, row.sink, write, row.delivery_guarantee, state,
     )
 }
 
@@ -442,5 +438,47 @@ pipeline:
         ))
         .unwrap();
         assert_eq!(a, b);
+    }
+
+    // ── `run` command flow (offline; tempfile) ───────────────────────────────
+
+    fn write_cfg(body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("faucet.yaml");
+        std::fs::write(&path, body).expect("write");
+        (dir, path)
+    }
+
+    fn args(path: std::path::PathBuf, json: bool, rows: bool) -> ExplainArgs {
+        ExplainArgs {
+            config: Some(path),
+            env_file: None,
+            no_env_file: true,
+            profile: None,
+            json,
+            rows,
+        }
+    }
+
+    const CFG: &str = "version: 1\nname: demo\npipeline:\n  source: { type: rest, config: { path: /x } }\n  sink: { type: jsonl, config: { path: o } }\n";
+
+    #[tokio::test]
+    async fn run_prose_succeeds() {
+        let (_d, path) = write_cfg(CFG);
+        run(args(path, false, false)).await.expect("prose ok");
+    }
+
+    #[tokio::test]
+    async fn run_json_succeeds() {
+        let (_d, path) = write_cfg(CFG);
+        run(args(path, true, false)).await.expect("json ok");
+    }
+
+    #[tokio::test]
+    async fn run_prose_all_rows_on_a_matrix() {
+        // A matrix config exercises the `--rows` (narrate every row) path.
+        let cfg = "version: 1\nname: m\nmatrix:\n  - { id: a }\n  - { id: b }\npipeline:\n  source: { type: rest, config: { path: /x } }\n  sink: { type: jsonl, config: { path: o } }\n";
+        let (_d, path) = write_cfg(cfg);
+        run(args(path, false, true)).await.expect("matrix prose ok");
     }
 }

--- a/cli/src/commands/fmt.rs
+++ b/cli/src/commands/fmt.rs
@@ -61,9 +61,8 @@ pub async fn run(args: FmtArgs) -> CliResult<()> {
         if formatted == text {
             println!("{}: already formatted", path.display());
         } else {
-            std::fs::write(path, &formatted).map_err(|e| {
-                CliError::Config(format!("cannot write '{}': {e}", path.display()))
-            })?;
+            std::fs::write(path, &formatted)
+                .map_err(|e| CliError::Config(format!("cannot write '{}': {e}", path.display())))?;
             println!("{}: formatted", path.display());
         }
     }
@@ -182,9 +181,7 @@ pub fn canonicalize(value: Value) -> Value {
         Value::Object(map) => {
             let mut entries: Vec<(String, Value)> =
                 map.into_iter().map(|(k, v)| (k, canonicalize(v))).collect();
-            entries.sort_by(|(a, _), (b, _)| {
-                key_rank(a).cmp(&key_rank(b)).then_with(|| a.cmp(b))
-            });
+            entries.sort_by(|(a, _), (b, _)| key_rank(a).cmp(&key_rank(b)).then_with(|| a.cmp(b)));
             Value::Object(entries.into_iter().collect::<Map<String, Value>>())
         }
         Value::Array(items) => Value::Array(items.into_iter().map(canonicalize).collect()),
@@ -306,7 +303,10 @@ mod tests {
     fn render_yaml_is_byte_stable_across_two_passes() {
         let p = Path::new("f.yaml");
         let v = ConfigFormat::Yaml
-            .parse("pipeline:\n  sink: {}\n  source: {}\nname: d\nversion: 1\n", p)
+            .parse(
+                "pipeline:\n  sink: {}\n  source: {}\nname: d\nversion: 1\n",
+                p,
+            )
             .unwrap();
         let once = ConfigFormat::Yaml.render(&canonicalize(v), p).unwrap();
         let reparsed = ConfigFormat::Yaml.parse(&once, p).unwrap();
@@ -332,8 +332,7 @@ mod tests {
         (dir, path)
     }
 
-    const UNSORTED: &str =
-        "name: demo\nversion: 1\npipeline:\n  sink: { type: jsonl, config: { path: o } }\n  source: { type: rest, config: {} }\n";
+    const UNSORTED: &str = "name: demo\nversion: 1\npipeline:\n  sink: { type: jsonl, config: { path: o } }\n  source: { type: rest, config: {} }\n";
 
     #[tokio::test]
     async fn run_rewrites_file_in_place_and_is_idempotent() {

--- a/cli/src/commands/fmt.rs
+++ b/cli/src/commands/fmt.rs
@@ -1,0 +1,403 @@
+//! `faucet fmt` — canonicalize a pipeline config (#387).
+//!
+//! A deterministic, idempotent config formatter — the config analogue of
+//! `cargo fmt` / `terraform fmt`. It parses the file, rewrites every object with
+//! a stable key order (a curated priority order for the well-known blocks, then
+//! alphabetical for everything else), and re-serializes it. Running `fmt` twice
+//! is always a no-op, so `--check` is a cheap CI gate for "is this config
+//! normalized?".
+//!
+//! Canonicalization is a **pure** `serde_json::Value → serde_json::Value`
+//! transform ([`canonicalize`]); the command layer only reads/writes files and
+//! renders the `--check` diff.
+//!
+//! **Scope:** `fmt` formats the *literal* file — it does not resolve
+//! `${env:…}` / `${file:…}` interpolation, apply `!include` / `extends`
+//! composition, or drop schema defaults. Use `faucet validate --show-composed`
+//! to see the composed result.
+//!
+//! **Comments are not preserved** — the config is parsed and re-serialized, the
+//! same limitation `faucet migrate` documents.
+
+use crate::cli::FmtArgs;
+use crate::error::{CliError, CliResult};
+use serde_json::{Map, Value};
+use std::path::{Path, PathBuf};
+
+/// Execute the `fmt` subcommand.
+pub async fn run(args: FmtArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let paths: Vec<PathBuf> = if args.configs.is_empty() {
+        vec![
+            crate::env_loader::discover_config_path(&cwd)
+                .ok_or_else(|| CliError::Config("no config file found to format".into()))?,
+        ]
+    } else {
+        args.configs.clone()
+    };
+
+    let mut not_canonical = 0usize;
+    for path in &paths {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| CliError::Config(format!("cannot read '{}': {e}", path.display())))?;
+        let format = ConfigFormat::from_path(path)?;
+        let value = format.parse(&text, path)?;
+        let formatted = format.render(&canonicalize(value), path)?;
+
+        if args.check {
+            if formatted != text {
+                not_canonical += 1;
+                eprintln!("{}: not canonical", path.display());
+                eprint!("{}", unified_diff(&text, &formatted));
+            }
+            continue;
+        }
+
+        if args.stdout {
+            print!("{formatted}");
+            continue;
+        }
+
+        if formatted == text {
+            println!("{}: already formatted", path.display());
+        } else {
+            std::fs::write(path, &formatted).map_err(|e| {
+                CliError::Config(format!("cannot write '{}': {e}", path.display()))
+            })?;
+            println!("{}: formatted", path.display());
+        }
+    }
+
+    if not_canonical > 0 {
+        return Err(CliError::Config(format!(
+            "{not_canonical} file{} not canonical; run `faucet fmt` to format",
+            if not_canonical == 1 { "" } else { "s" }
+        )));
+    }
+    Ok(())
+}
+
+/// The on-disk serialization of a config file.
+#[derive(Clone, Copy)]
+enum ConfigFormat {
+    Yaml,
+    Json,
+}
+
+impl ConfigFormat {
+    fn from_path(path: &Path) -> CliResult<Self> {
+        match path.extension().and_then(|e| e.to_str()) {
+            Some("yaml") | Some("yml") => Ok(ConfigFormat::Yaml),
+            Some("json") => Ok(ConfigFormat::Json),
+            _ => Err(CliError::Config(format!(
+                "unsupported config extension for '{}' (expected .yaml/.yml/.json)",
+                path.display()
+            ))),
+        }
+    }
+
+    fn parse(self, text: &str, path: &Path) -> CliResult<Value> {
+        let err = |e: String| CliError::Config(format!("cannot parse '{}': {e}", path.display()));
+        match self {
+            ConfigFormat::Yaml => serde_yaml::from_str(text).map_err(|e| err(e.to_string())),
+            ConfigFormat::Json => serde_json::from_str(text).map_err(|e| err(e.to_string())),
+        }
+    }
+
+    fn render(self, value: &Value, path: &Path) -> CliResult<String> {
+        let err =
+            |e: String| CliError::Config(format!("cannot serialize '{}': {e}", path.display()));
+        match self {
+            ConfigFormat::Yaml => serde_yaml::to_string(value).map_err(|e| err(e.to_string())),
+            ConfigFormat::Json => {
+                let mut s = serde_json::to_string_pretty(value).map_err(|e| err(e.to_string()))?;
+                s.push('\n');
+                Ok(s)
+            }
+        }
+    }
+}
+
+/// The canonical key order for the well-known config blocks. Keys appear in this
+/// order at the front of their object; every other key follows alphabetically.
+/// A single flat list works because these names are unambiguous across the nesting
+/// levels they appear at (there is no top-level `type`, no connector-level
+/// `version`, etc.).
+const KEY_ORDER: &[&str] = &[
+    // ── top level ────────────────────────────────────────────────────────────
+    "version",
+    "name",
+    "vars",
+    "auth",
+    "pipeline",
+    "matrix",
+    "execution",
+    "selection",
+    // ── pipeline children ──────────────────────────────────────────────────────
+    "sources",
+    "source",
+    "sinks",
+    "sink",
+    "transforms",
+    "state",
+    // ── connector / matrix-row block children ──────────────────────────────────
+    "id",
+    "parent",
+    "parent_key",
+    "depends_on",
+    "type",
+    "ref",
+    "status",
+    "tags",
+    "inherit_transforms",
+    "config",
+    // ── remaining top-level blocks (kept deterministic, after the canonical set) ─
+    "delivery",
+    "resilience",
+    "sla",
+    "backfill",
+    "replication",
+    "schedule",
+    "notifications",
+    "lineage",
+    "catalog",
+    "profiles",
+];
+
+/// Rank of `key` in the canonical order, or `KEY_ORDER.len()` for any key not in
+/// the list (which then sorts alphabetically after the ranked keys).
+fn key_rank(key: &str) -> usize {
+    KEY_ORDER
+        .iter()
+        .position(|k| *k == key)
+        .unwrap_or(KEY_ORDER.len())
+}
+
+/// Rewrite `value` into canonical form: every object's keys are reordered by
+/// (canonical rank, then name), recursively. Pure and idempotent — running it on
+/// its own output is a no-op. Relies on `serde_json`'s `preserve_order` feature
+/// (enabled workspace-wide) so the rebuilt insertion order survives serialization.
+pub fn canonicalize(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> =
+                map.into_iter().map(|(k, v)| (k, canonicalize(v))).collect();
+            entries.sort_by(|(a, _), (b, _)| {
+                key_rank(a).cmp(&key_rank(b)).then_with(|| a.cmp(b))
+            });
+            Value::Object(entries.into_iter().collect::<Map<String, Value>>())
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(canonicalize).collect()),
+        scalar => scalar,
+    }
+}
+
+/// A minimal LCS-based unified-ish line diff, used only to show what `--check`
+/// would change. Lines present in both are context; removed lines are `-` and
+/// added lines are `+`. Not a git-grade diff, but deterministic and enough to
+/// point a reviewer at the reordering.
+fn unified_diff(old: &str, new: &str) -> String {
+    let a: Vec<&str> = old.lines().collect();
+    let b: Vec<&str> = new.lines().collect();
+    // LCS table.
+    let (n, m) = (a.len(), b.len());
+    let mut lcs = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            lcs[i][j] = if a[i] == b[j] {
+                lcs[i + 1][j + 1] + 1
+            } else {
+                lcs[i + 1][j].max(lcs[i][j + 1])
+            };
+        }
+    }
+    let mut out = String::new();
+    let (mut i, mut j) = (0, 0);
+    while i < n && j < m {
+        if a[i] == b[j] {
+            out.push_str(&format!("  {}\n", a[i]));
+            i += 1;
+            j += 1;
+        } else if lcs[i + 1][j] >= lcs[i][j + 1] {
+            out.push_str(&format!("- {}\n", a[i]));
+            i += 1;
+        } else {
+            out.push_str(&format!("+ {}\n", b[j]));
+            j += 1;
+        }
+    }
+    while i < n {
+        out.push_str(&format!("- {}\n", a[i]));
+        i += 1;
+    }
+    while j < m {
+        out.push_str(&format!("+ {}\n", b[j]));
+        j += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn reorders_top_level_keys_canonically() {
+        let v = json!({
+            "matrix": [],
+            "pipeline": { "sink": {}, "source": {} },
+            "name": "demo",
+            "version": 1,
+        });
+        let out = canonicalize(v);
+        let keys: Vec<&String> = out.as_object().unwrap().keys().collect();
+        assert_eq!(keys, ["version", "name", "pipeline", "matrix"]);
+        // Nested pipeline is reordered too: source before sink.
+        let pk: Vec<&String> = out["pipeline"].as_object().unwrap().keys().collect();
+        assert_eq!(pk, ["source", "sink"]);
+    }
+
+    #[test]
+    fn connector_block_puts_type_before_config_and_sorts_rest() {
+        let v = json!({
+            "source": { "config": { "url": "x", "auth": {} }, "type": "rest", "status": "active" }
+        });
+        let out = canonicalize(v);
+        let sk: Vec<&String> = out["source"].as_object().unwrap().keys().collect();
+        assert_eq!(sk, ["type", "status", "config"]);
+    }
+
+    #[test]
+    fn unknown_keys_sort_alphabetically_after_ranked_keys() {
+        let v = json!({ "config": { "zebra": 1, "alpha": 2, "mango": 3 } });
+        let out = canonicalize(v);
+        let ck: Vec<&String> = out["config"].as_object().unwrap().keys().collect();
+        assert_eq!(ck, ["alpha", "mango", "zebra"]);
+    }
+
+    #[test]
+    fn canonicalize_is_idempotent() {
+        let v = json!({
+            "version": 1,
+            "pipeline": { "sink": { "type": "jsonl", "config": { "b": 1, "a": 2 } },
+                          "source": { "config": {}, "type": "rest" } },
+            "name": "x",
+        });
+        let once = canonicalize(v);
+        let twice = canonicalize(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn config_format_from_path() {
+        assert!(matches!(
+            ConfigFormat::from_path(Path::new("a.yaml")),
+            Ok(ConfigFormat::Yaml)
+        ));
+        assert!(matches!(
+            ConfigFormat::from_path(Path::new("a.json")),
+            Ok(ConfigFormat::Json)
+        ));
+        assert!(ConfigFormat::from_path(Path::new("a.toml")).is_err());
+    }
+
+    #[test]
+    fn render_yaml_is_byte_stable_across_two_passes() {
+        let p = Path::new("f.yaml");
+        let v = ConfigFormat::Yaml
+            .parse("pipeline:\n  sink: {}\n  source: {}\nname: d\nversion: 1\n", p)
+            .unwrap();
+        let once = ConfigFormat::Yaml.render(&canonicalize(v), p).unwrap();
+        let reparsed = ConfigFormat::Yaml.parse(&once, p).unwrap();
+        let twice = ConfigFormat::Yaml
+            .render(&canonicalize(reparsed), p)
+            .unwrap();
+        assert_eq!(once, twice, "fmt must be idempotent at the byte level");
+        assert!(once.starts_with("version: 1"), "{once}");
+    }
+
+    #[test]
+    fn unified_diff_marks_added_and_removed_lines() {
+        let d = unified_diff("a\nb\nc\n", "a\nx\nc\n");
+        assert!(d.contains("- b"), "{d}");
+        assert!(d.contains("+ x"), "{d}");
+        assert!(d.contains("  a"), "{d}");
+    }
+
+    fn write_tmp(name: &str, body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).expect("write");
+        (dir, path)
+    }
+
+    const UNSORTED: &str =
+        "name: demo\nversion: 1\npipeline:\n  sink: { type: jsonl, config: { path: o } }\n  source: { type: rest, config: {} }\n";
+
+    #[tokio::test]
+    async fn run_rewrites_file_in_place_and_is_idempotent() {
+        let (_d, path) = write_tmp("f.yaml", UNSORTED);
+        run(FmtArgs {
+            configs: vec![path.clone()],
+            check: false,
+            stdout: false,
+        })
+        .await
+        .unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.starts_with("version: 1"), "{after}");
+        // Second pass leaves it byte-identical.
+        run(FmtArgs {
+            configs: vec![path.clone()],
+            check: false,
+            stdout: false,
+        })
+        .await
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), after);
+    }
+
+    #[tokio::test]
+    async fn run_check_fails_on_unsorted_passes_on_canonical() {
+        let (_d, path) = write_tmp("f.yaml", UNSORTED);
+        assert!(
+            run(FmtArgs {
+                configs: vec![path.clone()],
+                check: true,
+                stdout: false,
+            })
+            .await
+            .is_err(),
+            "--check must fail on a non-canonical file"
+        );
+        // Format it, then --check passes.
+        run(FmtArgs {
+            configs: vec![path.clone()],
+            check: false,
+            stdout: false,
+        })
+        .await
+        .unwrap();
+        run(FmtArgs {
+            configs: vec![path],
+            check: true,
+            stdout: false,
+        })
+        .await
+        .expect("--check passes on a canonical file");
+    }
+
+    #[tokio::test]
+    async fn run_stdout_leaves_file_untouched() {
+        let (_d, path) = write_tmp("f.yaml", UNSORTED);
+        run(FmtArgs {
+            configs: vec![path.clone()],
+            check: false,
+            stdout: true,
+        })
+        .await
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), UNSORTED);
+    }
+}

--- a/cli/src/commands/history.rs
+++ b/cli/src/commands/history.rs
@@ -39,11 +39,7 @@ pub async fn run(args: HistoryArgs) -> CliResult<()> {
         .await
         .map_err(|e| CliError::Internal(format!("catalog run-history read: {e}")))?;
 
-    let mut runs: Vec<RunRecord> = page.runs;
-    if let Some(row) = &args.row {
-        runs.retain(|r| r.invocations.iter().any(|i| &i.row_id == row));
-    }
-    runs.truncate(args.limit);
+    let runs = select_runs(page.runs, args.row.as_deref(), args.limit);
 
     if args.json {
         // The RunRecord's `Serialize` already omits secret-bearing fields
@@ -89,6 +85,21 @@ async fn connect(args: &HistoryArgs) -> CliResult<(CatalogHandle, Option<String>
     })?;
     let handle = crate::catalog::connect_from_spec(spec).await?;
     Ok((handle, cfg.name.clone()))
+}
+
+/// Apply the `--row` filter and `--limit` truncation to a fetched page
+/// (newest-first order preserved by the backend). Pure — unit-testable without
+/// a catalog store.
+pub(crate) fn select_runs(
+    mut runs: Vec<RunRecord>,
+    row: Option<&str>,
+    limit: usize,
+) -> Vec<RunRecord> {
+    if let Some(row) = row {
+        runs.retain(|r| r.invocations.iter().any(|i| i.row_id == row));
+    }
+    runs.truncate(limit);
+    runs
 }
 
 /// Render the run table (newest first). Pure so it is unit-testable.
@@ -199,9 +210,8 @@ mod tests {
     async fn reads_seeded_in_memory_catalog() {
         use crate::serve::history::RunHistory;
         // Seed a memory backend with two runs, then read them back via list().
-        let store = crate::serve::history::memory::MemoryHistory::new(
-            std::time::Duration::from_secs(3600),
-        );
+        let store =
+            crate::serve::history::memory::MemoryHistory::new(std::time::Duration::from_secs(3600));
         store
             .upsert(&record("a", RunStatus::Completed, 10, Some(1.0)))
             .await
@@ -221,5 +231,50 @@ mod tests {
         assert_eq!(page.runs.len(), 2);
         let t = render_table(&page.runs);
         assert!(t.contains("a") && t.contains("b"), "{t}");
+    }
+
+    #[test]
+    fn select_runs_filters_by_row_and_truncates() {
+        let mut a = record("a", RunStatus::Completed, 1, Some(1.0));
+        a.invocations[0].row_id = "us".into();
+        let mut b = record("b", RunStatus::Completed, 1, Some(1.0));
+        b.invocations[0].row_id = "eu".into();
+        let all = vec![a.clone(), b.clone()];
+
+        // --row keeps only matching invocations.
+        let only_eu = select_runs(all.clone(), Some("eu"), 20);
+        assert_eq!(only_eu.len(), 1);
+        assert_eq!(only_eu[0].run_id, "b");
+        // No filter, but --limit truncates.
+        let capped = select_runs(all.clone(), None, 1);
+        assert_eq!(capped.len(), 1);
+        // A row nobody has → empty.
+        assert!(select_runs(all, Some("apac"), 20).is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_errors_without_a_catalog_block() {
+        use crate::cli::HistoryArgs;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("faucet.yaml");
+        std::fs::write(
+            &path,
+            "version: 1\nname: demo\npipeline:\n  source: { type: rest, config: { path: /x } }\n  sink: { type: jsonl, config: { path: o } }\n",
+        )
+        .unwrap();
+        let err = super::run(HistoryArgs {
+            config: Some(path),
+            env_file: None,
+            no_env_file: true,
+            profile: None,
+            limit: 20,
+            row: None,
+            json: false,
+        })
+        .await;
+        match err {
+            Err(CliError::Config(m)) => assert!(m.contains("catalog"), "got: {m}"),
+            other => panic!("expected a no-catalog Config error, got {other:?}"),
+        }
     }
 }

--- a/cli/src/commands/history.rs
+++ b/cli/src/commands/history.rs
@@ -1,0 +1,225 @@
+//! `faucet history` — terminal view of the run history recorded in a config's
+//! `catalog:` store (#391).
+//!
+//! The catalog store (the same backend `faucet serve` history and `faucet plan
+//! --diff` use) records a [`RunRecord`] per run. This command reads the most
+//! recent N of them and prints a table — status, duration, throughput — without
+//! standing up `faucet serve`. Read-only; requires the `catalog` build feature.
+//!
+//! Run records are written by the control plane (`faucet serve`); a plain
+//! `faucet run` with a `catalog:` block records dataset observations (see
+//! `faucet catalog`) but not run records. Point `faucet history` at the same
+//! store your `serve` instance writes to, to see its runs here.
+
+use crate::catalog::CatalogHandle;
+use crate::cli::HistoryArgs;
+use crate::config::PipelineConfig;
+use crate::error::{CliError, CliResult};
+use crate::serve::history::{ListFilter, RunRecord};
+
+/// Execute the `history` subcommand.
+pub async fn run(args: HistoryArgs) -> CliResult<()> {
+    let (handle, pipeline_name) = connect(&args).await?;
+
+    // Over-fetch when filtering by row so the post-filter still returns a full
+    // page; otherwise fetch exactly the requested limit. Newest-first ordering
+    // is guaranteed by the backend.
+    let fetch = if args.row.is_some() {
+        args.limit.max(200)
+    } else {
+        args.limit.max(1)
+    };
+    let page = handle
+        .store
+        .list(&ListFilter {
+            name: pipeline_name,
+            limit: fetch,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| CliError::Internal(format!("catalog run-history read: {e}")))?;
+
+    let mut runs: Vec<RunRecord> = page.runs;
+    if let Some(row) = &args.row {
+        runs.retain(|r| r.invocations.iter().any(|i| &i.row_id == row));
+    }
+    runs.truncate(args.limit);
+
+    if args.json {
+        // The RunRecord's `Serialize` already omits secret-bearing fields
+        // (config bodies are only present for cluster runs); scrub as a backstop.
+        let json = serde_json::to_string_pretty(&runs)
+            .map_err(|e| CliError::Internal(format!("rendering history JSON: {e}")))?;
+        println!("{}", crate::secrets::registry::redact(&json));
+        return Ok(());
+    }
+
+    if runs.is_empty() {
+        println!(
+            "no runs recorded yet in this catalog store \
+             (run history is written by `faucet serve`)"
+        );
+        return Ok(());
+    }
+
+    print!("{}", render_table(&runs));
+    Ok(())
+}
+
+/// Load the config named by the flags and connect its `catalog:` store,
+/// returning the handle + the pipeline name to filter run records by.
+async fn connect(args: &HistoryArgs) -> CliResult<(CatalogHandle, Option<String>)> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+    let path = match &args.config {
+        Some(p) => p.clone(),
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+    let cfg = PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
+    let spec = cfg.catalog.as_ref().ok_or_else(|| {
+        CliError::Config(
+            "no `catalog:` block in this config — add one naming the store (e.g. \
+             `catalog: { url: sqlite:./faucet-catalog.db }`), or run \
+             `faucet schema catalog` for the block's JSON Schema. `faucet history` \
+             requires the `catalog` build feature."
+                .to_string(),
+        )
+    })?;
+    let handle = crate::catalog::connect_from_spec(spec).await?;
+    Ok((handle, cfg.name.clone()))
+}
+
+/// Render the run table (newest first). Pure so it is unit-testable.
+pub(crate) fn render_table(runs: &[RunRecord]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<20}  {:<10}  {:<19}  {:>10}  {:>12}  {:>10}  ROWS\n",
+        "RUN ID", "STATUS", "STARTED", "DURATION", "ROWS OUT", "ROWS/S"
+    ));
+    for r in runs {
+        let started = r
+            .started_at
+            .or(Some(r.submitted_at))
+            .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let duration = match r.elapsed_secs {
+            Some(s) => format!("{s:.1}s"),
+            None => "-".to_string(),
+        };
+        let rate = match r.elapsed_secs {
+            Some(s) if s > 0.0 => format!("{:.0}", r.records_written as f64 / s),
+            _ => "-".to_string(),
+        };
+        // Truncate long run ids (UUIDs) so the table stays aligned.
+        let id = if r.run_id.len() > 20 {
+            format!("{}…", &r.run_id[..19])
+        } else {
+            r.run_id.clone()
+        };
+        out.push_str(&format!(
+            "{:<20}  {:<10}  {:<19}  {:>10}  {:>12}  {:>10}  {}\n",
+            id,
+            r.status.as_str(),
+            started,
+            duration,
+            r.records_written,
+            rate,
+            r.invocations.len(),
+        ));
+        if let Some(err) = &r.error {
+            out.push_str(&format!("  └─ error: {err}\n"));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::history::{InvocationRecord, RunStatus};
+    use chrono::{TimeZone, Utc};
+
+    fn record(id: &str, status: RunStatus, rows: u64, elapsed: Option<f64>) -> RunRecord {
+        let t = Utc.with_ymd_and_hms(2026, 7, 1, 12, 0, 0).unwrap();
+        RunRecord {
+            run_id: id.into(),
+            name: Some("demo".into()),
+            labels: Default::default(),
+            status,
+            submitted_at: t,
+            started_at: Some(t),
+            finished_at: Some(t),
+            elapsed_secs: elapsed,
+            records_written: rows,
+            invocations: vec![InvocationRecord {
+                row_id: "us".into(),
+                parent_record_key: None,
+                records_written: rows as usize,
+                error: None,
+            }],
+            error: (status == RunStatus::Failed).then(|| "boom".to_string()),
+            idempotency_key: None,
+            doctor_report: None,
+            config_body: None,
+            config_format: None,
+            timeout_secs: None,
+            clock: None,
+            attempt: 0,
+            replay_of: None,
+        }
+    }
+
+    #[test]
+    fn table_lists_runs_with_status_and_throughput() {
+        let runs = vec![
+            record("run-1", RunStatus::Completed, 1000, Some(2.0)),
+            record("run-2", RunStatus::Failed, 0, Some(0.5)),
+        ];
+        let t = render_table(&runs);
+        assert!(t.contains("RUN ID"), "{t}");
+        assert!(t.contains("run-1"), "{t}");
+        assert!(t.contains("completed"), "{t}");
+        assert!(t.contains("500"), "rows/s = 1000/2 = 500: {t}");
+        assert!(t.contains("failed"), "{t}");
+        assert!(t.contains("error: boom"), "failed run shows its error: {t}");
+    }
+
+    #[test]
+    fn missing_elapsed_renders_dashes_not_a_panic() {
+        let runs = vec![record("r", RunStatus::Running, 5, None)];
+        let t = render_table(&runs);
+        assert!(t.contains("running"), "{t}");
+        // No division by zero / no NaN in the rate column.
+        assert!(!t.contains("NaN") && !t.contains("inf"), "{t}");
+    }
+
+    #[tokio::test]
+    async fn reads_seeded_in_memory_catalog() {
+        use crate::serve::history::RunHistory;
+        // Seed a memory backend with two runs, then read them back via list().
+        let store = crate::serve::history::memory::MemoryHistory::new(
+            std::time::Duration::from_secs(3600),
+        );
+        store
+            .upsert(&record("a", RunStatus::Completed, 10, Some(1.0)))
+            .await
+            .unwrap();
+        store
+            .upsert(&record("b", RunStatus::Completed, 20, Some(1.0)))
+            .await
+            .unwrap();
+        let page = store
+            .list(&ListFilter {
+                name: Some("demo".into()),
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.runs.len(), 2);
+        let t = render_table(&page.runs);
+        assert!(t.contains("a") && t.contains("b"), "{t}");
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -13,6 +13,10 @@ pub mod dev;
 pub mod discover;
 pub mod dlq;
 pub mod doctor;
+pub mod explain;
+pub mod fmt;
+#[cfg(feature = "catalog")]
+pub mod history;
 pub mod init;
 pub mod install;
 pub mod list;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -236,8 +236,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         ),
         RunOutput::Json => {
             let doc = summary_document(&pipeline_name, started_at, finished_at, &summary);
-            let rendered =
-                serde_json::to_string_pretty(&doc).unwrap_or_else(|_| "{}".to_string());
+            let rendered = serde_json::to_string_pretty(&doc).unwrap_or_else(|_| "{}".to_string());
             // Belt-and-suspenders: scrub any resolved secret that reached an
             // error string before it hits stdout (#390 secret-redaction AC).
             println!("{}", crate::secrets::registry::redact(&rendered));

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1,11 +1,13 @@
 //! `faucet run` — load a pipeline config, expand the matrix, execute every
 //! invocation under bounded concurrency.
 
-use crate::cli::RunArgs;
+use crate::cli::{RunArgs, RunOutput};
 use crate::config::PipelineConfig;
 use crate::error::{CliError, CliResult};
-use crate::executor::{ExecuteOptions, run_expanded};
+use crate::executor::{ExecuteOptions, RunSummary, run_expanded};
 use crate::expand::expand;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
 
 /// Parse the optional `--clock` override (RFC3339 or `YYYY-MM-DD`), or default
 /// to process start. Returned as a UTC fixed-offset clock for `${now.*}`.
@@ -134,6 +136,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     let tui_cancel = tui_active.then(faucet_core::CancellationToken::new);
     #[cfg(not(feature = "cli-tui"))]
     let tui_cancel: Option<faucet_core::CancellationToken> = None;
+    let started_at = Utc::now();
     let run_fut = run_expanded(
         nodes,
         ExecuteOptions {
@@ -181,6 +184,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     #[cfg(not(feature = "cli-tui"))]
     let summary = run_fut.await?;
 
+    let finished_at = Utc::now();
     let total_written: usize = summary.invocations.iter().map(|i| i.records_written).sum();
     let success = summary
         .invocations
@@ -212,20 +216,39 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         records_written = total_written,
         "pipeline completed"
     );
-    println!(
-        "{}: {} invocation{}, {} ok, {} failed, wrote {} record{}",
-        pipeline_name,
-        summary.invocations.len(),
-        if summary.invocations.len() == 1 {
-            ""
-        } else {
-            "s"
-        },
-        success,
-        failed,
-        total_written,
-        if total_written == 1 { "" } else { "s" }
-    );
+    // End-of-run summary. `text` is the human line (default); `json` / `ndjson`
+    // emit a machine-readable summary and keep stdout otherwise clean so
+    // `faucet run` is scriptable in CI / cron / Slack (#390). Logs are on stderr.
+    match args.output {
+        RunOutput::Text => println!(
+            "{}: {} invocation{}, {} ok, {} failed, wrote {} record{}",
+            pipeline_name,
+            summary.invocations.len(),
+            if summary.invocations.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
+            success,
+            failed,
+            total_written,
+            if total_written == 1 { "" } else { "s" }
+        ),
+        RunOutput::Json => {
+            let doc = summary_document(&pipeline_name, started_at, finished_at, &summary);
+            let rendered =
+                serde_json::to_string_pretty(&doc).unwrap_or_else(|_| "{}".to_string());
+            // Belt-and-suspenders: scrub any resolved secret that reached an
+            // error string before it hits stdout (#390 secret-redaction AC).
+            println!("{}", crate::secrets::registry::redact(&rendered));
+        }
+        RunOutput::Ndjson => {
+            for row in summary_rows(&summary) {
+                let line = serde_json::to_string(&row).unwrap_or_else(|_| "{}".to_string());
+                println!("{}", crate::secrets::registry::redact(&line));
+            }
+        }
+    }
 
     // Flush any buffered OTLP telemetry before the process exits (no-op without
     // the `otel` feature). Done on both the success and failure exit paths.
@@ -237,9 +260,151 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     Ok(())
 }
 
+/// One matrix row's line in a `--output json`/`ndjson` summary (#390). Every
+/// field is a counter the pipeline already maintains; `rows_in` is `null` when
+/// input sampling was not active (no `lineage:` / `catalog:` block).
+#[derive(Debug, Serialize)]
+pub(crate) struct RunRowSummary {
+    pub row_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_key: Option<String>,
+    pub source: String,
+    pub sink: String,
+    pub status: &'static str,
+    pub rows_in: Option<u64>,
+    pub rows_out: u64,
+    pub duration_ms: u64,
+    pub dlq_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bookmark: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Aggregate counters across every row.
+#[derive(Debug, Serialize)]
+pub(crate) struct RunTotals {
+    pub rows: usize,
+    pub rows_out: u64,
+    pub dlq_count: u64,
+    pub ok: usize,
+    pub failed: usize,
+}
+
+/// The full `--output json` document.
+#[derive(Debug, Serialize)]
+pub(crate) struct RunSummaryDocument {
+    pub pipeline: String,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub status: &'static str,
+    pub totals: RunTotals,
+    pub rows: Vec<RunRowSummary>,
+}
+
+/// Project one invocation outcome into its summary row.
+pub(crate) fn summary_rows(summary: &RunSummary) -> Vec<RunRowSummary> {
+    summary
+        .invocations
+        .iter()
+        .map(|o| {
+            let m = o.metrics.clone().unwrap_or_default();
+            RunRowSummary {
+                row_id: o.row_id.clone(),
+                parent_key: o.parent_record_key.clone(),
+                source: m.source_kind,
+                sink: m.sink_kind,
+                status: if o.error.is_some() { "failed" } else { "ok" },
+                rows_in: m.records_read,
+                rows_out: o.records_written as u64,
+                duration_ms: m.duration_ms,
+                dlq_count: m.dlq_count,
+                bookmark: m.bookmark,
+                error: o.error.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Build the top-level `--output json` document from a run summary.
+pub(crate) fn summary_document(
+    pipeline: &str,
+    started_at: DateTime<Utc>,
+    finished_at: DateTime<Utc>,
+    summary: &RunSummary,
+) -> RunSummaryDocument {
+    let rows = summary_rows(summary);
+    let failed = rows.iter().filter(|r| r.status == "failed").count();
+    let totals = RunTotals {
+        rows: rows.len(),
+        rows_out: rows.iter().map(|r| r.rows_out).sum(),
+        dlq_count: rows.iter().map(|r| r.dlq_count).sum(),
+        ok: rows.len() - failed,
+        failed,
+    };
+    RunSummaryDocument {
+        pipeline: pipeline.to_string(),
+        started_at,
+        finished_at,
+        status: if failed > 0 { "failed" } else { "ok" },
+        totals,
+        rows,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executor::{InvocationMetrics, InvocationOutcome};
+
+    fn outcome(id: &str, written: usize, err: Option<&str>) -> InvocationOutcome {
+        InvocationOutcome {
+            row_id: id.into(),
+            parent_record_key: None,
+            records_written: written,
+            error: err.map(|s| s.to_string()),
+            metrics: Some(InvocationMetrics {
+                source_kind: "rest".into(),
+                sink_kind: "jsonl".into(),
+                duration_ms: 12,
+                records_read: Some(written as u64),
+                dlq_count: 0,
+                bookmark: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn summary_document_aggregates_rows_and_status() {
+        let summary = RunSummary {
+            invocations: vec![outcome("a", 3, None), outcome("b", 0, Some("boom"))],
+        };
+        let now = Utc::now();
+        let doc = summary_document("demo", now, now, &summary);
+        assert_eq!(doc.status, "failed");
+        assert_eq!(doc.totals.rows, 2);
+        assert_eq!(doc.totals.rows_out, 3);
+        assert_eq!(doc.totals.ok, 1);
+        assert_eq!(doc.totals.failed, 1);
+        assert_eq!(doc.rows[0].source, "rest");
+        assert_eq!(doc.rows[0].rows_in, Some(3));
+        assert_eq!(doc.rows[1].status, "failed");
+        assert_eq!(doc.rows[1].error.as_deref(), Some("boom"));
+        // Serializes cleanly.
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(json.contains("\"pipeline\":\"demo\""), "{json}");
+    }
+
+    #[test]
+    fn all_ok_run_reports_ok_status() {
+        let summary = RunSummary {
+            invocations: vec![outcome("only", 5, None)],
+        };
+        let now = Utc::now();
+        let doc = summary_document("p", now, now, &summary);
+        assert_eq!(doc.status, "ok");
+        assert_eq!(doc.totals.failed, 0);
+    }
 
     #[test]
     fn run_clock_parses_rfc3339_date_and_defaults() {

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -835,6 +835,7 @@ mod tests {
                 } else {
                     None
                 },
+                metrics: None,
             });
         }
         RunSummary { invocations }
@@ -895,6 +896,7 @@ mod tests {
             parent_record_key: None,
             records_written: 0,
             error: Some(circuit_open_msg),
+            metrics: None,
         }];
         let joined = Ok(Ok(RunSummary { invocations }));
         let f = classify(joined, Some(Duration::from_secs(45)));
@@ -916,6 +918,7 @@ mod tests {
             parent_record_key: None,
             records_written: 0,
             error: Some(circuit_open_msg),
+            metrics: None,
         }];
         let joined = Ok(Ok(RunSummary { invocations }));
         let f = classify(joined, None);

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1469,13 +1469,17 @@ async fn run_one_invocation(
     // is only known when the source sampler was installed (a `lineage:` or
     // `catalog:` block); otherwise it stays `None` rather than guessing.
     #[cfg(feature = "lineage")]
-    let records_read = in_sample.as_ref().map(|s| s.count() as u64);
+    let records_read = in_sample.as_ref().map(|s| s.count());
     #[cfg(not(feature = "lineage"))]
     let records_read: Option<u64> = None;
     let stats = PipelineStats {
         records_written: result.records_written,
         records_read,
-        dlq_count: result.dlq.as_ref().map(|d| d.records_dlq as u64).unwrap_or(0),
+        dlq_count: result
+            .dlq
+            .as_ref()
+            .map(|d| d.records_dlq as u64)
+            .unwrap_or(0),
         bookmark: result.bookmark.clone(),
     };
 

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -130,6 +130,35 @@ pub struct InvocationOutcome {
     pub parent_record_key: Option<String>,
     pub records_written: usize,
     pub error: Option<String>,
+    /// Machine-readable per-invocation stats for `faucet run --output json`
+    /// (#390). `None` for synthetic outcomes (a task panic, or the placeholder
+    /// outcomes the replication / schedule orchestrators build) where no
+    /// pipeline actually ran.
+    pub metrics: Option<InvocationMetrics>,
+}
+
+/// Per-invocation stats surfaced by `faucet run --output json` (#390). Every
+/// field comes from counters the pipeline already maintains — no new
+/// measurement. `records_read` is `None` unless input sampling was active
+/// (a `lineage:` or `catalog:` block installs the source sampler).
+#[derive(Debug, Clone, Default)]
+pub struct InvocationMetrics {
+    pub source_kind: String,
+    pub sink_kind: String,
+    pub duration_ms: u64,
+    pub records_read: Option<u64>,
+    pub dlq_count: u64,
+    pub bookmark: Option<Value>,
+}
+
+/// What [`run_one_invocation`] hands back on success alongside the captured
+/// records — the pipeline-level counters `run_unit` folds into an
+/// [`InvocationMetrics`] (which then adds the connector kinds + wall-clock).
+struct PipelineStats {
+    records_written: usize,
+    records_read: Option<u64>,
+    dlq_count: u64,
+    bookmark: Option<Value>,
 }
 
 /// Aggregate outcome of `run_expanded`.
@@ -462,6 +491,7 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
                         parent_record_key,
                         records_written: 0,
                         error: Some(format!("pipeline invocation task panicked: {e}")),
+                        metrics: None,
                     }
                 }
             };
@@ -539,6 +569,7 @@ async fn run_unit(
     cancel: CancellationToken,
 ) -> InvocationOutcome {
     let needs_capture = capture.is_some();
+    let started = std::time::Instant::now();
     let result = run_one_invocation(
         &unit.node,
         unit.parent_record.as_deref(),
@@ -548,10 +579,17 @@ async fn run_unit(
         cancel,
     )
     .await;
+    let duration_ms = started.elapsed().as_millis() as u64;
     let row_id = unit.node.id.clone();
     let parent_record_key = unit.parent_record_key.clone();
+    let base_metrics = || InvocationMetrics {
+        source_kind: unit.node.source.kind.clone(),
+        sink_kind: unit.node.sink.kind.clone(),
+        duration_ms,
+        ..Default::default()
+    };
     match result {
-        Ok((records, written)) => {
+        Ok((records, stats)) => {
             if needs_capture {
                 captured
                     .lock()
@@ -565,8 +603,14 @@ async fn run_unit(
             InvocationOutcome {
                 row_id,
                 parent_record_key,
-                records_written: written,
+                records_written: stats.records_written,
                 error: None,
+                metrics: Some(InvocationMetrics {
+                    records_read: stats.records_read,
+                    dlq_count: stats.dlq_count,
+                    bookmark: stats.bookmark,
+                    ..base_metrics()
+                }),
             }
         }
         Err(e) => InvocationOutcome {
@@ -574,6 +618,7 @@ async fn run_unit(
             parent_record_key,
             records_written: 0,
             error: Some(e.to_string()),
+            metrics: Some(base_metrics()),
         },
     }
 }
@@ -870,7 +915,7 @@ async fn run_one_invocation(
     capture: Option<Arc<Projection>>,
     opts: &ExecuteOptions,
     cancel: CancellationToken,
-) -> CliResult<(Vec<Value>, usize)> {
+) -> CliResult<(Vec<Value>, PipelineStats)> {
     // Observability identity for this invocation — built once, reused by both
     // the Pipeline builder and the transform instrumentation.
     let run_id = uuid::Uuid::now_v7().to_string();
@@ -1420,12 +1465,26 @@ async fn run_one_invocation(
 
     let result = result?;
 
+    // Per-invocation stats for `faucet run --output json` (#390). `records_read`
+    // is only known when the source sampler was installed (a `lineage:` or
+    // `catalog:` block); otherwise it stays `None` rather than guessing.
+    #[cfg(feature = "lineage")]
+    let records_read = in_sample.as_ref().map(|s| s.count() as u64);
+    #[cfg(not(feature = "lineage"))]
+    let records_read: Option<u64> = None;
+    let stats = PipelineStats {
+        records_written: result.records_written,
+        records_read,
+        dlq_count: result.dlq.as_ref().map(|d| d.records_dlq as u64).unwrap_or(0),
+        bookmark: result.bookmark.clone(),
+    };
+
     let captured = if capture.is_some() {
         std::mem::take(&mut *captured.lock().await)
     } else {
         Vec::new()
     };
-    Ok((captured, result.records_written))
+    Ok((captured, stats))
 }
 
 async fn build_state_for_node(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -182,6 +182,10 @@ pub async fn run_command(cli: Cli) -> CliResult<()> {
         Command::Catalog(args) => commands::catalog::run(args).await,
         Command::Completions(args) => commands::completions::run(args.shell),
         Command::Migrate(args) => commands::migrate::run(args).await,
+        Command::Fmt(args) => commands::fmt::run(args).await,
+        Command::Explain(args) => commands::explain::run(args).await,
+        #[cfg(feature = "catalog")]
+        Command::History(args) => commands::history::run(args).await,
     }
 }
 

--- a/cli/src/replication/orchestrator.rs
+++ b/cli/src/replication/orchestrator.rs
@@ -434,6 +434,7 @@ pipeline:
                 parent_record_key: None,
                 records_written: 0,
                 error: Some("connection refused".into()),
+                metrics: None,
             }],
         };
         let err = phase_failure(&summary, "snapshot");
@@ -456,6 +457,7 @@ pipeline:
                 parent_record_key: None,
                 records_written: 0,
                 error: None,
+                metrics: None,
             }],
         };
         let err = phase_failure(&summary, "CDC");

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -1408,6 +1408,7 @@ mod tests {
                 parent_record_key: None,
                 records_written: 3,
                 error: None,
+                metrics: None,
             }],
         };
         let (status, reason, records, _, error) = classify_run(Ok(summary)).into_parts();
@@ -1425,6 +1426,7 @@ mod tests {
                 parent_record_key: None,
                 records_written: 0,
                 error: Some("boom".into()),
+                metrics: None,
             }],
         };
         let (status, reason, _, _, error) = classify_run(Ok(summary)).into_parts();

--- a/cli/tests/history_e2e.rs
+++ b/cli/tests/history_e2e.rs
@@ -1,0 +1,88 @@
+#![cfg(all(feature = "catalog", feature = "serve-history-sqlite"))]
+//! End-to-end for `faucet history` (#391): seed run records into a real sqlite
+//! catalog store, then drive `history::run` over the table, `--json`, and
+//! `--row` paths. Exercises the command's connect → fetch → filter → render
+//! wiring that the pure unit tests can't reach.
+
+use chrono::Utc;
+use faucet_cli::cli::HistoryArgs;
+use faucet_cli::serve::history::{InvocationRecord, RunRecord, RunStatus};
+use std::path::PathBuf;
+
+fn args(config: PathBuf, row: Option<String>, json: bool) -> HistoryArgs {
+    HistoryArgs {
+        config: Some(config),
+        env_file: None,
+        no_env_file: true,
+        profile: None,
+        limit: 20,
+        row,
+        json,
+    }
+}
+
+fn record(id: &str, row_id: &str) -> RunRecord {
+    let t = Utc::now();
+    RunRecord {
+        run_id: id.into(),
+        name: Some("demo".into()),
+        labels: Default::default(),
+        status: RunStatus::Completed,
+        submitted_at: t,
+        started_at: Some(t),
+        finished_at: Some(t),
+        elapsed_secs: Some(1.0),
+        records_written: 10,
+        invocations: vec![InvocationRecord {
+            row_id: row_id.into(),
+            parent_record_key: None,
+            records_written: 10,
+            error: None,
+        }],
+        error: None,
+        idempotency_key: None,
+        doctor_report: None,
+        config_body: None,
+        config_format: None,
+        timeout_secs: None,
+        clock: None,
+        attempt: 0,
+        replay_of: None,
+    }
+}
+
+#[tokio::test]
+async fn history_reads_seeded_sqlite_catalog() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("cat.db");
+    let cfg = dir.path().join("faucet.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "version: 1\nname: demo\ncatalog:\n  url: \"sqlite:{db}\"\npipeline:\n  source: {{ type: rest, config: {{ path: /x }} }}\n  sink: {{ type: jsonl, config: {{ path: o }} }}\n",
+            db = db.display(),
+        ),
+    )
+    .unwrap();
+
+    // Seed two run records under different matrix rows.
+    let handle = faucet_cli::catalog::connect_from_spec(&faucet_cli::catalog::CatalogSpec {
+        url: format!("sqlite:{}", db.display()),
+        sample_records: 10,
+    })
+    .await
+    .unwrap();
+    handle.store.upsert(&record("run-a", "us")).await.unwrap();
+    handle.store.upsert(&record("run-b", "eu")).await.unwrap();
+
+    // Table, JSON, and --row filter all drive `run()` to completion.
+    faucet_cli::commands::history::run(args(cfg.clone(), None, false))
+        .await
+        .expect("table render");
+    faucet_cli::commands::history::run(args(cfg.clone(), None, true))
+        .await
+        .expect("json render");
+    faucet_cli::commands::history::run(args(cfg.clone(), Some("eu".into()), false))
+        .await
+        .expect("row filter");
+}

--- a/cli/tests/lineage_run.rs
+++ b/cli/tests/lineage_run.rs
@@ -20,6 +20,7 @@ fn run_args(config: PathBuf) -> faucet_cli::cli::RunArgs {
         clock: None,
         profile: None,
         tui: false,
+        output: Default::default(),
         selection: Default::default(),
     }
 }

--- a/cli/tests/plan_diff_e2e.rs
+++ b/cli/tests/plan_diff_e2e.rs
@@ -18,6 +18,7 @@ fn run_args(config: PathBuf) -> faucet_cli::cli::RunArgs {
         clock: None,
         profile: None,
         tui: false,
+        output: Default::default(),
         selection: Default::default(),
     }
 }

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -25,6 +25,10 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet completions <shell>` | Print a shell tab-completion script (bash / zsh / fish / powershell / elvish). |
 | `faucet migrate [config]` | Upgrade a config written against an older grammar to the current shape (idempotent). |
 | `faucet doctor --offline [config]` | Static, credential-free config lints (no network) — dangling/unused auth, unused vars, no-op sink `batch_size`. |
+| `faucet fmt [config] [--check]` | Canonicalize a config (stable key order); `--check` is a CI gate. |
+| `faucet explain [config]` | Plain-English narration of what a pipeline does (offline, zero I/O). |
+| `faucet history [config]` | Terminal view of the run history in a config's `catalog:` store. |
+| `faucet run … --output json\|ndjson` | Machine-readable end-of-run summary (per-row + totals) for scripting. |
 
 `[config]` is optional for `run` / `validate` / `preview` / `doctor` / `replicate` / `schedule`: if
 omitted, faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
@@ -827,3 +831,63 @@ a `vars:` entry never interpolated (**warning**); and a file/append sink
 The command exits non-zero on any lint *error* (warnings don't fail). Secret and
 `${env:…}` resolution is validated separately at config load (and by
 `faucet validate`).
+
+## `fmt`
+
+`faucet fmt [config…]` rewrites a config into a canonical form — a stable key
+order (a curated priority for well-known blocks like `version`/`name`/`pipeline`,
+then alphabetical), so diffs stay meaningful and reviews stay quiet. Running it
+twice is always a no-op, so `--check` is a cheap CI gate.
+
+```bash
+faucet fmt pipeline.yaml            # rewrite in place
+faucet fmt pipeline.yaml --stdout   # print, don't write
+faucet fmt pipeline.yaml --check    # exit non-zero if not already canonical (CI)
+```
+
+Comments are not preserved (the file is parsed and re-serialized).
+
+## `explain`
+
+`faucet explain [config]` narrates, in plain English, what a pipeline does —
+source → transforms → sink, write mode/key, matrix expansion, delivery
+guarantee. It is built entirely from the resolved config: **fully offline, zero
+I/O, no source touched**, and secrets are never printed (only a curated
+allowlist of structural fields is surfaced, and the output is scrubbed).
+
+```bash
+faucet explain pipeline.yaml          # prose
+faucet explain pipeline.yaml --json   # structured
+faucet explain pipeline.yaml --rows   # narrate every row of a large matrix
+```
+
+## `history`
+
+`faucet history [config]` prints the recent run history recorded in the config's
+`catalog:` store (the same backend `faucet serve` history and `faucet plan
+--diff` use) — status, duration, throughput — without standing up `faucet
+serve`. Read-only; requires the `catalog` build feature.
+
+```bash
+faucet history                 # table, newest first (default 20)
+faucet history --limit 50      # more rows
+faucet history --row us        # only runs with an invocation for row `us`
+faucet history --json          # machine-readable
+```
+
+Run records are written by `faucet serve`; point `history` at the same store.
+
+## `run --output`
+
+`faucet run … --output json` (or `ndjson`) emits a machine-readable end-of-run
+summary instead of the human line, keeping stdout otherwise clean (logs stay on
+stderr) so `faucet run` is composable in CI / cron / Slack:
+
+```bash
+faucet run pipeline.yaml --output json      # one JSON document: per-row + totals
+faucet run pipeline.yaml --output ndjson     # one JSON object per matrix row
+```
+
+Each row reports `rows_in` / `rows_out` / `duration_ms` / `dlq_count` / `status`
+/ `bookmark`; the exit code is unchanged (non-zero on failure). Secret material
+is scrubbed from the output.


### PR DESCRIPTION
The four **tier-3 CLI ergonomics** features, in one PR. Closes #387, #389, #390, #391.

> Note: the implementation was started in an earlier session and left uncommitted in the working tree; this PR picks it up, fixes the test build it stopped on, and finishes it (coverage, docs, an integration test).

## Commands

- **#387 `faucet fmt [config] [--check|--stdout]`** — canonicalize a config (stable key order: a curated priority for well-known blocks, then alphabetical). Idempotent; `--check` exits non-zero when not canonical (CI gate); `--stdout` previews. Comments aren't preserved (parse + re-serialize).
- **#389 `faucet explain [config] [--json|--rows]`** — plain-English narration: source → transforms → sink, write mode/key, matrix expansion, delivery guarantee. **Fully offline, zero I/O**; secrets never printed (curated safe-field allowlist + scrub).
- **#390 `faucet run … --output <text|json|ndjson>`** — machine-readable end-of-run summary (per-row `rows_in`/`rows_out`/`duration_ms`/`dlq_count`/`status`/`bookmark` + totals). Clean stdout, logs on stderr; exit code unchanged; secrets scrubbed.
- **#391 `faucet history [config] [--limit|--row|--json]`** — terminal view of the `catalog:` store's run history (status/duration/throughput), newest first. Read-only; requires the `catalog` feature.

## Finishing work (on top of the picked-up implementation)

- Fixed the test build the prior session stopped on: added the new `output` field to the `RunArgs` literals in `lineage_run` + `plan_diff_e2e`.
- Hardened coverage (measured locally with `cargo llvm-cov`): extracted a pure `select_runs` in history + a no-catalog error test; added `run()`-flow tests for `explain`; a **Docker-free sqlite `history_e2e`** integration test seeding run records via `connect_from_spec` + `store.upsert`. Per-file diff coverage: **fmt 93%, explain 92%, history 96% (with e2e), run added ~92%** — clears the 90% `codecov/patch` gate.
- `cargo clippy --all-targets` (with `catalog,serve-history-sqlite`) clean; `cargo fmt --check` clean. No new dependencies.

## Verified functionally on the binary
`fmt --check` exits 1/0 correctly; `explain` narrates single + matrix configs; `run --output json` emits a valid summary; `history` reads a seeded catalog and errors gracefully with a helpful hint when no `catalog:` block is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)