### PR TITLE
docs(book): charted benchmarks page (vs Meltano)

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -67,6 +67,7 @@
 # Comparisons
 
 - [How faucet-stream compares](./comparison/index.md)
+- [Benchmarks (vs Meltano)](./comparison/benchmarks.md)
 - [vs. Meltano (Singer)](./comparison/meltano.md)
 - [vs. Airbyte](./comparison/airbyte.md)
 - [vs. Singer](./comparison/singer.md)

--- a/docs/book/src/comparison/benchmarks.md
+++ b/docs/book/src/comparison/benchmarks.md
@@ -1,0 +1,178 @@
+# Benchmarks (vs Meltano)
+
+Honest, reproducible evidence for the "built for throughput" claim. Every number
+below comes from [`BENCHMARKS.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)
+— identical workloads, one machine (Apple M3 Pro, 12 cores, 18 GiB RAM), 1M rows,
+seed 42, median of 5 timed runs. faucet-stream is compared against
+[Meltano](https://meltano.com/) (the most common [Singer](https://www.singer.io/)
+runtime).
+
+> **Read the caveats first.** This measures single-machine *batch* throughput of
+> three specific moves. It does **not** measure distributed throughput, connector
+> breadth, or correctness. The CSV→JSONL figure is a **best case** (upper bound),
+> not the typical case — see [vs. Meltano](./meltano.md) and
+> [`BENCHMARKS.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)
+> for the full methodology, hardware capture, and the Postgres-row measurement
+> caveat.
+
+<style>
+.viz-root {
+  --surface-1: #fcfcfb;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --muted: #898781;
+  --track: #eceae4;
+  --series-faucet: #2a78d6;   /* categorical slot 1 — blue (the hero) */
+  --series-meltano: #eb6834;  /* categorical slot 8 — orange */
+  --gap-bar: #256abf;         /* derived-ratio bars: one muted blue */
+  --hairline: rgba(11,11,11,0.10);
+}
+html.navy .viz-root, html.coal .viz-root, html.ayu .viz-root {
+  --surface-1: #1a1a19;
+  --text-primary: #ffffff;
+  --text-secondary: #c3c2b7;
+  --muted: #898781;
+  --track: #2c2c2a;
+  --series-faucet: #3987e5;
+  --series-meltano: #d95926;
+  --gap-bar: #5598e7;
+  --hairline: rgba(255,255,255,0.10);
+}
+.viz-root { margin: 1.25rem 0 1.75rem; }
+.viz-hero { display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 0.5rem 0 1.5rem; }
+.viz-tile {
+  flex: 1 1 150px; background: var(--surface-1); border: 1px solid var(--hairline);
+  border-radius: 10px; padding: 0.85rem 1rem;
+}
+.viz-tile .num {
+  font: 700 1.9rem/1.05 system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--series-faucet); letter-spacing: -0.01em;
+}
+.viz-tile .cap { color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem; }
+.viz-title {
+  font: 600 0.95rem/1.3 system-ui, sans-serif; color: var(--text-primary);
+  margin: 1.1rem 0 0.15rem;
+}
+.viz-sub { color: var(--muted); font-size: 0.78rem; margin: 0 0 0.7rem; }
+.viz-legend { display: flex; gap: 1.1rem; margin: 0.2rem 0 0.9rem; font-size: 0.82rem; color: var(--text-secondary); }
+.viz-legend span { display: inline-flex; align-items: center; gap: 0.4rem; }
+.viz-legend i { width: 12px; height: 12px; border-radius: 3px; display: inline-block; }
+.viz-group { margin: 0.55rem 0 0.9rem; }
+.viz-group > .g-label { font-size: 0.8rem; color: var(--text-secondary); margin-bottom: 0.35rem; }
+.bar-row { display: flex; align-items: center; gap: 0.6rem; margin: 3px 0; }
+.bar-name { flex: 0 0 118px; text-align: right; font-size: 0.78rem; color: var(--text-secondary); }
+.bar-track { flex: 1 1 auto; background: var(--track); border-radius: 4px; height: 20px; overflow: hidden; }
+.bar-fill { height: 100%; border-radius: 4px; min-width: 3px; }
+.bar-fill.faucet { background: var(--series-faucet); }
+.bar-fill.meltano { background: var(--series-meltano); }
+.bar-fill.gap { background: var(--gap-bar); }
+.bar-val {
+  flex: 0 0 96px; font-size: 0.8rem; color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.viz-root details { margin-top: 0.6rem; font-size: 0.85rem; }
+.viz-root details summary { cursor: pointer; color: var(--text-secondary); }
+@media (max-width: 520px) {
+  .bar-name { flex-basis: 84px; }
+  .bar-val { flex-basis: 78px; font-size: 0.74rem; }
+}
+</style>
+
+<div class="viz-root">
+
+<div class="viz-hero">
+  <div class="viz-tile"><div class="num">~96×</div><div class="cap">faster on CSV → JSONL (best case, parse-bound)</div></div>
+  <div class="viz-tile"><div class="num">~16×</div><div class="cap">faster on a realistic DB → DB move (sink-bound)</div></div>
+  <div class="viz-tile"><div class="num">~62×</div><div class="cap">less peak memory (11.8 vs 724 MiB)</div></div>
+  <div class="viz-tile"><div class="num">1:1</div><div class="cap">exact row-count parity, every scenario</div></div>
+</div>
+
+<div class="viz-legend">
+  <span><i style="background:var(--series-faucet)"></i> faucet-stream</span>
+  <span><i style="background:var(--series-meltano)"></i> Meltano (Singer)</span>
+</div>
+
+<div class="viz-title">Throughput — rows/second (higher is better)</div>
+<div class="viz-sub">1,000,000 rows. Meltano's bar is a sliver on purpose — that is the result.</div>
+
+<div class="viz-group">
+  <div class="g-label">A — CSV → JSONL · parse-bound (best case)</div>
+  <div class="bar-row"><div class="bar-name">faucet</div><div class="bar-track"><div class="bar-fill faucet" style="width:100%"></div></div><div class="bar-val">712,403</div></div>
+  <div class="bar-row"><div class="bar-name">Meltano</div><div class="bar-track"><div class="bar-fill meltano" style="width:1.04%"></div></div><div class="bar-val">7,383</div></div>
+</div>
+
+<div class="viz-group">
+  <div class="g-label">B — Postgres → JSONL · typed row decode</div>
+  <div class="bar-row"><div class="bar-name">faucet</div><div class="bar-track"><div class="bar-fill faucet" style="width:25.2%"></div></div><div class="bar-val">179,700</div></div>
+  <div class="bar-row"><div class="bar-name">Meltano</div><div class="bar-track"><div class="bar-fill meltano" style="width:1.01%"></div></div><div class="bar-val">7,184</div></div>
+</div>
+
+<div class="viz-group">
+  <div class="g-label">C — Postgres → Postgres · sink-bound (the realistic move)</div>
+  <div class="bar-row"><div class="bar-name">faucet (COPY)</div><div class="bar-track"><div class="bar-fill faucet" style="width:17.3%"></div></div><div class="bar-val">123,200</div></div>
+  <div class="bar-row"><div class="bar-name">faucet (INSERT)</div><div class="bar-track"><div class="bar-fill faucet" style="width:13.9%"></div></div><div class="bar-val">99,000</div></div>
+  <div class="bar-row"><div class="bar-name">Meltano</div><div class="bar-track"><div class="bar-fill meltano" style="width:1.08%"></div></div><div class="bar-val">7,706</div></div>
+</div>
+
+<div class="viz-title">Peak memory — MiB (lower is better)</div>
+<div class="viz-sub">Here faucet is the sliver: bounded-memory streaming holds flat while Meltano buffers.</div>
+
+<div class="viz-group">
+  <div class="g-label">A — CSV → JSONL</div>
+  <div class="bar-row"><div class="bar-name">faucet</div><div class="bar-track"><div class="bar-fill faucet" style="width:1.6%"></div></div><div class="bar-val">11.8</div></div>
+  <div class="bar-row"><div class="bar-name">Meltano</div><div class="bar-track"><div class="bar-fill meltano" style="width:97.5%"></div></div><div class="bar-val">724.5</div></div>
+</div>
+
+<div class="viz-group">
+  <div class="g-label">B — Postgres → JSONL</div>
+  <div class="bar-row"><div class="bar-name">faucet</div><div class="bar-track"><div class="bar-fill faucet" style="width:1.9%"></div></div><div class="bar-val">13.9</div></div>
+  <div class="bar-row"><div class="bar-name">Meltano</div><div class="bar-track"><div class="bar-fill meltano" style="width:100%"></div></div><div class="bar-val">743.0</div></div>
+</div>
+
+<div class="viz-group">
+  <div class="g-label">C — Postgres → Postgres</div>
+  <div class="bar-row"><div class="bar-name">faucet</div><div class="bar-track"><div class="bar-fill faucet" style="width:4.8%"></div></div><div class="bar-val">35.9</div></div>
+  <div class="bar-row"><div class="bar-name">Meltano</div><div class="bar-track"><div class="bar-fill meltano" style="width:65.4%"></div></div><div class="bar-val">485.7</div></div>
+</div>
+
+<div class="viz-title">The gap collapses as the workload gets more I/O-bound</div>
+<div class="viz-sub">Speed-up multiplier (faucet ÷ Meltano). The best case is not the typical case.</div>
+
+<div class="viz-group">
+  <div class="bar-row"><div class="bar-name">A · parse-bound</div><div class="bar-track"><div class="bar-fill gap" style="width:100%"></div></div><div class="bar-val">~96×</div></div>
+  <div class="bar-row"><div class="bar-name">B · row decode</div><div class="bar-track"><div class="bar-fill gap" style="width:26%"></div></div><div class="bar-val">~25×</div></div>
+  <div class="bar-row"><div class="bar-name">C · sink-bound</div><div class="bar-track"><div class="bar-fill gap" style="width:16.7%"></div></div><div class="bar-val">~16×</div></div>
+</div>
+
+<details>
+<summary>Show the raw numbers as a table</summary>
+
+| Scenario | Bottleneck | faucet (rows/s) | Meltano (rows/s) | Gap | faucet RSS (MiB) | Meltano RSS (MiB) |
+|---|---|--:|--:|--:|--:|--:|
+| A — CSV → JSONL | parse/serialize (best case) | 712,403 | 7,383 | ~96× | 11.8 | 724.5 |
+| B — Postgres → JSONL | typed row decode | 179,700 | 7,184 | ~25× | 13.9 | 743.0 |
+| C — Postgres → Postgres | destination write (sink-bound) | 123,200 (COPY) / 99,000 (INSERT) | 7,706 | ~16× / ~13× | 35.9 | 485.7 |
+
+All runs: 1,000,000 rows, seed 42, exact row-count parity (1,000,000 = 1,000,000).
+
+</details>
+
+</div>
+
+## How to reproduce
+
+The harness never fabricates a number — a tool that won't install/run is recorded
+as such, not faked. Regenerate everything on your own hardware:
+
+```bash
+make bench            # Scenario A (CSV → JSONL, 1M rows) — no infra
+make bench-smoke      # 100k-row smoke run
+make bench-postgres   # adds Scenarios B & C (needs Docker)
+```
+
+Results land in `benchmarks/results/`. One independent confirmation on your own
+hardware is worth more to this project than a new connector — open an issue or PR
+with your output, **especially if faucet does not win.** See
+[`benchmarks/README.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/benchmarks/README.md)
+and [Performance tuning](../operations/tuning.md) for the levers behind these
+numbers.

--- a/docs/book/src/comparison/meltano.md
+++ b/docs/book/src/comparison/meltano.md
@@ -61,6 +61,6 @@ Then start from [your first pipeline](../getting-started/first-pipeline.md) and 
 
 ## See for yourself
 
-- **[Benchmarks](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)** — full methodology and honest caveats.
+- **[Benchmarks (vs Meltano)](./benchmarks.md)** — the numbers charted per scenario, with full methodology and honest caveats ([raw source](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)).
 - **[Try it in 60 seconds](../getting-started/try-it-locally.md)** — no infrastructure needed.
 - **[Choosing a connector](../reference/choosing.md)** — confirm your sources and sinks are covered.

--- a/docs/book/src/operations/tuning.md
+++ b/docs/book/src/operations/tuning.md
@@ -66,3 +66,7 @@ cargo bench -p faucet-core --bench observability
 
 Numbers are hardware-dependent, so run the benchmark on your target machine
 rather than relying on published figures.
+
+For the end-to-end throughput comparison against Meltano (Singer) — charted per
+scenario, with the full methodology and caveats — see
+[Benchmarks (vs Meltano)](../comparison/benchmarks.md).


### PR DESCRIPTION
## What

Adds a visual **Benchmarks (vs Meltano)** page to the mdBook docs site, turning the static tables in `BENCHMARKS.md` into intuitive per-scenario charts. Follows up the discussion that a graph page reads better than tables — the memory gap especially is a visual story.

## Charts (theme-aware HTML/CSS bars, no external JS)

- **Throughput (rows/s)** — faucet vs Meltano across the 3 scenarios; Meltano is a deliberate sliver.
- **Peak memory (MiB)** — inverted (faucet is the sliver), reinforcing bounded-memory streaming.
- **The gap collapses** — speed-up multiplier 96× → 25× → 16× as the workload moves parse-bound → sink-bound, keeping the "best case ≠ typical case" framing honest.
- Hero stat row + a `<details>` raw-numbers table view.

## Correctness & design

- Every number is copied **exactly** from `BENCHMARKS.md` (1M rows, seed 42, M3 Pro).
- 2-series palette (blue = faucet, orange = Meltano) validated CVD-safe (ΔE ~97) for both light and dark surfaces.
- Theming keyed to mdBook's `.navy`/`.coal`/`.ayu` theme classes so it tracks the site's light/dark toggle (not `prefers-color-scheme`).
- Raw HTML verified to pass through unescaped in the built output; `mdbook build docs/book` clean.

## Wiring

- Added to `SUMMARY.md` under **Comparisons**.
- Cross-linked from `operations/tuning.md` and `comparison/meltano.md` (the latter now points at the charted page, keeping the raw-source link).

## Notes

- Docs-only — `release-plz` filters `docs:` commits, so no version bump.
- Related but separate: connector-tier promotion follow-ups filed as #396 and #397 (no code in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)