### PR TITLE
docs(gtm): elevate Singer on-ramp, fix conformance + count drift (Tier-0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ cargo add faucet-stream           # the library
   (~96× faster, ~62× less memory, exact row parity); sink-bound moves like
   Postgres→Postgres narrow the gap. See [`BENCHMARKS.md`](BENCHMARKS.md) for the
   methodology, the sink-bound scenario, and honest caveats.
+- **🔌 Adopt incrementally — bring your Singer taps** — the `singer` source runs any
+  existing Singer/Meltano tap unchanged, so you can start with the taps you already
+  have and move to native connectors where throughput matters. _Experimental (v0):
+  single-stream today, and a bridged tap still runs its own Python process._
 - **🧩 Config-driven _or_ embeddable** — run `faucet run pipeline.yaml`, or call
   `Pipeline::new(&source, &sink).run().await?` from Rust. Same orchestration either way.
 - **⚙️ A runtime, not just connectors** — incremental + resumable replication, change-data-capture,
@@ -398,6 +402,7 @@ own service.
 | Config-driven (YAML/JSON) | ✓ | ✓ | via UI/API | ✓ | ✓ | via UI |
 | Embeddable as a library | ✓ (Rust) | ✗ | ✗ | ✓ (Go) | ✗ | ✗ |
 | Connector count | 58, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
+| Runs existing Singer taps | ✓ bridge (experimental) | ✓ native | ✗ | ✗ | ✗ | ✗ |
 | Change data capture | ✓ Postgres / MySQL / Mongo / SQL Server | partial¹ | ✓ | partial | ✗ | ✓ |
 | Incremental + resumable state | ✓ | ✓ | ✓ | partial | n/a | ✓ |
 | Effectively-once delivery³ | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |

--- a/crates/conformance/README.md
+++ b/crates/conformance/README.md
@@ -16,10 +16,10 @@ invokes and passes these checks in CI; connectors that don't are Tier-2
 |---|---|---|
 | 1 | `assert_config_schema_valid` | ✅ implemented — `config_schema()` is a valid, round-tripping JSON Schema |
 | 2 | `assert_bounded_memory` | ✅ implemented — `stream_pages` pages instead of buffering the whole set |
-| 3 | `assert_bookmark_roundtrip` | 🚧 skeleton (stable signature, `// TODO`) |
-| 4 | `assert_idempotent_replay` | 🚧 skeleton |
-| 5 | `assert_capabilities_truthful` | 🚧 skeleton |
-| 6 | `assert_errors_not_panics` | 🚧 skeleton |
+| 3 | `assert_bookmark_roundtrip` | ✅ implemented — a resumed run picks up *after* the emitted bookmark; strictly fewer records reappear |
+| 4 | `assert_idempotent_replay` | ✅ implemented — atomic-watermark replay (or keyed-upsert) converges to one row per key, no double-writes |
+| 5 | `assert_capabilities_truthful` | ✅ implemented — advertised `supports_*` capabilities match actual behavior (idempotency, schema evolution) |
+| 6 | `assert_errors_not_panics` | ✅ implemented — a failing source surfaces a typed `FaucetError` without unwinding |
 
 ## Usage
 

--- a/docs/launch/RELEASE_PUBLICITY.md
+++ b/docs/launch/RELEASE_PUBLICITY.md
@@ -8,7 +8,7 @@ A **repeatable, per-release** playbook so publicity is routine, not heroic. Wher
 account. Keep the copy consistent across channels: consistency compounds recognition.
 
 > **Single source of truth:** the canonical pitch and the connector count live in the root
-> [`README.md`](../../README.md) hero (currently **49 connectors — 28 sources / 21 sinks**).
+> [`README.md`](../../README.md) hero (currently **58 connectors — 33 sources / 25 sinks**).
 > Copy from there; don't invent variants. If the count changed this release, update the
 > templates below in the same PR.
 
@@ -83,7 +83,7 @@ DB→DB move, **~96×** as the CSV→JSONL upper bound — never the ~96× alone
 
 ### This Week in Rust
 
-> **faucet-stream vX.Y.Z** — a config-driven data-movement platform for Rust: 49 connectors,
+> **faucet-stream vX.Y.Z** — a config-driven data-movement platform for Rust: 58 connectors,
 > a `faucet` CLI that runs pipelines from YAML, and an embeddable library, with streaming,
 > Postgres CDC, dead-letter queues, and built-in Prometheus/tracing. This release:
 > <one-line highlight>.


### PR DESCRIPTION
Tier-0 GTM/positioning polish from the ranking of epic **#91** + playbook **#314**. All docs-only.

## What & why

The audit found most of what #91's "GTM refinement" section flagged is already fixed (README + docs-site book are self-consistent at **33 sources / 25 sinks / 58 total**, the benchmark already leads the hero, FCP is already linked). Two things remained:

**1. The Singer on-ramp (Lever A) — the real remaining positioning gap.**
Singer/Meltano appeared *only* as the competitor the benchmark beats; the `singer` bridge was buried in the connector table. This adds it as:
- a **"Why faucet-stream" bullet** — adopt incrementally by running your existing Singer taps unchanged, then move to native connectors where throughput matters;
- a **"Runs existing Singer taps" comparison-table row**.

Both are framed **honestly**: experimental v0, single-stream, and a bridged tap still runs its own Python process — per the guardrails in #91 (don't over-claim; be upfront about the two-worlds tradeoff).

**2. Factual drift.**
- `crates/conformance/README.md` marked checks 3–6 as "🚧 skeleton", but all six are fully implemented in `src/lib.rs` (639 lines, zero `TODO`/`unimplemented`). Updated to ✅ with accurate one-line descriptions.
- `docs/launch/RELEASE_PUBLICITY.md` still said "49 connectors — 28 sources / 21 sinks"; reconciled to the README hero + tree (**58 — 33/25**).

## Deliberately out of scope (follow-ups)
- `docs/launch/blog-post.md` + `docs/launch/README.md` still say "49 connectors" and predate the Singer/benchmark/FCP levers — #91 §6 slates these for a **wholesale rewrite as the Tier-1 anchor post**, so they're left for that rather than half-patched here.
- `CLAUDE.md` internal crate-count example ("67 crates", "28/21") is inconsistent with the README's "80 crates" — internal-only, tracked separately from this public-facing GTM PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)