### PR TITLE
docs(gtm): refresh launch kit + blog posts (Tier-1/Tier-2)

### DIFF
--- a/docs/blog/exactly-once-without-a-broker.md
+++ b/docs/blog/exactly-once-without-a-broker.md
@@ -137,5 +137,5 @@ Kill it mid-run. Restart it. Count the rows. They'll be right.
 ---
 
 *faucet-stream is an MIT/Apache-2.0 Rust library + CLI for moving data between
-28 sources and 21 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
+33 sources and 25 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
 [GitHub](https://github.com/PawanSikawat/faucet-stream).*

--- a/docs/blog/migrating-from-meltano.md
+++ b/docs/blog/migrating-from-meltano.md
@@ -13,8 +13,10 @@ an honest note on when you shouldn't switch.*
 Straight answer first, because it makes the rest credible.
 
 **Stay on Meltano if** your first requirement is **connector breadth** — 600+
-Singer taps vs faucet's ~49 built-in connectors. If you depend on a long-tail
-SaaS tap that faucet doesn't have, Meltano wins today, full stop.
+Singer taps vs faucet's ~58 built-in connectors. If you depend on a long-tail
+SaaS tap that faucet doesn't have, Meltano wins today, full stop. (That said, the
+experimental `singer` source lets faucet run those taps unchanged — see the
+gotcha below — so "no native connector" isn't necessarily a dealbreaker.)
 
 **Move to faucet if** you feel the cost of the Python plugin runtime and want:
 
@@ -155,8 +157,11 @@ This is a real, runnable config —
 
 - **No tap for your source?** If it's a REST or GraphQL API, the generic source
   usually covers it with `pagination` + `auth` config — you're configuring, not
-  writing a plugin. If it's a truly bespoke SaaS with no HTTP-shaped API, that's
-  the case to stay on Meltano (or file a connector request).
+  writing a plugin. If it's a truly bespoke SaaS with only a Singer tap, the
+  experimental [`singer` source](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+  runs that tap unchanged under faucet — a zero-rewrite stepping stone (it's v0
+  and single-stream, and reintroduces the tap's Python process) while you wait
+  for, or file, a native connector request.
 - **Mappers → transforms.** Simple renames/casts/drops map to built-in
   [record transforms](https://pawansikawat.github.io/faucet-stream/cookbook/transforms.html);
   anything SQL-shaped maps to the embedded-DuckDB
@@ -175,5 +180,5 @@ faucet run cli/examples/csv_to_jsonl.yaml   # no infra needed
 ---
 
 *faucet-stream is an MIT/Apache-2.0 Rust library + CLI for moving data between
-28 sources and 21 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
+33 sources and 25 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
 [GitHub](https://github.com/PawanSikawat/faucet-stream).*

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -24,7 +24,7 @@ add this line under a relevant section (e.g. *Database* → *ETL* or *Data
 processing*), and open a PR:
 
 ```markdown
-* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement platform: 49 source and sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; streaming, CDC, DLQ, and built-in metrics.
+* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement platform: 58 source and sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; runs your existing Singer taps unchanged, with streaming, CDC, DLQ, and built-in metrics.
 ```
 
 Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesome-data-engineering).
@@ -34,7 +34,7 @@ Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesom
 Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-week-in-rust)
 (Crate of the Week nominations + project updates). Suggested blurb:
 
-> **faucet-stream** — a config-driven data-movement platform: 49 connectors, a
+> **faucet-stream** — a config-driven data-movement platform: 58 connectors, a
 > `faucet` CLI that runs pipelines from YAML, and an embeddable library, with
 > streaming, Postgres CDC, dead-letter queues, and built-in Prometheus/tracing.
 
@@ -48,11 +48,14 @@ Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-w
 > It's a single static binary that runs pipelines from a YAML file (no platform,
 > no Python, no daemon), or an embeddable library with typed Source/Sink traits.
 >
-> 49 connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
-> SQLite, S3/GCS, Parquet, MongoDB, Redis, Elasticsearch, BigQuery, Snowflake),
-> with native streaming (bounded memory), incremental/resumable replication,
-> dead-letter queues, retries, and built-in Prometheus metrics + tracing — no
-> per-connector code.
+> 58 connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
+> SQLite, S3/GCS/Azure, Parquet/Delta/Iceberg, MongoDB, Redis, Elasticsearch,
+> BigQuery, Snowflake, Databricks), with native streaming (bounded memory),
+> incremental/resumable replication, dead-letter queues, retries, and built-in
+> Prometheus metrics + tracing — no per-connector code.
+>
+> It also runs your existing Singer/Meltano taps unchanged (an experimental
+> bridge), so you can adopt it incrementally instead of rewriting pipelines.
 >
 > It's the EL of ELT — I'm upfront in the README about where Meltano/Airbyte/dbt
 > fit better. Pre-1.0 and moving fast; connector requests welcome.
@@ -64,7 +67,7 @@ Post early in the US morning (Pacific) on a weekday; reply to comments quickly.
 
 ### 4. Reddit — r/rust
 
-**Title:** `faucet-stream: a config-driven data-movement platform (49 connectors, streaming, CDC) — CLI or embeddable library`
+**Title:** `faucet-stream: a config-driven data-movement platform (58 connectors, streaming, CDC) — CLI or embeddable library`
 
 Lead with the Rust angle: single binary, typed traits, every connector a Cargo
 feature, performance-first design (connection reuse, multi-row inserts, bounded

--- a/docs/launch/RELEASE_PUBLICITY.md
+++ b/docs/launch/RELEASE_PUBLICITY.md
@@ -27,7 +27,7 @@ per-crate patch bump. Rule of thumb:
 - [ ] Release PR merged; crates published; the umbrella tag is live and installable
       (`cargo install faucet-cli` / the Homebrew tap / the installer script all resolve).
 - [ ] Connector count in the templates below still matches reality
-      (`ls crates/source/* crates/sink/*` → currently 28 + 21 = **49**).
+      (`ls crates/source/* crates/sink/*` → currently 33 + 25 = **58**).
 - [ ] Pull the release highlights from the per-crate `CHANGELOG.md` files (release-plz writes
       these from `feat`/`fix`/`perf` commits). Pick the 2–4 user-facing headlines.
 - [ ] The repo **social-preview image** (Settings → Social preview, 1280×640) is set so
@@ -59,14 +59,14 @@ Front-load the high-signal, low-effort channels; do the rest as time allows.
 
 ## Copy templates
 
-Reuse verbatim; swap `vX.Y.Z` and the highlights. All counts are **49**; all benchmark
+Reuse verbatim; swap `vX.Y.Z` and the highlights. All counts are **58**; all benchmark
 figures come from [`BENCHMARKS.md`](../../BENCHMARKS.md) (quote **~16×** for a realistic
 DB→DB move, **~96×** as the CSV→JSONL upper bound — never the ~96× alone).
 
 ### Elevator pitch (one-liner — use everywhere)
 
 > **faucet-stream** — the fast, config-driven way to move data in Rust. A data-movement
-> platform with 49 source and sink connectors for ETL, CDC, and streaming, run from a YAML
+> platform with 58 source and sink connectors for ETL, CDC, and streaming, run from a YAML
 > file by a single binary or embedded as a Rust library.
 
 ### Release thread (X / Bluesky / Mastodon / LinkedIn)

--- a/docs/launch/blog-post.md
+++ b/docs/launch/blog-post.md
@@ -31,13 +31,30 @@ pipeline from Rust with typed `Source`/`Sink` traits.
 
 ## What's in the box
 
-- **49 connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
-  Postgres CDC, S3/GCS, Parquet, MongoDB, Redis, Elasticsearch, BigQuery, and
-  Snowflake.
+- **58 connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
+  Postgres/MySQL/Mongo/SQL-Server CDC, S3/GCS/Azure, Parquet/Delta/Iceberg,
+  MongoDB, Redis, Elasticsearch, BigQuery, Snowflake, Databricks, and more.
+- **Bring your existing Singer taps.** The `singer` source runs any Singer/Meltano
+  tap unchanged, so you can adopt faucet incrementally and switch to native
+  connectors where throughput matters. It's an experimental v0 bridge — single
+  stream, and a bridged tap still runs its own Python process — but it drops the
+  switching cost from *rewrite your pipeline* to *point faucet at the tap you
+  already run*.
 - **A real runtime, not just connectors:** native streaming with bounded memory,
-  incremental + resumable replication, change-data-capture, dead-letter queues,
-  automatic retries, and built-in Prometheus metrics + `tracing` spans — with
-  zero per-connector code.
+  incremental + resumable replication, change-data-capture, effectively-once
+  delivery, dead-letter queues, automatic retries, and built-in Prometheus
+  metrics + `tracing` spans — with zero per-connector code.
+- **Fast, and honest about it.** On a reproducible 1M-row CSV→JSONL move faucet
+  sustains 712k rows/s in 11.8 MiB of RAM (~96× faster, ~62× less memory than
+  Meltano, exact row parity); sink-bound moves like Postgres→Postgres narrow the
+  gap toward ~16×. The harness is `make bench` — see
+  [`BENCHMARKS.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)
+  for the methodology and the caveats.
+- **A connector marketplace you can trust.** Every connector is graded against the
+  [Faucet Connector Protocol](https://pawansikawat.github.io/faucet-stream/spec/faucet-connector-spec-v0.html)
+  by a conformance battery — valid config schema, bounded-memory streaming,
+  bookmark round-trip, idempotent replay, truthful capabilities, errors-not-panics
+  — that runs in CI and sets each connector's maturity tier.
 - **Config-driven *or* embeddable:** the CLI and the library are the same engine.
 - **Pay only for what you compile:** every connector is a Cargo feature.
 
@@ -66,6 +83,8 @@ already run — without standing up a platform — that's exactly what we built.
 - Docs: <https://pawansikawat.github.io/faucet-stream/>
 - Source: <https://github.com/PawanSikawat/faucet-stream>
 - Crates: <https://crates.io/crates/faucet-stream>
+- Deep dive: [Exactly-once delivery without a broker](https://github.com/PawanSikawat/faucet-stream/blob/main/docs/blog/exactly-once-without-a-broker.md)
+- Coming from Singer/Meltano? [Migration guide](https://github.com/PawanSikawat/faucet-stream/blob/main/docs/blog/migrating-from-meltano.md)
 
 It's pre-1.0 and moving fast. Connector requests and contributions welcome —
 there's a [contributing guide](https://github.com/PawanSikawat/faucet-stream/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
Follow-up to the Tier-0 PR (#401), covering the in-repo Tier-1 + Tier-2 items from the ranking of epic **#91** / playbook **#314**.

## Key finding first

Nearly all the in-repo TR1/TR2 content **already exists**: every `vs.` comparison page, the SEO head tags + per-page meta injection + generated `sitemap.xml`, an Airflow/Dagster+dbt orchestration cookbook, a Tier-1 engineering deep-dive (`docs/blog/exactly-once-without-a-broker.md`), and the Tier-2 migration guide (`docs/blog/migrating-from-meltano.md`). So this is **not net-new content** — it's reconciling those artifacts' staleness and threading the three positioning levers (Singer on-ramp / honest benchmark / FCP marketplace) through them, consistent with the Tier-0 hero edits.

## Changes (all docs-only)

- **`docs/launch/blog-post.md`** — the stale launch-announcement draft: `49 → 58` connectors; "What's in the box" now leads with the Singer on-ramp, the benchmark (with the CSV-best-case / DB→DB caveats), and the FCP conformance-graded marketplace; links the deep-dive + migration guide.
- **`docs/launch/README.md`** — `49 → 58` across the crates.io / TWiR / Show HN / r/rust blurbs; crates.io + Show HN copy now mention the run-your-Singer-taps on-ramp.
- **`docs/launch/RELEASE_PUBLICITY.md`** — the last stale "49 connectors" blurb.
- **`docs/blog/migrating-from-meltano.md`** — `49 → 58`; footer `28/21 → 33/25`; adds the experimental `singer` bridge as a zero-rewrite stepping stone for taps with no native connector (honest about v0 / single-stream / Python).
- **`docs/blog/exactly-once-without-a-broker.md`** — footer `28/21 → 33/25`.

Every connector count now matches the tree (**58 — 33 sources / 25 sinks**) across README, docs-site, launch kit, and blog.

## Not in this PR
- **Tier-3** = filing *GitHub issues* (good-first-issue connector tickets), which can't live in a PR — I'll file those separately with `gh`.
- The **launch burst** itself (posting to r/rust, Show HN, etc.) is maintainer-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)