### PR TITLE
feat(connectors): DuckDB, SQS, NATS, SFTP pairs + Airtable REST recipe (#410–#414)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,10 @@ jobs:
           - source-clickhouse
           - source-azure-blob
           - source-sqlite
+          - source-duckdb
+          - source-sqs
+          - source-nats
+          - source-sftp
           - source-s3
           - source-mongodb
           - source-mongodb-cdc
@@ -207,6 +211,10 @@ jobs:
           - sink-mysql
           - sink-mssql
           - sink-sqlite
+          - sink-duckdb
+          - sink-sqs
+          - sink-nats
+          - sink-sftp
           - sink-s3
           - sink-mongodb
           - sink-redis

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docs/superpowers/
 # CI-invoked docs helpers (tracked; must not be ignored or cargo/release-plz's
 # working-tree dirty check fails on "tracked but ignored" files).
 !/scripts/check-doc-counts.sh
+!/scripts/sync-doc-counts.py
 !/scripts/inject-page-meta.py
 
 # Benchmark generated artifacts (harness + configs are tracked; outputs are not)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -58,6 +59,7 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -257,6 +259,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.3.0",
+ "password-hash",
 ]
 
 [[package]]
@@ -815,6 +829,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83a251fa1a4c9d0fe6e816b7acd60549e473e08d14f27a1d992c2675abff05f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.10.1",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1179,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-sqs"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52add2841d4ed9995145a0e87e53f6731b88cf643b77bcbe1cad726ce8307e5a"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.4.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sso"
 version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,13 +1289,13 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
- "p256",
+ "p256 0.13.2",
  "percent-encoding",
  "sha2 0.11.0",
  "subtle",
@@ -1732,7 +1808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand 2.4.1",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "tokio",
 ]
 
@@ -1741,6 +1817,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -1799,6 +1881,17 @@ dependencies = [
  "tiberius",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.13.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1885,12 +1978,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1900,6 +2002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1908,7 +2011,26 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+dependencies = [
+ "byteorder",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2263,6 +2385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,8 +2424,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2367,6 +2500,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "crypto-common 0.2.2",
  "inout 0.2.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -2808,8 +2942,25 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2820,7 +2971,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -2832,6 +2983,16 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.5",
  "rand_core 0.10.1",
 ]
 
@@ -2915,6 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -2927,7 +3089,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -3050,6 +3229,17 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "deltae"
@@ -3200,7 +3390,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -3299,6 +3500,15 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3468,12 +3678,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3482,8 +3707,18 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -3492,10 +3727,27 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -3515,17 +3767,39 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "hkdf 0.12.4",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -3567,6 +3841,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3828,6 +4114,9 @@ dependencies = [
  "dashmap",
  "dotenvy",
  "faucet-auth",
+ "faucet-common-nats",
+ "faucet-common-sftp",
+ "faucet-common-sqs",
  "faucet-core",
  "faucet-lineage",
  "faucet-sink-azure-blob",
@@ -3835,6 +4124,7 @@ dependencies = [
  "faucet-sink-clickhouse",
  "faucet-sink-csv",
  "faucet-sink-delta",
+ "faucet-sink-duckdb",
  "faucet-sink-elasticsearch",
  "faucet-sink-gcs",
  "faucet-sink-http",
@@ -3845,15 +4135,18 @@ dependencies = [
  "faucet-sink-mongodb",
  "faucet-sink-mssql",
  "faucet-sink-mysql",
+ "faucet-sink-nats",
  "faucet-sink-parquet",
  "faucet-sink-postgres",
  "faucet-sink-pubsub",
  "faucet-sink-redis",
  "faucet-sink-redshift",
  "faucet-sink-s3",
+ "faucet-sink-sftp",
  "faucet-sink-snowflake",
  "faucet-sink-spanner",
  "faucet-sink-sqlite",
+ "faucet-sink-sqs",
  "faucet-sink-stdout",
  "faucet-source-azure-blob",
  "faucet-source-bigquery",
@@ -3861,6 +4154,7 @@ dependencies = [
  "faucet-source-csv",
  "faucet-source-databricks",
  "faucet-source-delta",
+ "faucet-source-duckdb",
  "faucet-source-elasticsearch",
  "faucet-source-gcs",
  "faucet-source-graphql",
@@ -3873,6 +4167,7 @@ dependencies = [
  "faucet-source-mssql-cdc",
  "faucet-source-mysql",
  "faucet-source-mysql-cdc",
+ "faucet-source-nats",
  "faucet-source-parquet",
  "faucet-source-postgres",
  "faucet-source-postgres-cdc",
@@ -3881,10 +4176,12 @@ dependencies = [
  "faucet-source-redshift",
  "faucet-source-rest",
  "faucet-source-s3",
+ "faucet-source-sftp",
  "faucet-source-singer",
  "faucet-source-snowflake",
  "faucet-source-spanner",
  "faucet-source-sqlite",
+ "faucet-source-sqs",
  "faucet-source-webhook",
  "faucet-source-websocket",
  "faucet-source-xml",
@@ -4065,6 +4362,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-common-nats"
+version = "1.0.0"
+dependencies = [
+ "async-nats",
+ "faucet-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "faucet-common-pubsub"
 version = "1.0.0"
 dependencies = [
@@ -4092,13 +4401,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-common-sftp"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "faucet-core",
+ "russh",
+ "russh-sftp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-common-snowflake"
 version = "1.0.6"
 dependencies = [
  "base64 0.22.1",
  "faucet-core",
  "jsonwebtoken 9.3.1",
- "rsa",
+ "rsa 0.9.10",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4119,6 +4443,21 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "faucet-common-sqs"
+version = "1.0.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-sqs",
+ "faucet-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4297,6 +4636,22 @@ dependencies = [
  "faucet-core",
  "faucet-source-delta",
  "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-sink-duckdb"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "duckdb",
+ "faucet-conformance",
+ "faucet-core",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4517,6 +4872,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-sink-nats"
+version = "1.0.0"
+dependencies = [
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "faucet-common-nats",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-sink-parquet"
 version = "1.1.5"
 dependencies = [
@@ -4641,6 +5016,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-sink-sftp"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "faucet-common-sftp",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "russh-sftp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "testcontainers",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "faucet-sink-snowflake"
 version = "1.3.0"
 dependencies = [
@@ -4698,6 +5093,26 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-sink-sqs"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "aws-sdk-sqs",
+ "faucet-common-sqs",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tracing",
 ]
@@ -4836,6 +5251,25 @@ dependencies = [
  "futures",
  "object_store",
  "parquet 58.3.0",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-source-duckdb"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "duckdb",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -5111,6 +5545,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-nats"
+version = "1.0.0"
+dependencies = [
+ "async-nats",
+ "async-stream",
+ "async-trait",
+ "faucet-common-nats",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-source-parquet"
 version = "1.2.3"
 dependencies = [
@@ -5296,6 +5750,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-sftp"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "faucet-common-sftp",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "testcontainers",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-source-singer"
 version = "1.1.1"
 dependencies = [
@@ -5372,6 +5845,27 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-source-sqs"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "aws-sdk-sqs",
+ "faucet-common-sqs",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tracing",
 ]
@@ -5470,10 +5964,13 @@ dependencies = [
  "faucet-common-gcs",
  "faucet-common-kafka",
  "faucet-common-kinesis",
+ "faucet-common-nats",
  "faucet-common-pubsub",
  "faucet-common-redshift",
+ "faucet-common-sftp",
  "faucet-common-snowflake",
  "faucet-common-spanner",
+ "faucet-common-sqs",
  "faucet-core",
  "faucet-lineage",
  "faucet-sink-azure-blob",
@@ -5481,6 +5978,7 @@ dependencies = [
  "faucet-sink-clickhouse",
  "faucet-sink-csv",
  "faucet-sink-delta",
+ "faucet-sink-duckdb",
  "faucet-sink-elasticsearch",
  "faucet-sink-gcs",
  "faucet-sink-http",
@@ -5491,15 +5989,18 @@ dependencies = [
  "faucet-sink-mongodb",
  "faucet-sink-mssql",
  "faucet-sink-mysql",
+ "faucet-sink-nats",
  "faucet-sink-parquet",
  "faucet-sink-postgres",
  "faucet-sink-pubsub",
  "faucet-sink-redis",
  "faucet-sink-redshift",
  "faucet-sink-s3",
+ "faucet-sink-sftp",
  "faucet-sink-snowflake",
  "faucet-sink-spanner",
  "faucet-sink-sqlite",
+ "faucet-sink-sqs",
  "faucet-sink-stdout",
  "faucet-source-azure-blob",
  "faucet-source-bigquery",
@@ -5507,6 +6008,7 @@ dependencies = [
  "faucet-source-csv",
  "faucet-source-databricks",
  "faucet-source-delta",
+ "faucet-source-duckdb",
  "faucet-source-elasticsearch",
  "faucet-source-gcs",
  "faucet-source-graphql",
@@ -5519,6 +6021,7 @@ dependencies = [
  "faucet-source-mssql-cdc",
  "faucet-source-mysql",
  "faucet-source-mysql-cdc",
+ "faucet-source-nats",
  "faucet-source-parquet",
  "faucet-source-postgres",
  "faucet-source-postgres-cdc",
@@ -5527,10 +6030,12 @@ dependencies = [
  "faucet-source-redshift",
  "faucet-source-rest",
  "faucet-source-s3",
+ "faucet-source-sftp",
  "faucet-source-singer",
  "faucet-source-snowflake",
  "faucet-source-spanner",
  "faucet-source-sqlite",
+ "faucet-source-sqs",
  "faucet-source-webhook",
  "faucet-source-websocket",
  "faucet-source-xml",
@@ -5583,10 +6088,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -6046,6 +6567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb130435a959a8d525e6bca66ff6c40981a300ee96d70e3ef56f046556d614a3"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6090,11 +6622,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6117,6 +6651,18 @@ name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -6352,8 +6898,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -6489,6 +7046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6553,6 +7116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -6677,11 +7249,14 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "ctutils",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -7208,8 +7783,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
- "generic-array",
+ "block-padding 0.3.3",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -7218,6 +7793,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -7270,6 +7846,18 @@ checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 dependencies = [
  "async-trait",
  "tokio",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7514,19 +8102,19 @@ checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac 0.12.1",
  "js-sys",
- "p256",
- "p384",
+ "p256 0.13.2",
+ "p384 0.13.1",
  "pem",
  "rand 0.8.6",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -7540,6 +8128,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7878,7 +8486,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -8142,6 +8750,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "moka"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8201,7 +8834,7 @@ dependencies = [
  "md-5 0.10.6",
  "mongocrypt",
  "mongodb-internal-macros",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "percent-encoding",
  "rand 0.9.4",
  "rustc_version_runtime",
@@ -8415,6 +9048,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519 2.2.3",
+ "ed25519-dalek 2.2.0",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.6",
+ "signatory",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8464,6 +9124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -8946,10 +9615,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -8958,10 +9640,38 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "fiat-crypto 0.3.0",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
+dependencies = [
+ "base16ct 1.0.0",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -8972,6 +9682,26 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+dependencies = [
+ "base16ct 1.0.0",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "windows",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9125,6 +9855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9138,6 +9877,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -9155,6 +9904,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -9254,6 +10012,16 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -9405,9 +10173,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -9417,12 +10195,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes 0.8.4",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
+ "cbc 0.1.2",
+ "der 0.7.10",
+ "pbkdf2 0.12.2",
+ "scrypt 0.11.0",
  "sha2 0.10.9",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes 0.9.1",
+ "aes-gcm",
+ "cbc 0.2.1",
+ "der 0.8.1",
+ "pbkdf2 0.13.0",
+ "rand_core 0.10.1",
+ "scrypt 0.12.0",
+ "sha2 0.11.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -9431,10 +10226,22 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "pkcs5",
+ "der 0.7.10",
+ "pkcs5 0.7.1",
  "rand_core 0.6.4",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "pkcs5 0.8.1",
+ "rand_core 0.10.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -9448,6 +10255,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash",
+ "zeroize",
+]
 
 [[package]]
 name = "polyval"
@@ -9575,12 +10393,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -10570,7 +11415,7 @@ dependencies = [
  "quick-xml 0.37.5",
  "rand 0.8.6",
  "reqwest 0.12.28",
- "rsa",
+ "rsa 0.9.10",
  "rust-ini",
  "serde",
  "serde_json",
@@ -10688,6 +11533,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10780,14 +11635,149 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+dependencies = [
+ "aes 0.9.1",
+ "aws-lc-rs",
+ "bitflags 2.13.0",
+ "block-padding 0.4.2",
+ "byteorder",
+ "bytes",
+ "cbc 0.2.1",
+ "cipher 0.5.2",
+ "crypto-bigint 0.7.5",
+ "ctr",
+ "curve25519-dalek 5.0.0",
+ "data-encoding",
+ "delegate",
+ "der 0.8.1",
+ "digest 0.11.3",
+ "ecdsa 0.17.0",
+ "ed25519-dalek 3.0.0",
+ "elliptic-curve 0.14.1",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.2",
+ "getrandom 0.4.2",
+ "ghash",
+ "hex-literal",
+ "hmac 0.13.0",
+ "inout 0.2.2",
+ "internal-russh-num-bigint",
+ "keccak",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256 0.14.0",
+ "p384 0.14.0",
+ "p521",
+ "pageant",
+ "pbkdf2 0.13.0",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs5 0.8.1",
+ "pkcs8 0.11.0",
+ "polyval",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "rsa 0.10.0-rc.18",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20 0.11.0",
+ "scrypt 0.12.0",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
+dependencies = [
+ "log",
+ "nix 0.31.3",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "gloo-timers 0.4.0",
+ "log",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -11060,6 +12050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11159,9 +12159,21 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "pbkdf2",
- "salsa20",
+ "pbkdf2 0.12.2",
+ "salsa20 0.10.2",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20 0.11.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -11192,10 +12204,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -11333,6 +12359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11423,6 +12458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11496,6 +12541,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -11573,6 +12639,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11580,6 +12658,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -11729,8 +12817,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlparser"
@@ -11853,9 +12957,9 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "itoa",
  "log",
@@ -11864,7 +12968,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "sha1 0.10.6",
  "sha2 0.10.9",
@@ -11896,7 +13000,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "home",
  "itoa",
@@ -11942,6 +13046,65 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
+dependencies = [
+ "aead",
+ "aes 0.9.1",
+ "aes-gcm",
+ "chacha20",
+ "cipher 0.5.2",
+ "ctutils",
+ "des",
+ "poly1305",
+ "ssh-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "crypto-bigint 0.7.5",
+ "ctutils",
+ "digest 0.11.3",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.7.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek 3.0.0",
+ "hex",
+ "hmac 0.13.0",
+ "p256 0.14.0",
+ "p384 0.14.0",
+ "p521",
+ "rand_core 0.10.1",
+ "rsa 0.10.0-rc.18",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -12229,7 +13392,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -12601,8 +13764,30 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "httparse",
+ "rand 0.8.6",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12891,6 +14076,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tungstenite"
@@ -13333,7 +14528,7 @@ dependencies = [
  "metainfo",
  "motore",
  "mur3",
- "nix",
+ "nix 0.29.0",
  "once_cell",
  "pin-project",
  "rand 0.9.4",
@@ -13774,6 +14969,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13784,6 +15000,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -13813,6 +15040,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -13925,6 +15162,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -14192,6 +15438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14319,18 +15576,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,17 @@ members = [
     "crates/sink/pubsub",
     "crates/sink/clickhouse",
     "crates/sink/azure-blob",
+    "crates/source/duckdb",
+    "crates/sink/duckdb",
+    "crates/common/sqs",
+    "crates/source/sqs",
+    "crates/sink/sqs",
+    "crates/common/nats",
+    "crates/source/nats",
+    "crates/sink/nats",
+    "crates/common/sftp",
+    "crates/source/sftp",
+    "crates/sink/sftp",
     "crates/state/redis",
     "crates/state/postgres",
     "faucet-stream",
@@ -181,6 +192,17 @@ faucet-sink-clickhouse = { path = "crates/sink/clickhouse", version = "1.0.0" }
 faucet-common-azure = { path = "crates/common/azure", version = "1.0.0" }
 faucet-source-azure-blob = { path = "crates/source/azure-blob", version = "1.0.0" }
 faucet-sink-azure-blob = { path = "crates/sink/azure-blob", version = "1.0.0" }
+faucet-source-duckdb = { path = "crates/source/duckdb", version = "1.0.0" }
+faucet-sink-duckdb = { path = "crates/sink/duckdb", version = "1.0.0" }
+faucet-common-sqs = { path = "crates/common/sqs", version = "1.0.0" }
+faucet-source-sqs = { path = "crates/source/sqs", version = "1.0.0" }
+faucet-sink-sqs = { path = "crates/sink/sqs", version = "1.0.0" }
+faucet-common-nats = { path = "crates/common/nats", version = "1.0.0" }
+faucet-source-nats = { path = "crates/source/nats", version = "1.0.0" }
+faucet-sink-nats = { path = "crates/sink/nats", version = "1.0.0" }
+faucet-common-sftp = { path = "crates/common/sftp", version = "1.0.0" }
+faucet-source-sftp = { path = "crates/source/sftp", version = "1.0.0" }
+faucet-sink-sftp = { path = "crates/sink/sftp", version = "1.0.0" }
 faucet-source-mssql-cdc = { path = "crates/source/mssql-cdc", version = "1.0.0" }
 
 # Shared external deps
@@ -245,8 +267,14 @@ gcloud-pubsub = { version = "1", default-features = false, features = ["auth", "
 gcloud-auth = { version = "1", default-features = false, features = ["rustls-tls", "jwt-rust-crypto"] }
 aws-sdk-kinesis = "1"
 aws-sdk-s3 = "1"
+aws-sdk-sqs = "1"
 aws-sdk-secretsmanager = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
+# NATS (JetStream-capable async client) for the nats source/sink pair.
+async-nats = "0.50"
+# SFTP over SSH (pure-Rust) for the sftp source/sink pair.
+russh = "0.62"
+russh-sftp = "2"
 azure_security_keyvault_secrets = "1"
 azure_identity = "1"
 azure_core = "1"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 ~62× less memory than Meltano**, output identical row-for-row ([see the benchmarks](BENCHMARKS.md)).
 No Python runtime, no platform to stand up, no daemon to babysit.
 
-faucet-stream is a **data-movement platform** for Rust — with governance built in: **37 source**
-and **29 sink** connectors (**66 in total**) plus in-flight transforms, including a page-level
+faucet-stream is a **data-movement platform** for Rust — with governance built in: **<!--COUNT:sources-->37<!--/COUNT--> source**
+and **<!--COUNT:sinks-->29<!--/COUNT--> sink** connectors (**<!--COUNT:connectors-->66<!--/COUNT--> in total**) plus in-flight transforms, including a page-level
 embedded-DuckDB `sql` transform — wired by a single `faucet` binary that runs pipelines
 declaratively from YAML/JSON (no Rust code required), or embedded in your own service through
 the typed `Source` / `Sink` traits. One platform, whether you want a CLI you can drop on any
@@ -68,7 +68,7 @@ cargo add faucet-stream           # the library
   sink sees a row), schema-drift detection & policy, column-level lineage (OpenLineage) + a
   data-movement catalog, and freshness/volume SLA monitoring.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
-  be just REST + JSONL, or pull in all 58 connectors with `--features full`.
+  be just REST + JSONL, or pull in all <!--COUNT:connectors-->66<!--/COUNT--> connectors with `--features full`.
 
 **Documentation:** the [faucet-stream guide](https://pawansikawat.github.io/faucet-stream/)
 (getting started, tutorials, cookbook, operations) · API reference on
@@ -485,7 +485,7 @@ flowchart LR
     class K sink
 ```
 
-faucet-stream is a Cargo workspace with **91 crates** — 37 sources, 29 sinks, 16 shared
+faucet-stream is a Cargo workspace with **<!--COUNT:crates-->91<!--/COUNT--> crates** — <!--COUNT:sources-->37<!--/COUNT--> sources, <!--COUNT:sinks-->29<!--/COUNT--> sinks, <!--COUNT:common-->16<!--/COUNT--> shared
 connector libraries, the shared auth-provider library, 2 state-store backends, the lineage
 crate, the SQL transform crate, the conformance test battery, the shared core, the umbrella
 crate, and the CLI binary. See
@@ -847,13 +847,13 @@ and the runnable [`cli/examples/custom-cli/`](cli/examples/custom-cli/main.rs).
 ## Project structure
 
 ```
-Cargo.toml                    — workspace manifest (91 crates)
+Cargo.toml                    — workspace manifest (<!--COUNT:crates-->91<!--/COUNT--> crates)
 crates/
   core/                       — faucet-core: shared types, traits, pipeline, transforms, config
   auth/                       — faucet-auth: shared OAuth2 / token-endpoint providers
-  source/                     — 37 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, azure-blob, redshift, clickhouse, pubsub, delta, databricks, singer, duckdb, sqs, nats, sftp, …)
-  sink/                       — 29 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, redshift, clickhouse, pubsub, azure-blob, duckdb, sqs, nats, sftp, …)
-  common/                     — 16 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql, kinesis, spanner, delta, redshift, pubsub, clickhouse, azure, sqs, nats, sftp)
+  source/                     — <!--COUNT:sources-->37<!--/COUNT--> source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, azure-blob, redshift, clickhouse, pubsub, delta, databricks, singer, duckdb, sqs, nats, sftp, …)
+  sink/                       — <!--COUNT:sinks-->29<!--/COUNT--> sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, redshift, clickhouse, pubsub, azure-blob, duckdb, sqs, nats, sftp, …)
+  common/                     — <!--COUNT:common-->16<!--/COUNT--> shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql, kinesis, spanner, delta, redshift, pubsub, clickhouse, azure, sqs, nats, sftp)
   state/                      — Redis- and Postgres-backed StateStore backends
   lineage/                    — faucet-lineage: OpenLineage event emission
   transform-sql/              — faucet-transform-sql: embedded DuckDB SQL transform

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 ~62× less memory than Meltano**, output identical row-for-row ([see the benchmarks](BENCHMARKS.md)).
 No Python runtime, no platform to stand up, no daemon to babysit.
 
-faucet-stream is a **data-movement platform** for Rust — with governance built in: **33 source**
-and **25 sink** connectors (**58 in total**) plus in-flight transforms, including a page-level
+faucet-stream is a **data-movement platform** for Rust — with governance built in: **37 source**
+and **29 sink** connectors (**66 in total**) plus in-flight transforms, including a page-level
 embedded-DuckDB `sql` transform — wired by a single `faucet` binary that runs pipelines
 declaratively from YAML/JSON (no Rust code required), or embedded in your own service through
 the typed `Source` / `Sink` traits. One platform, whether you want a CLI you can drop on any
@@ -270,6 +270,10 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-mssql`](crates/source/mssql) | T1 ✅ | Microsoft SQL Server — streaming queries, incremental replication |
 | [`faucet-source-mssql-cdc`](crates/source/mssql-cdc) | T1 ✅ | Microsoft SQL Server CDC — change tables (`fn_cdc_get_all_changes`), LSN bookmarks, resumable |
 | [`faucet-source-sqlite`](crates/source/sqlite) | **T1 ✅** | SQLite — run SQL queries, return rows as JSON |
+| [`faucet-source-duckdb`](crates/source/duckdb) | T2 | DuckDB — run SQL against a file or `:memory:` database, stream rows as JSON |
+| [`faucet-source-sqs`](crates/source/sqs) | T2 | AWS SQS — long-poll receive, delete-after-emit (at-least-once), idle/max termination |
+| [`faucet-source-nats`](crates/source/nats) | T2 | NATS — subject subscription or JetStream consumer; idle/max termination |
+| [`faucet-source-sftp`](crates/source/sftp) | T2 | SFTP — list/glob a remote directory over SSH; JSONL / JSON array / raw text |
 | [`faucet-source-mongodb`](crates/source/mongodb) | T1 ✅ | MongoDB — find() with filter, projection, sort |
 | [`faucet-source-mongodb-cdc`](crates/source/mongodb-cdc) | T1 ✅ | MongoDB CDC — Change Streams, resumable via resumeToken |
 | [`faucet-source-redis`](crates/source/redis) | T1 ✅ | Redis — read from streams, lists, or key patterns |
@@ -303,6 +307,10 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-sink-mysql`](crates/sink/mysql) | T1 ✅ | MySQL — JSON column or auto-mapped columns; upsert/delete |
 | [`faucet-sink-mssql`](crates/sink/mssql) | T1 ✅ | Microsoft SQL Server — JSON or auto-mapped columns, 2100-param split |
 | [`faucet-sink-sqlite`](crates/sink/sqlite) | **T1 ✅** | SQLite — JSON column or auto-mapped columns; upsert/delete; effectively-once |
+| [`faucet-sink-duckdb`](crates/sink/duckdb) | T2 | DuckDB — transaction-wrapped multi-row INSERT (JSON column or auto-mapped); append-only |
+| [`faucet-sink-sqs`](crates/sink/sqs) | T2 | AWS SQS — batched SendMessageBatch with per-entry retry; FIFO group/dedup |
+| [`faucet-sink-nats`](crates/sink/nats) | T2 | NATS — publish records to a subject (optional subject-per-record), flush per batch |
+| [`faucet-sink-sftp`](crates/sink/sftp) | T2 | SFTP — write JSONL files over SSH with atomic temp-then-rename |
 | [`faucet-sink-snowflake`](crates/sink/snowflake) | T2 | Snowflake — SQL REST API with JWT/OAuth |
 | [`faucet-sink-redshift`](crates/sink/redshift) | T1 ✅ | Amazon Redshift — COPY-from-S3 (staged) or multi-row `INSERT`; append-only |
 | [`faucet-sink-clickhouse`](crates/sink/clickhouse) | T1 ✅ | ClickHouse — `INSERT … FORMAT JSONEachRow`; optional `async_insert`; append-only |
@@ -477,7 +485,7 @@ flowchart LR
     class K sink
 ```
 
-faucet-stream is a Cargo workspace with **80 crates** — 33 sources, 25 sinks, 13 shared
+faucet-stream is a Cargo workspace with **91 crates** — 37 sources, 29 sinks, 16 shared
 connector libraries, the shared auth-provider library, 2 state-store backends, the lineage
 crate, the SQL transform crate, the conformance test battery, the shared core, the umbrella
 crate, and the CLI binary. See
@@ -531,6 +539,10 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `source-mssql` | no | Microsoft SQL Server query source |
 | `source-mssql-cdc` | no | Microsoft SQL Server CDC source (change tables) |
 | `source-sqlite` | no | SQLite query source |
+| `source-duckdb` | no | DuckDB query source |
+| `source-sqs` | no | AWS SQS source |
+| `source-nats` | no | NATS source |
+| `source-sftp` | no | SFTP source |
 | `source-mongodb` | no | MongoDB query source |
 | `source-mongodb-cdc` | no | MongoDB CDC source (Change Streams) |
 | `source-redis` | no | Redis source |
@@ -559,6 +571,10 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `sink-mysql` | no | MySQL sink |
 | `sink-mssql` | no | Microsoft SQL Server sink |
 | `sink-sqlite` | no | SQLite sink |
+| `sink-duckdb` | no | DuckDB sink |
+| `sink-sqs` | no | AWS SQS sink |
+| `sink-nats` | no | NATS sink |
+| `sink-sftp` | no | SFTP sink |
 | `sink-snowflake` | no | Snowflake sink |
 | `sink-redshift` | no | Amazon Redshift sink (COPY-from-S3 or multi-row INSERT) |
 | `sink-clickhouse` | no | ClickHouse sink (INSERT … FORMAT JSONEachRow) |
@@ -831,13 +847,13 @@ and the runnable [`cli/examples/custom-cli/`](cli/examples/custom-cli/main.rs).
 ## Project structure
 
 ```
-Cargo.toml                    — workspace manifest (80 crates)
+Cargo.toml                    — workspace manifest (91 crates)
 crates/
   core/                       — faucet-core: shared types, traits, pipeline, transforms, config
   auth/                       — faucet-auth: shared OAuth2 / token-endpoint providers
-  source/                     — 33 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, azure-blob, redshift, clickhouse, pubsub, delta, databricks, singer, …)
-  sink/                       — 25 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, redshift, clickhouse, pubsub, azure-blob, …)
-  common/                     — 13 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql, kinesis, spanner, delta, redshift, pubsub, clickhouse, azure)
+  source/                     — 37 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, azure-blob, redshift, clickhouse, pubsub, delta, databricks, singer, duckdb, sqs, nats, sftp, …)
+  sink/                       — 29 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, redshift, clickhouse, pubsub, azure-blob, duckdb, sqs, nats, sftp, …)
+  common/                     — 16 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql, kinesis, spanner, delta, redshift, pubsub, clickhouse, azure, sqs, nats, sftp)
   state/                      — Redis- and Postgres-backed StateStore backends
   lineage/                    — faucet-lineage: OpenLineage event emission
   transform-sql/              — faucet-transform-sql: embedded DuckDB SQL transform

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,10 @@ source = [
     "source-mysql",
     "source-mssql",
     "source-sqlite",
+    "source-duckdb",
+    "source-sqs",
+    "source-nats",
+    "source-sftp",
     "source-s3",
     "source-mongodb",
     "source-mongodb-cdc",
@@ -104,6 +108,10 @@ sink = [
     "sink-mysql",
     "sink-mssql",
     "sink-sqlite",
+    "sink-duckdb",
+    "sink-sqs",
+    "sink-nats",
+    "sink-sftp",
     "sink-s3",
     "sink-mongodb",
     "sink-redis",
@@ -134,6 +142,10 @@ source-postgres-cdc = ["dep:faucet-source-postgres-cdc"]
 source-mysql = ["dep:faucet-source-mysql"]
 source-mssql = ["dep:faucet-source-mssql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
+source-duckdb = ["dep:faucet-source-duckdb"]
+source-sqs = ["dep:faucet-source-sqs", "dep:faucet-common-sqs"]
+source-nats = ["dep:faucet-source-nats", "dep:faucet-common-nats"]
+source-sftp = ["dep:faucet-source-sftp", "dep:faucet-common-sftp"]
 source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
 source-mongodb-cdc = ["dep:faucet-source-mongodb-cdc"]
@@ -167,6 +179,10 @@ sink-snowflake = ["dep:faucet-sink-snowflake"]
 sink-mysql = ["dep:faucet-sink-mysql"]
 sink-mssql = ["dep:faucet-sink-mssql"]
 sink-sqlite = ["dep:faucet-sink-sqlite"]
+sink-duckdb = ["dep:faucet-sink-duckdb"]
+sink-sqs = ["dep:faucet-sink-sqs", "dep:faucet-common-sqs"]
+sink-nats = ["dep:faucet-sink-nats", "dep:faucet-common-nats"]
+sink-sftp = ["dep:faucet-sink-sftp", "dep:faucet-common-sftp"]
 sink-s3 = ["dep:faucet-sink-s3"]
 sink-mongodb = ["dep:faucet-sink-mongodb"]
 sink-redis = ["dep:faucet-sink-redis"]
@@ -340,6 +356,13 @@ faucet-source-postgres-cdc = { workspace = true, optional = true }
 faucet-source-mysql = { workspace = true, optional = true }
 faucet-source-mssql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
+faucet-source-duckdb = { workspace = true, optional = true }
+faucet-source-sqs = { workspace = true, optional = true }
+faucet-common-sqs = { workspace = true, optional = true }
+faucet-source-nats = { workspace = true, optional = true }
+faucet-common-nats = { workspace = true, optional = true }
+faucet-source-sftp = { workspace = true, optional = true }
+faucet-common-sftp = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
 faucet-source-mongodb-cdc = { workspace = true, optional = true }
@@ -372,6 +395,10 @@ faucet-sink-snowflake = { workspace = true, optional = true }
 faucet-sink-mysql = { workspace = true, optional = true }
 faucet-sink-mssql = { workspace = true, optional = true }
 faucet-sink-sqlite = { workspace = true, optional = true }
+faucet-sink-duckdb = { workspace = true, optional = true }
+faucet-sink-sqs = { workspace = true, optional = true }
+faucet-sink-nats = { workspace = true, optional = true }
+faucet-sink-sftp = { workspace = true, optional = true }
 faucet-sink-s3 = { workspace = true, optional = true }
 faucet-sink-mongodb = { workspace = true, optional = true }
 faucet-sink-redis = { workspace = true, optional = true }

--- a/cli/connectors/registry.json
+++ b/cli/connectors/registry.json
@@ -1,65 +1,468 @@
 {
   "version": 1,
-  "_comment": "faucet-stream connector registry — the index behind `faucet search` / `faucet install`. Built-in connectors are `verified` and ship in the `faucet` binary (enable with `--features <kind>-<name>`). Community connectors: open a PR adding an entry with `verified: false`, an explicit `crate`, and (optionally) a `feature`; users consume them by building a custom binary (see cli/README.md → Custom binaries with third-party connectors). `crate` defaults to `faucet-<kind>-<name>` and `feature` to `<kind>-<name>` when omitted. `tier` is the connector conformance maturity tier (stable/experimental/beta/draft, #330); for verified built-ins it is validated against the score computed by `faucet conformance` (see the `builtin_tiers_match_conformance` test), so it never drifts from the code.",
+  "_comment": "faucet-stream connector registry \u2014 the index behind `faucet search` / `faucet install`. Built-in connectors are `verified` and ship in the `faucet` binary (enable with `--features <kind>-<name>`). Community connectors: open a PR adding an entry with `verified: false`, an explicit `crate`, and (optionally) a `feature`; users consume them by building a custom binary (see cli/README.md \u2192 Custom binaries with third-party connectors). `crate` defaults to `faucet-<kind>-<name>` and `feature` to `<kind>-<name>` when omitted. `tier` is the connector conformance maturity tier (stable/experimental/beta/draft, #330); for verified built-ins it is validated against the score computed by `faucet conformance` (see the `builtin_tiers_match_conformance` test), so it never drifts from the code.",
   "connectors": [
-    { "name": "rest", "kind": "source", "verified": true, "tier": "stable", "description": "REST API source with pagination, auth, transforms" },
-    { "name": "graphql", "kind": "source", "verified": true, "tier": "stable", "description": "GraphQL API source with cursor pagination" },
-    { "name": "xml", "kind": "source", "verified": true, "tier": "stable", "description": "XML / SOAP API source with XML→JSON conversion" },
-    { "name": "grpc", "kind": "source", "verified": true, "tier": "stable", "description": "gRPC source with dynamic protobuf" },
-    { "name": "postgres", "kind": "source", "verified": true, "tier": "stable", "description": "PostgreSQL query source" },
-    { "name": "postgres-cdc", "kind": "source", "verified": true, "tier": "stable", "description": "PostgreSQL CDC source (logical replication)" },
-    { "name": "mysql", "kind": "source", "verified": true, "tier": "stable", "description": "MySQL query source" },
-    { "name": "mysql-cdc", "kind": "source", "verified": true, "tier": "stable", "description": "MySQL CDC source (binlog replication)" },
-    { "name": "mssql-cdc", "kind": "source", "verified": true, "tier": "stable", "description": "Microsoft SQL Server CDC source (change data capture, exactly-once capable)" },
-    { "name": "redshift", "kind": "source", "verified": true, "tier": "stable", "description": "Amazon Redshift query source (PostgreSQL wire; streaming rows, incremental replication)" },
-    { "name": "pubsub", "kind": "source", "verified": true, "tier": "stable", "description": "Google Cloud Pub/Sub consumer with ack at durable page boundaries" },
-    { "name": "clickhouse", "kind": "source", "verified": true, "tier": "stable", "description": "ClickHouse query source (HTTP interface, JSONEachRow streaming)" },
-    { "name": "azure-blob", "kind": "source", "verified": true, "tier": "stable", "description": "Azure Blob Storage / ADLS Gen2 source — JSONL, JSON array, or raw text" },
-    { "name": "mssql", "kind": "source", "verified": true, "tier": "stable", "description": "Microsoft SQL Server query source" },
-    { "name": "sqlite", "kind": "source", "verified": true, "tier": "stable", "description": "SQLite query source" },
-    { "name": "mongodb", "kind": "source", "verified": true, "tier": "stable", "description": "MongoDB query source" },
-    { "name": "mongodb-cdc", "kind": "source", "verified": true, "tier": "stable", "description": "MongoDB CDC source (Change Streams)" },
-    { "name": "s3", "kind": "source", "verified": true, "tier": "stable", "description": "AWS S3 object source" },
-    { "name": "gcs", "kind": "source", "verified": true, "tier": "stable", "description": "Google Cloud Storage source — JSONL, JSON array, or raw text" },
-    { "name": "redis", "kind": "source", "verified": true, "tier": "stable", "description": "Redis (streams, lists, keys) source" },
-    { "name": "webhook", "kind": "source", "verified": true, "tier": "stable", "description": "Webhook HTTP receiver source" },
-    { "name": "websocket", "kind": "source", "verified": true, "tier": "stable", "description": "WebSocket streaming source" },
-    { "name": "csv", "kind": "source", "verified": true, "tier": "stable", "description": "CSV file source" },
-    { "name": "singer", "kind": "source", "verified": true, "tier": "stable", "description": "Singer tap bridge (runs an external Singer tap)" },
-    { "name": "elasticsearch", "kind": "source", "verified": true, "tier": "stable", "description": "Elasticsearch search / scroll source" },
-    { "name": "kafka", "kind": "source", "verified": true, "tier": "stable", "description": "Apache Kafka consumer with idle/max-messages termination" },
-    { "name": "kinesis", "kind": "source", "verified": true, "tier": "stable", "description": "AWS Kinesis Data Streams consumer with per-shard checkpoints" },
-    { "name": "parquet", "kind": "source", "verified": true, "tier": "stable", "description": "Apache Parquet file source (local, glob, or S3)" },
-    { "name": "delta", "kind": "source", "verified": true, "tier": "stable", "description": "Apache Delta Lake source (local FS or S3/Azure/GCS; time travel, projection)" },
-    { "name": "databricks", "kind": "source", "verified": true, "tier": "stable", "description": "Databricks SQL query source (Statement Execution API; typed rows, chunk pagination, incremental)" },
-    { "name": "bigquery", "kind": "source", "verified": true, "tier": "stable", "description": "Google BigQuery query source" },
-    { "name": "snowflake", "kind": "source", "verified": true, "tier": "stable", "description": "Snowflake query source (SQL REST API)" },
-    { "name": "spanner", "kind": "source", "verified": true, "tier": "stable", "description": "Google Cloud Spanner query source (streaming SQL, incremental replication)" },
-
-    { "name": "bigquery", "kind": "sink", "verified": true, "tier": "stable", "description": "Google BigQuery streaming-insert sink" },
-    { "name": "iceberg", "kind": "sink", "verified": true, "tier": "stable", "description": "Apache Iceberg sink (append; REST/Glue/SQL/HMS catalogs)" },
-    { "name": "postgres", "kind": "sink", "verified": true, "tier": "stable", "description": "PostgreSQL sink (JSONB or auto-mapped columns)" },
-    { "name": "jsonl", "kind": "sink", "verified": true, "tier": "stable", "description": "JSON Lines file sink" },
-    { "name": "snowflake", "kind": "sink", "verified": true, "tier": "stable", "description": "Snowflake SQL REST API sink" },
-    { "name": "mysql", "kind": "sink", "verified": true, "tier": "stable", "description": "MySQL sink" },
-    { "name": "mssql", "kind": "sink", "verified": true, "tier": "stable", "description": "Microsoft SQL Server sink" },
-    { "name": "sqlite", "kind": "sink", "verified": true, "tier": "stable", "description": "SQLite sink" },
-    { "name": "s3", "kind": "sink", "verified": true, "tier": "stable", "description": "AWS S3 object sink" },
-    { "name": "gcs", "kind": "sink", "verified": true, "tier": "stable", "description": "Google Cloud Storage sink — JSONL files" },
-    { "name": "mongodb", "kind": "sink", "verified": true, "tier": "stable", "description": "MongoDB insert sink" },
-    { "name": "redis", "kind": "sink", "verified": true, "tier": "stable", "description": "Redis (streams, lists, key-value) sink" },
-    { "name": "csv", "kind": "sink", "verified": true, "tier": "stable", "description": "CSV file sink" },
-    { "name": "elasticsearch", "kind": "sink", "verified": true, "tier": "stable", "description": "Elasticsearch bulk index sink" },
-    { "name": "kafka", "kind": "sink", "verified": true, "tier": "stable", "description": "Apache Kafka producer with QueueFull retry and topic routing" },
-    { "name": "kinesis", "kind": "sink", "verified": true, "tier": "stable", "description": "AWS Kinesis Data Streams producer with partial-failure retry" },
-    { "name": "spanner", "kind": "sink", "verified": true, "tier": "stable", "description": "Google Cloud Spanner mutation sink (upsert/delete, exactly-once)" },
-    { "name": "http", "kind": "sink", "verified": true, "tier": "stable", "description": "HTTP POST sink (individual or array batch)" },
-    { "name": "stdout", "kind": "sink", "verified": true, "tier": "stable", "description": "Stdout / stderr sink (JSON Lines, pretty, TSV)" },
-    { "name": "parquet", "kind": "sink", "verified": true, "tier": "stable", "description": "Apache Parquet file sink (local path or S3)" },
-    { "name": "delta", "kind": "sink", "verified": true, "tier": "stable", "description": "Apache Delta Lake sink (append-only; local FS or S3/Azure/GCS)" },
-    { "name": "redshift", "kind": "sink", "verified": true, "tier": "stable", "description": "Amazon Redshift sink (COPY-from-S3 or multi-row INSERT)" },
-    { "name": "pubsub", "kind": "sink", "verified": true, "tier": "stable", "description": "Google Cloud Pub/Sub producer with ordering keys and partial-failure retry" },
-    { "name": "clickhouse", "kind": "sink", "verified": true, "tier": "stable", "description": "ClickHouse sink (HTTP INSERT … FORMAT JSONEachRow; optional async inserts)" },
-    { "name": "azure-blob", "kind": "sink", "verified": true, "tier": "stable", "description": "Azure Blob Storage / ADLS Gen2 sink — JSONL files" }
+    {
+      "name": "rest",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "REST API source with pagination, auth, transforms"
+    },
+    {
+      "name": "graphql",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "GraphQL API source with cursor pagination"
+    },
+    {
+      "name": "xml",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "XML / SOAP API source with XML\u2192JSON conversion"
+    },
+    {
+      "name": "grpc",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "gRPC source with dynamic protobuf"
+    },
+    {
+      "name": "postgres",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "PostgreSQL query source"
+    },
+    {
+      "name": "postgres-cdc",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "PostgreSQL CDC source (logical replication)"
+    },
+    {
+      "name": "mysql",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "MySQL query source"
+    },
+    {
+      "name": "mysql-cdc",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "MySQL CDC source (binlog replication)"
+    },
+    {
+      "name": "mssql-cdc",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Microsoft SQL Server CDC source (change data capture, exactly-once capable)"
+    },
+    {
+      "name": "redshift",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Amazon Redshift query source (PostgreSQL wire; streaming rows, incremental replication)"
+    },
+    {
+      "name": "pubsub",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google Cloud Pub/Sub consumer with ack at durable page boundaries"
+    },
+    {
+      "name": "clickhouse",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "ClickHouse query source (HTTP interface, JSONEachRow streaming)"
+    },
+    {
+      "name": "azure-blob",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Azure Blob Storage / ADLS Gen2 source \u2014 JSONL, JSON array, or raw text"
+    },
+    {
+      "name": "mssql",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Microsoft SQL Server query source"
+    },
+    {
+      "name": "sqlite",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "SQLite query source"
+    },
+    {
+      "name": "mongodb",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "MongoDB query source"
+    },
+    {
+      "name": "mongodb-cdc",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "MongoDB CDC source (Change Streams)"
+    },
+    {
+      "name": "s3",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "AWS S3 object source"
+    },
+    {
+      "name": "gcs",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google Cloud Storage source \u2014 JSONL, JSON array, or raw text"
+    },
+    {
+      "name": "redis",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Redis (streams, lists, keys) source"
+    },
+    {
+      "name": "webhook",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Webhook HTTP receiver source"
+    },
+    {
+      "name": "websocket",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "WebSocket streaming source"
+    },
+    {
+      "name": "csv",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "CSV file source"
+    },
+    {
+      "name": "singer",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Singer tap bridge (runs an external Singer tap)"
+    },
+    {
+      "name": "elasticsearch",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Elasticsearch search / scroll source"
+    },
+    {
+      "name": "kafka",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Kafka consumer with idle/max-messages termination"
+    },
+    {
+      "name": "kinesis",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "AWS Kinesis Data Streams consumer with per-shard checkpoints"
+    },
+    {
+      "name": "parquet",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Parquet file source (local, glob, or S3)"
+    },
+    {
+      "name": "delta",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Delta Lake source (local FS or S3/Azure/GCS; time travel, projection)"
+    },
+    {
+      "name": "databricks",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Databricks SQL query source (Statement Execution API; typed rows, chunk pagination, incremental)"
+    },
+    {
+      "name": "bigquery",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google BigQuery query source"
+    },
+    {
+      "name": "snowflake",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Snowflake query source (SQL REST API)"
+    },
+    {
+      "name": "spanner",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google Cloud Spanner query source (streaming SQL, incremental replication)"
+    },
+    {
+      "name": "bigquery",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google BigQuery streaming-insert sink"
+    },
+    {
+      "name": "iceberg",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Iceberg sink (append; REST/Glue/SQL/HMS catalogs)"
+    },
+    {
+      "name": "postgres",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "PostgreSQL sink (JSONB or auto-mapped columns)"
+    },
+    {
+      "name": "jsonl",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "JSON Lines file sink"
+    },
+    {
+      "name": "snowflake",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Snowflake SQL REST API sink"
+    },
+    {
+      "name": "mysql",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "MySQL sink"
+    },
+    {
+      "name": "mssql",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Microsoft SQL Server sink"
+    },
+    {
+      "name": "sqlite",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "SQLite sink"
+    },
+    {
+      "name": "s3",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "AWS S3 object sink"
+    },
+    {
+      "name": "gcs",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google Cloud Storage sink \u2014 JSONL files"
+    },
+    {
+      "name": "mongodb",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "MongoDB insert sink"
+    },
+    {
+      "name": "redis",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Redis (streams, lists, key-value) sink"
+    },
+    {
+      "name": "csv",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "CSV file sink"
+    },
+    {
+      "name": "elasticsearch",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Elasticsearch bulk index sink"
+    },
+    {
+      "name": "kafka",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Kafka producer with QueueFull retry and topic routing"
+    },
+    {
+      "name": "kinesis",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "AWS Kinesis Data Streams producer with partial-failure retry"
+    },
+    {
+      "name": "spanner",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google Cloud Spanner mutation sink (upsert/delete, exactly-once)"
+    },
+    {
+      "name": "http",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "HTTP POST sink (individual or array batch)"
+    },
+    {
+      "name": "stdout",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Stdout / stderr sink (JSON Lines, pretty, TSV)"
+    },
+    {
+      "name": "parquet",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Parquet file sink (local path or S3)"
+    },
+    {
+      "name": "delta",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Apache Delta Lake sink (append-only; local FS or S3/Azure/GCS)"
+    },
+    {
+      "name": "redshift",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Amazon Redshift sink (COPY-from-S3 or multi-row INSERT)"
+    },
+    {
+      "name": "pubsub",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Google Cloud Pub/Sub producer with ordering keys and partial-failure retry"
+    },
+    {
+      "name": "clickhouse",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "ClickHouse sink (HTTP INSERT \u2026 FORMAT JSONEachRow; optional async inserts)"
+    },
+    {
+      "name": "azure-blob",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "Azure Blob Storage / ADLS Gen2 sink \u2014 JSONL files"
+    },
+    {
+      "name": "duckdb",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "DuckDB query source (file or in-memory), rows streamed as JSON"
+    },
+    {
+      "name": "duckdb",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "DuckDB sink; transaction-wrapped multi-row INSERT (JSON column or auto-mapped)"
+    },
+    {
+      "name": "sqs",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "AWS SQS source; long-poll ReceiveMessage, delete-after-confirm"
+    },
+    {
+      "name": "sqs",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "AWS SQS sink; batched SendMessageBatch with per-entry retry"
+    },
+    {
+      "name": "nats",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "NATS source; subject/JetStream drain with idle/max termination"
+    },
+    {
+      "name": "nats",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "NATS sink; publish records to a subject, flush per batch"
+    },
+    {
+      "name": "sftp",
+      "kind": "source",
+      "verified": true,
+      "tier": "stable",
+      "description": "SFTP source; list/glob a remote dir, stream JSONL/JSON-array/raw-text"
+    },
+    {
+      "name": "sftp",
+      "kind": "sink",
+      "verified": true,
+      "tier": "stable",
+      "description": "SFTP sink; JSONL objects, atomic temp+rename upload"
+    }
   ]
 }

--- a/cli/examples/airtable_to_jsonl.yaml
+++ b/cli/examples/airtable_to_jsonl.yaml
@@ -1,0 +1,68 @@
+# Airtable → JSONL on disk.
+#
+# Airtable's REST API is a plain bearer-authenticated, offset-token-paginated
+# JSON API, so faucet's generic `rest` source covers it end-to-end — no
+# dedicated connector crate is needed (issue #414).
+#
+# How it maps onto the `rest` source:
+#   - Bearer / personal-access-token auth  → auth: { type: bearer }
+#   - Records live under the `records` array  → records_path: "$.records"
+#   - The next-page token is `offset` in the body, sent back as the `offset`
+#     query param  → pagination: { type: Cursor, next_token_path: offset,
+#     param_name: offset }.  Pagination stops when `offset` is absent.
+#   - Airtable's 5 req/s per-base rate limit returns HTTP 429 with Retry-After;
+#     the rest source's built-in retry (max_retries / retry_backoff) honours it.
+#
+# Required env vars:
+#   AIRTABLE_TOKEN — a personal access token with data.records:read scope
+#   AIRTABLE_BASE_ID — the base id, e.g. appXXXXXXXXXXXXXX
+#
+#   faucet run cli/examples/airtable_to_jsonl.yaml
+version: 1
+name: airtable_to_jsonl
+
+vars:
+  base_id: ${env:AIRTABLE_BASE_ID}
+  table: Contacts
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.airtable.com
+      path: /v0/${vars.base_id}/${vars.table}
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:AIRTABLE_TOKEN}
+      query_params:
+        pageSize: "100"
+        # Optional: restrict to a view, or push a formula filter server-side.
+        # view: "Grid view"
+        # filterByFormula: "NOT({Status} = 'Archived')"
+      records_path: "$.records"
+      pagination:
+        type: Cursor
+        next_token_path: offset
+        param_name: offset
+      # Airtable rate-limits at 5 req/s per base (HTTP 429 + Retry-After).
+      max_retries: 5
+      retry_backoff: 1
+      tolerated_http_errors: []
+      replication_method:
+        type: FullTable
+      primary_keys: ["id"]
+      partitions: []
+      schema_sample_size: 100
+
+  # Each Airtable record is { id, createdTime, fields: {...} }. Flatten collapses
+  # the nested `fields` object into dotted top-level keys (fields.Name, …) for a
+  # flatter downstream shape.
+  transforms:
+    - type: flatten
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/airtable_contacts.jsonl

--- a/cli/examples/duckdb_to_jsonl.yaml
+++ b/cli/examples/duckdb_to_jsonl.yaml
@@ -1,0 +1,22 @@
+# DuckDB query → JSONL on disk.
+#
+#   faucet run cli/examples/duckdb_to_jsonl.yaml
+#
+# Point `database` at an existing .duckdb file (or use ":memory:" and a query
+# that reads a file via DuckDB's read_parquet/read_csv — though faucet has
+# native Parquet/CSV connectors for that). Rows stream in bounded-memory pages.
+version: 1
+name: duckdb_to_jsonl
+
+pipeline:
+  source:
+    type: duckdb
+    config:
+      database: ./warehouse.duckdb
+      query: "SELECT id, name, amount FROM sales WHERE amount > 0 ORDER BY id"
+      batch_size: 5000
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/sales.jsonl

--- a/cli/examples/nats_to_jsonl.yaml
+++ b/cli/examples/nats_to_jsonl.yaml
@@ -1,0 +1,17 @@
+# NATS → JSONL. Runs against a local NATS (JetStream enabled):
+#   docker run -p 4222:4222 nats:latest -js
+#   faucet run cli/examples/nats_to_jsonl.yaml
+version: 1
+name: nats_to_jsonl
+pipeline:
+  source:
+    type: nats
+    config:
+      servers: ["nats://127.0.0.1:4222"]
+      subject: "events.>"
+      idle_timeout_secs: 5     # at least one of idle_timeout_secs / max_messages is required
+      batch_size: 500
+  sink:
+    type: jsonl
+    config:
+      path: ./out/nats_events.jsonl

--- a/cli/examples/sftp_to_jsonl.yaml
+++ b/cli/examples/sftp_to_jsonl.yaml
@@ -1,0 +1,24 @@
+# SFTP directory → JSONL. Point host/username/path at a real SFTP server.
+#   export SFTP_PASSWORD=...
+#   faucet run cli/examples/sftp_to_jsonl.yaml
+version: 1
+name: sftp_to_jsonl
+pipeline:
+  source:
+    type: sftp
+    config:
+      host: sftp.example.com
+      port: 22
+      username: reporting
+      type: password
+      config:
+        password: ${env:SFTP_PASSWORD}
+      known_hosts: { mode: accept_new }   # strict | accept_new | insecure
+      path: /exports/daily
+      glob: "*.jsonl"
+      format: jsonl                        # jsonl | json_array | raw_text
+      batch_size: 1000
+  sink:
+    type: jsonl
+    config:
+      path: ./out/sftp_exports.jsonl

--- a/cli/examples/sqs_to_jsonl.yaml
+++ b/cli/examples/sqs_to_jsonl.yaml
@@ -1,0 +1,22 @@
+# AWS SQS → JSONL. Runs against LocalStack:
+#   docker run -p 4566:4566 -e SERVICES=sqs localstack/localstack
+#   faucet run cli/examples/sqs_to_jsonl.yaml
+version: 1
+name: sqs_to_jsonl
+pipeline:
+  source:
+    type: sqs
+    config:
+      queue_url: https://sqs.us-east-1.amazonaws.com/000000000000/events
+      region: us-east-1
+      endpoint_url: http://localhost:4566
+      credentials:
+        type: access_key
+        config: { access_key_id: test, secret_access_key: test }
+      idle_timeout_secs: 30        # at least one of idle_timeout_secs / max_messages is required
+      wait_time_seconds: 10
+      batch_size: 1000
+  sink:
+    type: jsonl
+    config:
+      path: ./out/sqs_events.jsonl

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -355,6 +355,29 @@ pub async fn build_source(
                 faucet_source_sqlite::SqliteSource::new(cfg).await?,
             ))
         }
+        #[cfg(feature = "source-duckdb")]
+        "duckdb" => {
+            let cfg =
+                decode::<faucet_source_duckdb::DuckdbSourceConfig>("source", "duckdb", config)?;
+            Ok(Box::new(
+                faucet_source_duckdb::DuckdbSource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-sqs")]
+        "sqs" => {
+            let cfg = decode::<faucet_source_sqs::SqsSourceConfig>("source", "sqs", config)?;
+            Ok(Box::new(faucet_source_sqs::SqsSource::new(cfg).await?))
+        }
+        #[cfg(feature = "source-nats")]
+        "nats" => {
+            let cfg = decode::<faucet_source_nats::NatsSourceConfig>("source", "nats", config)?;
+            Ok(Box::new(faucet_source_nats::NatsSource::new(cfg).await?))
+        }
+        #[cfg(feature = "source-sftp")]
+        "sftp" => {
+            let cfg = decode::<faucet_source_sftp::SftpSourceConfig>("source", "sftp", config)?;
+            Ok(Box::new(faucet_source_sftp::SftpSource::new(cfg)?))
+        }
         #[cfg(feature = "source-s3")]
         "s3" => {
             let cfg = decode::<faucet_source_s3::S3SourceConfig>("source", "s3", config)?;
@@ -629,6 +652,26 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
             let cfg = decode::<faucet_sink_sqlite::SqliteSinkConfig>("sink", "sqlite", config)?;
             Ok(Box::new(faucet_sink_sqlite::SqliteSink::new(cfg).await?))
         }
+        #[cfg(feature = "sink-duckdb")]
+        "duckdb" => {
+            let cfg = decode::<faucet_sink_duckdb::DuckdbSinkConfig>("sink", "duckdb", config)?;
+            Ok(Box::new(faucet_sink_duckdb::DuckdbSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-sqs")]
+        "sqs" => {
+            let cfg = decode::<faucet_sink_sqs::SqsSinkConfig>("sink", "sqs", config)?;
+            Ok(Box::new(faucet_sink_sqs::SqsSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-nats")]
+        "nats" => {
+            let cfg = decode::<faucet_sink_nats::NatsSinkConfig>("sink", "nats", config)?;
+            Ok(Box::new(faucet_sink_nats::NatsSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-sftp")]
+        "sftp" => {
+            let cfg = decode::<faucet_sink_sftp::SftpSinkConfig>("sink", "sftp", config)?;
+            Ok(Box::new(faucet_sink_sftp::SftpSink::new(cfg)?))
+        }
         #[cfg(feature = "sink-s3")]
         "s3" => {
             let cfg = decode::<faucet_sink_s3::S3SinkConfig>("sink", "s3", config)?;
@@ -894,6 +937,14 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "mssql" => Ok(schema::<faucet_source_mssql::MssqlSourceConfig>()),
         #[cfg(feature = "source-sqlite")]
         "sqlite" => Ok(schema::<faucet_source_sqlite::SqliteSourceConfig>()),
+        #[cfg(feature = "source-duckdb")]
+        "duckdb" => Ok(schema::<faucet_source_duckdb::DuckdbSourceConfig>()),
+        #[cfg(feature = "source-sqs")]
+        "sqs" => Ok(schema::<faucet_source_sqs::SqsSourceConfig>()),
+        #[cfg(feature = "source-nats")]
+        "nats" => Ok(schema::<faucet_source_nats::NatsSourceConfig>()),
+        #[cfg(feature = "source-sftp")]
+        "sftp" => Ok(schema::<faucet_source_sftp::SftpSourceConfig>()),
         #[cfg(feature = "source-s3")]
         "s3" => Ok(schema::<faucet_source_s3::S3SourceConfig>()),
         #[cfg(feature = "source-mongodb")]
@@ -982,6 +1033,14 @@ pub fn sink_schema(kind: &str) -> CliResult<Value> {
         "mssql" => Ok(schema::<faucet_sink_mssql::MssqlSinkConfig>()),
         #[cfg(feature = "sink-sqlite")]
         "sqlite" => Ok(schema::<faucet_sink_sqlite::SqliteSinkConfig>()),
+        #[cfg(feature = "sink-duckdb")]
+        "duckdb" => Ok(schema::<faucet_sink_duckdb::DuckdbSinkConfig>()),
+        #[cfg(feature = "sink-sqs")]
+        "sqs" => Ok(schema::<faucet_sink_sqs::SqsSinkConfig>()),
+        #[cfg(feature = "sink-nats")]
+        "nats" => Ok(schema::<faucet_sink_nats::NatsSinkConfig>()),
+        #[cfg(feature = "sink-sftp")]
+        "sftp" => Ok(schema::<faucet_sink_sftp::SftpSinkConfig>()),
         #[cfg(feature = "sink-s3")]
         "s3" => Ok(schema::<faucet_sink_s3::S3SinkConfig>()),
         #[cfg(feature = "sink-mongodb")]
@@ -1052,6 +1111,26 @@ fn builtin_source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("mssql", "Microsoft SQL Server query source"));
     #[cfg(feature = "source-sqlite")]
     v.push(("sqlite", "SQLite query source"));
+    #[cfg(feature = "source-duckdb")]
+    v.push((
+        "duckdb",
+        "DuckDB query source. Runs SQL against a DuckDB file or in-memory database and streams rows as JSON with bounded memory.",
+    ));
+    #[cfg(feature = "source-sqs")]
+    v.push((
+        "sqs",
+        "AWS SQS source. Long-polls ReceiveMessage, deletes after the batch is emitted (at-least-once), with idle/max-messages termination.",
+    ));
+    #[cfg(feature = "source-nats")]
+    v.push((
+        "nats",
+        "NATS source. Subscribes to a subject (or a JetStream durable consumer) and drains with idle/max-messages termination.",
+    ));
+    #[cfg(feature = "source-sftp")]
+    v.push((
+        "sftp",
+        "SFTP source. Lists/globs a remote directory and streams JSONL / JSON-array / raw-text files over SSH.",
+    ));
     #[cfg(feature = "source-s3")]
     v.push(("s3", "AWS S3 object source"));
     #[cfg(feature = "source-mongodb")]
@@ -1168,6 +1247,26 @@ fn builtin_sink_descriptions() -> Vec<(&'static str, &'static str)> {
     ));
     #[cfg(feature = "sink-sqlite")]
     v.push(("sqlite", "SQLite sink"));
+    #[cfg(feature = "sink-duckdb")]
+    v.push((
+        "duckdb",
+        "DuckDB sink. Transaction-wrapped multi-row INSERT (JSON column or auto-mapped columns).",
+    ));
+    #[cfg(feature = "sink-sqs")]
+    v.push((
+        "sqs",
+        "AWS SQS sink. Batched SendMessageBatch (10-message chunks) with per-entry partial-failure retry; FIFO group/dedup support.",
+    ));
+    #[cfg(feature = "sink-nats")]
+    v.push((
+        "nats",
+        "NATS sink. Publishes records to a subject (optionally subject-per-record) and flushes per batch.",
+    ));
+    #[cfg(feature = "sink-sftp")]
+    v.push((
+        "sftp",
+        "SFTP sink. Writes JSONL files over SSH with atomic temp-then-rename uploads.",
+    ));
     #[cfg(feature = "sink-s3")]
     v.push(("s3", "AWS S3 object sink"));
     #[cfg(feature = "sink-mongodb")]

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -814,6 +814,11 @@ fn shipped_example_yamls_pass_validate() {
         ("SOAP_PASS", "x"),
         ("STRIPE_TOKEN", "x"),
         ("FEED_TOKEN", "x"),
+        // sftp_to_jsonl.yaml (SFTP source password).
+        ("SFTP_PASSWORD", "x"),
+        // airtable_to_jsonl.yaml (Airtable PAT + base id, via the rest source).
+        ("AIRTABLE_TOKEN", "x"),
+        ("AIRTABLE_BASE_ID", "appXXXXXXXXXXXXXX"),
         // shared_auth_rest.yaml (top-level `auth:` catalog provider).
         ("API_BASE_URL", "https://api.example.com"),
         ("API_TOKEN_URL", "https://auth.example.com/oauth/token"),

--- a/crates/common/nats/CHANGELOG.md
+++ b/crates/common/nats/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: shared NATS configuration types for the source and sink
+  connectors — `NatsAuth` (secret-safe `Debug`), `NatsConnectionConfig`, and
+  the `connect` client builder ([#411](https://github.com/PawanSikawat/faucet-stream/issues/411)).

--- a/crates/common/nats/Cargo.toml
+++ b/crates/common/nats/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "faucet-common-nats"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared NATS config types for the faucet-stream source and sink"
+readme = "README.md"
+keywords = ["nats", "messaging", "streaming", "etl", "faucet"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+async-nats.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/nats/README.md
+++ b/crates/common/nats/README.md
@@ -1,0 +1,51 @@
+# faucet-common-nats
+
+Shared configuration types for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+NATS **source** ([`faucet-source-nats`](https://crates.io/crates/faucet-source-nats))
+and **sink** ([`faucet-sink-nats`](https://crates.io/crates/faucet-sink-nats)).
+
+Both connectors depend on this crate and re-export its types, so end-user
+imports do not change.
+
+## Types
+
+- **`NatsAuth`** — authentication mode, serialized as the standard faucet
+  `{ type, config }` adjacent tag:
+  - `none` (default) — anonymous
+  - `token` — `{ token }`
+  - `user_password` — `{ username, password }`
+  - `nkey` — `{ nkey }` (Ed25519 seed)
+  - `creds_file` — `{ path }` (an `nsc`-produced `.creds` bundle)
+
+  Its `Debug` implementation is secret-safe: `token`, `password`, and `nkey`
+  are never printed.
+
+- **`NatsConnectionConfig`** — the connection surface both connectors
+  `#[serde(flatten)]` into their config:
+
+  | field     | type            | default                      | description                              |
+  |-----------|-----------------|------------------------------|------------------------------------------|
+  | `servers` | `Vec<String>`   | `["nats://127.0.0.1:4222"]`  | server URLs (first reachable wins)       |
+  | `auth`    | `NatsAuth`      | `none`                       | authentication mode                      |
+  | `tls`     | `bool`          | `false`                      | require a TLS connection                 |
+  | `name`    | `Option<String>`| —                            | client connection name (server monitor)  |
+
+- **`connect(&NatsConnectionConfig) -> Result<async_nats::Client, FaucetError>`**
+  — the single client builder both connectors use. Retry-on-initial-connect is
+  left off, so an unreachable server fails immediately with a typed error.
+
+## Example (embedded in a connector config)
+
+```yaml
+servers: ["nats://127.0.0.1:4222"]
+auth:
+  type: token
+  config:
+    token: ${env:NATS_TOKEN}
+tls: false
+name: faucet
+```
+
+## License
+
+Licensed under either of Apache-2.0 or MIT at your option.

--- a/crates/common/nats/src/auth.rs
+++ b/crates/common/nats/src/auth.rs
@@ -1,0 +1,145 @@
+//! NATS authentication modes.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// NATS client authentication configuration.
+///
+/// Serializes with an adjacent `{ "type": <method>, "config": { … } }` tag in
+/// snake_case, matching every other faucet connector's auth shape.
+///
+/// The [`std::fmt::Debug`] implementation is hand-written so secret material
+/// (`token`, `password`, `nkey` seed) is never printed — only the variant name
+/// and non-secret fields appear.
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum NatsAuth {
+    /// No authentication (anonymous connection).
+    #[default]
+    None,
+    /// Bearer/token authentication.
+    Token {
+        /// The authentication token.
+        token: String,
+    },
+    /// Username + password authentication.
+    UserPassword {
+        /// The username.
+        username: String,
+        /// The password.
+        password: String,
+    },
+    /// NKey (Ed25519 seed) authentication.
+    NKey {
+        /// The NKey seed (starts with `S`).
+        nkey: String,
+    },
+    /// Credentials-file (`.creds`) authentication — a decentralized JWT +
+    /// NKey seed bundle as produced by `nsc`.
+    CredsFile {
+        /// Path to the `.creds` file.
+        path: PathBuf,
+    },
+}
+
+impl std::fmt::Debug for NatsAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render secret material — only the variant and non-secret fields.
+        match self {
+            NatsAuth::None => f.write_str("None"),
+            NatsAuth::Token { .. } => f
+                .debug_struct("Token")
+                .field("token", &"<redacted>")
+                .finish(),
+            NatsAuth::UserPassword { username, .. } => f
+                .debug_struct("UserPassword")
+                .field("username", username)
+                .field("password", &"<redacted>")
+                .finish(),
+            NatsAuth::NKey { .. } => f.debug_struct("NKey").field("nkey", &"<redacted>").finish(),
+            NatsAuth::CredsFile { path } => {
+                f.debug_struct("CredsFile").field("path", path).finish()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_is_none() {
+        assert!(matches!(NatsAuth::default(), NatsAuth::None));
+    }
+
+    #[test]
+    fn serde_round_trip_token() {
+        let auth = NatsAuth::Token {
+            token: "sekret".into(),
+        };
+        let v = serde_json::to_value(&auth).unwrap();
+        assert_eq!(v["type"], "token");
+        assert_eq!(v["config"]["token"], "sekret");
+        let parsed: NatsAuth = serde_json::from_value(v).unwrap();
+        assert!(matches!(parsed, NatsAuth::Token { token } if token == "sekret"));
+    }
+
+    #[test]
+    fn serde_round_trip_user_password() {
+        let v = json!({"type": "user_password", "config": {"username": "u", "password": "p"}});
+        let parsed: NatsAuth = serde_json::from_value(v).unwrap();
+        assert!(
+            matches!(parsed, NatsAuth::UserPassword { username, password } if username == "u" && password == "p")
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_creds_file() {
+        let v = json!({"type": "creds_file", "config": {"path": "/tmp/x.creds"}});
+        let parsed: NatsAuth = serde_json::from_value(v).unwrap();
+        assert!(
+            matches!(parsed, NatsAuth::CredsFile { path } if path == std::path::Path::new("/tmp/x.creds"))
+        );
+    }
+
+    #[test]
+    fn debug_redacts_token() {
+        let auth = NatsAuth::Token {
+            token: "super-secret-token".into(),
+        };
+        let dbg = format!("{auth:?}");
+        assert!(
+            !dbg.contains("super-secret-token"),
+            "debug leaked token: {dbg}"
+        );
+        assert!(dbg.contains("redacted"));
+    }
+
+    #[test]
+    fn debug_redacts_password_but_shows_username() {
+        let auth = NatsAuth::UserPassword {
+            username: "alice".into(),
+            password: "hunter2".into(),
+        };
+        let dbg = format!("{auth:?}");
+        assert!(dbg.contains("alice"));
+        assert!(!dbg.contains("hunter2"), "debug leaked password: {dbg}");
+    }
+
+    #[test]
+    fn debug_redacts_nkey() {
+        let auth = NatsAuth::NKey {
+            nkey: "SUACSSL3UAHUDXKFSNVUZRF5UHPMWZ6BFDTJ7M6USDXIEDNPPQYYYCU3VY".into(),
+        };
+        let dbg = format!("{auth:?}");
+        assert!(!dbg.contains("SUACSSL3"), "debug leaked nkey: {dbg}");
+    }
+
+    #[test]
+    fn schema_compiles() {
+        let _ = schemars::schema_for!(NatsAuth);
+    }
+}

--- a/crates/common/nats/src/connection.rs
+++ b/crates/common/nats/src/connection.rs
@@ -1,0 +1,174 @@
+//! Shared NATS connection configuration and the single client builder used by
+//! both the source and the sink.
+
+use crate::auth::NatsAuth;
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_servers() -> Vec<String> {
+    vec!["nats://127.0.0.1:4222".to_string()]
+}
+
+/// Connection settings shared by the NATS source and sink.
+///
+/// This struct is `#[serde(flatten)]`ed into each connector's config so a
+/// single `servers` / `auth` / `tls` / `name` surface is presented to users.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NatsConnectionConfig {
+    /// One or more NATS server URLs, e.g. `["nats://127.0.0.1:4222"]`. The
+    /// client connects to the first reachable server and uses the rest for
+    /// failover.
+    #[serde(default = "default_servers")]
+    pub servers: Vec<String>,
+    /// Authentication mode. Defaults to [`NatsAuth::None`] (anonymous).
+    #[serde(default)]
+    pub auth: NatsAuth,
+    /// Require a TLS connection to the server. Defaults to `false`.
+    #[serde(default)]
+    pub tls: bool,
+    /// Optional client connection name (surfaced in NATS server monitoring).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl Default for NatsConnectionConfig {
+    fn default() -> Self {
+        Self {
+            servers: default_servers(),
+            auth: NatsAuth::None,
+            tls: false,
+            name: None,
+        }
+    }
+}
+
+impl NatsConnectionConfig {
+    /// Validate the connection settings. Callers should run this at config-load
+    /// time (a connector's `validate`), before any lazy connect.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.servers.is_empty() {
+            return Err(FaucetError::Config(
+                "nats: `servers` must contain at least one server URL".into(),
+            ));
+        }
+        if self.servers.iter().any(|s| s.trim().is_empty()) {
+            return Err(FaucetError::Config(
+                "nats: `servers` entries must not be empty".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Connect to NATS using the shared connection config.
+///
+/// Applies the configured authentication mode, TLS requirement and connection
+/// name, then dials the server list. This does **not** enable
+/// retry-on-initial-connect, so an unreachable server surfaces as an immediate
+/// typed error rather than blocking — which is what lets a lazy connector's
+/// first poll fail cleanly.
+pub async fn connect(cfg: &NatsConnectionConfig) -> Result<async_nats::Client, FaucetError> {
+    cfg.validate()?;
+
+    let mut options = async_nats::ConnectOptions::new();
+
+    match &cfg.auth {
+        NatsAuth::None => {}
+        NatsAuth::Token { token } => {
+            options = options.token(token.clone());
+        }
+        NatsAuth::UserPassword { username, password } => {
+            options = options.user_and_password(username.clone(), password.clone());
+        }
+        NatsAuth::NKey { nkey } => {
+            options = options.nkey(nkey.clone());
+        }
+        NatsAuth::CredsFile { path } => {
+            options = options.credentials_file(path).await.map_err(|e| {
+                FaucetError::Config(format!(
+                    "nats: failed to read credentials file '{}': {e}",
+                    path.display()
+                ))
+            })?;
+        }
+    }
+
+    if cfg.tls {
+        options = options.require_tls(true);
+    }
+    if let Some(name) = &cfg.name {
+        options = options.name(name.clone());
+    }
+
+    async_nats::connect_with_options(cfg.servers.clone(), options)
+        .await
+        .map_err(|e| FaucetError::Custom(Box::new(e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_has_one_server_and_no_auth() {
+        let cfg = NatsConnectionConfig::default();
+        assert_eq!(cfg.servers.len(), 1);
+        assert!(matches!(cfg.auth, NatsAuth::None));
+        assert!(!cfg.tls);
+        assert!(cfg.name.is_none());
+    }
+
+    #[test]
+    fn validate_rejects_empty_servers() {
+        let cfg = NatsConnectionConfig {
+            servers: vec![],
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_blank_server_entry() {
+        let cfg = NatsConnectionConfig {
+            servers: vec!["   ".into()],
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn deserializes_with_flattened_defaults() {
+        let cfg: NatsConnectionConfig = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(cfg.servers, vec!["nats://127.0.0.1:4222".to_string()]);
+    }
+
+    #[test]
+    fn deserializes_full() {
+        let cfg: NatsConnectionConfig = serde_json::from_value(json!({
+            "servers": ["nats://a:4222", "nats://b:4222"],
+            "auth": {"type": "token", "config": {"token": "t"}},
+            "tls": true,
+            "name": "faucet"
+        }))
+        .unwrap();
+        assert_eq!(cfg.servers.len(), 2);
+        assert!(cfg.tls);
+        assert_eq!(cfg.name.as_deref(), Some("faucet"));
+        assert!(matches!(cfg.auth, NatsAuth::Token { .. }));
+    }
+
+    #[tokio::test]
+    async fn connect_to_unreachable_server_errors_not_panics() {
+        let cfg = NatsConnectionConfig {
+            servers: vec!["nats://127.0.0.1:1".into()],
+            ..Default::default()
+        };
+        let result = connect(&cfg).await;
+        assert!(
+            result.is_err(),
+            "expected connect to fail on unreachable server"
+        );
+    }
+}

--- a/crates/common/nats/src/lib.rs
+++ b/crates/common/nats/src/lib.rs
@@ -1,0 +1,21 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-nats
+//!
+//! Shared configuration types for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+//! NATS source and sink connectors.
+//!
+//! - [`NatsAuth`] — authentication modes (None, Token, UserPassword, NKey,
+//!   CredsFile) with a secret-safe [`std::fmt::Debug`].
+//! - [`NatsConnectionConfig`] — the connection surface (`servers`, `auth`,
+//!   `tls`, `name`) that both connectors `#[serde(flatten)]` into their config.
+//! - [`connect`] — the single client builder both connectors use.
+//!
+//! All types derive `Serialize`, `Deserialize`, and `JsonSchema` so they
+//! round-trip through YAML/JSON configs and CLI introspection.
+
+pub mod auth;
+pub mod connection;
+
+pub use auth::NatsAuth;
+pub use connection::{NatsConnectionConfig, connect};

--- a/crates/common/sftp/CHANGELOG.md
+++ b/crates/common/sftp/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: shared SFTP connection config (`SftpConnectionConfig`,
+  `SftpAuth`, `HostKeyPolicy`) and the async `connect` helper used by the
+  `faucet-source-sftp` and `faucet-sink-sftp` connectors. Password and
+  private-key auth; host-key verification via strict / accept-new / insecure
+  policies; secret-safe `Debug` ([#410](https://github.com/PawanSikawat/faucet-stream/issues/410)).

--- a/crates/common/sftp/Cargo.toml
+++ b/crates/common/sftp/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "faucet-common-sftp"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared SFTP connection config for the faucet-stream source and sink"
+readme = "README.md"
+keywords = ["sftp", "ssh", "file", "etl", "faucet"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "io-util", "net"] }
+russh.workspace = true
+russh-sftp.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/sftp/README.md
+++ b/crates/common/sftp/README.md
@@ -1,0 +1,47 @@
+# faucet-common-sftp
+
+Shared SFTP connection configuration and connect helper for the
+[`faucet-source-sftp`](https://crates.io/crates/faucet-source-sftp) and
+[`faucet-sink-sftp`](https://crates.io/crates/faucet-sink-sftp) connectors in
+the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem.
+
+This crate is a small building block, not a connector itself. It provides:
+
+- `SftpConnectionConfig` — host, port (default `22`), username, auth, host-key
+  policy. Its fields are `#[serde(flatten)]`ed into the source/sink configs, so
+  end users see one flat config block.
+- `SftpAuth` — `password` or `private_key` (with optional passphrase),
+  serialized with the faucet `{ type, config }` shape. Its `Debug` impl never
+  prints the password or passphrase.
+- `HostKeyPolicy` — how the server host key is verified (see below).
+- `async fn connect(&SftpConnectionConfig) -> Result<SftpSession, FaucetError>`
+  — opens the SSH transport, authenticates, verifies the host key, and opens
+  the `sftp` subsystem.
+
+## Host-key verification
+
+Man-in-the-middle protection is on by default. The policy is selected via the
+`known_hosts` block:
+
+| `mode`        | Behaviour |
+|---------------|-----------|
+| `accept_new`  | **Default.** Trust-on-first-use: record an unknown host key in `~/.ssh/known_hosts`, reject a key that has *changed*. |
+| `strict`      | Reject any key not already present in `known_hosts` (optionally at a custom `known_hosts_path`). |
+| `insecure`    | Disable verification entirely. **Vulnerable to MITM** — use only on trusted networks / test servers. |
+
+## Auth config shapes
+
+```yaml
+# Password
+type: password
+config:
+  password: ${env:SFTP_PASSWORD}
+
+# Private key
+type: private_key
+config:
+  path: /home/me/.ssh/id_ed25519
+  passphrase: ${env:SFTP_KEY_PASSPHRASE}   # optional
+```
+
+Licensed under MIT OR Apache-2.0.

--- a/crates/common/sftp/src/lib.rs
+++ b/crates/common/sftp/src/lib.rs
@@ -1,0 +1,466 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-sftp
+//!
+//! Shared SFTP connection configuration and connect helper for the
+//! [`faucet-source-sftp`](https://docs.rs/faucet-source-sftp) and
+//! [`faucet-sink-sftp`](https://docs.rs/faucet-sink-sftp) connectors.
+//!
+//! The single entry point is [`connect`], which opens an SSH transport
+//! (password or private-key auth), verifies the server host key against the
+//! configured [`HostKeyPolicy`], opens the `sftp` subsystem, and hands back a
+//! ready [`SftpSession`]. Both the source and the sink build their session
+//! through this helper so auth, host-key handling, and error mapping stay
+//! consistent.
+//!
+//! ## Host-key verification
+//!
+//! Man-in-the-middle protection is on by default. [`HostKeyPolicy`] defaults to
+//! [`AcceptNew`](HostKeyPolicy::AcceptNew) (trust-on-first-use — record an
+//! unknown key, reject a *changed* one). [`Strict`](HostKeyPolicy::Strict)
+//! requires the key to already be present in `known_hosts`.
+//! [`Insecure`](HostKeyPolicy::Insecure) disables verification entirely and
+//! must be selected explicitly.
+//!
+//! ## Secrets
+//!
+//! [`SftpAuth`] has a hand-written [`Debug`] impl that never prints the
+//! password or key passphrase, so a `Debug`-formatted
+//! [`SftpConnectionConfig`] is safe to log.
+
+use std::sync::Arc;
+
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub use russh_sftp::client::SftpSession;
+
+/// Default SSH port.
+pub const DEFAULT_PORT: u16 = 22;
+
+fn default_port() -> u16 {
+    DEFAULT_PORT
+}
+
+/// How the server's host key is verified during the SSH handshake.
+///
+/// Defaults to [`AcceptNew`](Self::AcceptNew). The insecure, verification-off
+/// mode is a distinct explicit variant so it can never be selected by
+/// accident.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum HostKeyPolicy {
+    /// Reject any host key that is not already recorded in `known_hosts`.
+    /// The most secure policy; requires the key to be pre-provisioned.
+    Strict {
+        /// Path to the `known_hosts` file. `None` uses the standard
+        /// `~/.ssh/known_hosts` location.
+        #[serde(default)]
+        known_hosts_path: Option<String>,
+    },
+    /// Trust-on-first-use: accept and record a host key the first time it is
+    /// seen (in `~/.ssh/known_hosts`), but reject a key that has *changed*
+    /// from a previously recorded one. This is the default.
+    #[default]
+    AcceptNew,
+    /// Disable host-key verification entirely. **Insecure** — vulnerable to
+    /// man-in-the-middle attacks. Use only against trusted networks / test
+    /// servers.
+    Insecure,
+}
+
+/// SFTP authentication method.
+///
+/// Serializes with the faucet `{ "type": <method>, "config": { … } }`
+/// adjacently-tagged shape shared by every connector's auth block.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum SftpAuth {
+    /// Password authentication.
+    Password {
+        /// The account password.
+        password: String,
+    },
+    /// Public-key authentication with an OpenSSH/PEM private key on disk.
+    PrivateKey {
+        /// Path to the private-key file.
+        path: String,
+        /// Optional passphrase used to decrypt an encrypted private key.
+        #[serde(default)]
+        passphrase: Option<String>,
+    },
+}
+
+/// Secret-safe: never prints the password or passphrase material.
+impl std::fmt::Debug for SftpAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SftpAuth::Password { .. } => f
+                .debug_struct("Password")
+                .field("password", &"<redacted>")
+                .finish(),
+            SftpAuth::PrivateKey { path, passphrase } => f
+                .debug_struct("PrivateKey")
+                .field("path", path)
+                .field("passphrase", &passphrase.as_ref().map(|_| "<redacted>"))
+                .finish(),
+        }
+    }
+}
+
+/// Shared SFTP connection configuration.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SftpConnectionConfig {
+    /// Server hostname or IP address.
+    pub host: String,
+    /// Server port (default: 22).
+    #[serde(default = "default_port")]
+    pub port: u16,
+    /// SSH username.
+    pub username: String,
+    /// Authentication method (`{ type, config }`).
+    #[serde(flatten)]
+    pub auth: SftpAuth,
+    /// Host-key verification policy (default: `accept_new`).
+    #[serde(default)]
+    pub known_hosts: HostKeyPolicy,
+}
+
+impl SftpConnectionConfig {
+    /// Build a config with password authentication and default host-key policy.
+    pub fn with_password(
+        host: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port: DEFAULT_PORT,
+            username: username.into(),
+            auth: SftpAuth::Password {
+                password: password.into(),
+            },
+            known_hosts: HostKeyPolicy::default(),
+        }
+    }
+
+    /// Set the port.
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Set the host-key policy.
+    pub fn known_hosts(mut self, policy: HostKeyPolicy) -> Self {
+        self.known_hosts = policy;
+        self
+    }
+}
+
+/// Error type for the SSH client handler (host-key verification + transport).
+///
+/// Kept local to satisfy [`russh::client::Handler::Error`]'s
+/// `From<russh::Error>` bound; [`connect`] maps it into a [`FaucetError`] for
+/// callers.
+#[derive(Debug)]
+enum HandlerError {
+    /// A transport-level SSH error surfaced through the handler.
+    Ssh(russh::Error),
+    /// The server's host key was rejected by the configured policy.
+    HostKey(String),
+}
+
+impl std::fmt::Display for HandlerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HandlerError::Ssh(e) => write!(f, "SSH transport error: {e}"),
+            HandlerError::HostKey(m) => write!(f, "host key rejected: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for HandlerError {}
+
+impl From<russh::Error> for HandlerError {
+    fn from(e: russh::Error) -> Self {
+        HandlerError::Ssh(e)
+    }
+}
+
+/// SSH client handler that verifies the server host key against a policy.
+struct ClientHandler {
+    policy: HostKeyPolicy,
+    host: String,
+    port: u16,
+}
+
+impl russh::client::Handler for ClientHandler {
+    type Error = HandlerError;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        match &self.policy {
+            HostKeyPolicy::Insecure => {
+                tracing::warn!(
+                    host = %self.host,
+                    port = self.port,
+                    "SFTP host-key verification is DISABLED (insecure policy)"
+                );
+                Ok(true)
+            }
+            HostKeyPolicy::Strict { known_hosts_path } => {
+                let found = match known_hosts_path {
+                    Some(path) => russh::keys::check_known_hosts_path(
+                        &self.host,
+                        self.port,
+                        server_public_key,
+                        path,
+                    ),
+                    None => {
+                        russh::keys::check_known_hosts(&self.host, self.port, server_public_key)
+                    }
+                }
+                .map_err(|e| HandlerError::HostKey(format!("known_hosts lookup failed: {e}")))?;
+                if found {
+                    Ok(true)
+                } else {
+                    Err(HandlerError::HostKey(format!(
+                        "host key for {}:{} is not present in known_hosts (strict policy)",
+                        self.host, self.port
+                    )))
+                }
+            }
+            HostKeyPolicy::AcceptNew => {
+                match russh::keys::check_known_hosts(&self.host, self.port, server_public_key) {
+                    Ok(true) => Ok(true),
+                    Ok(false) => {
+                        russh::keys::known_hosts::learn_known_hosts(
+                            &self.host,
+                            self.port,
+                            server_public_key,
+                        )
+                        .map_err(|e| {
+                            HandlerError::HostKey(format!(
+                                "failed to record new host key for {}:{}: {e}",
+                                self.host, self.port
+                            ))
+                        })?;
+                        tracing::info!(
+                            host = %self.host,
+                            port = self.port,
+                            "recorded new SFTP host key (accept-new policy)"
+                        );
+                        Ok(true)
+                    }
+                    Err(e) => Err(HandlerError::HostKey(format!(
+                        "host key for {}:{} changed or is invalid: {e}",
+                        self.host, self.port
+                    ))),
+                }
+            }
+        }
+    }
+}
+
+/// Open an SSH transport to the configured server, authenticate, verify the
+/// host key, and open the `sftp` subsystem.
+///
+/// The returned [`SftpSession`] owns the underlying channel; the SSH session
+/// task stays alive for as long as the session is held and shuts down cleanly
+/// when it is dropped.
+///
+/// # Errors
+///
+/// Returns [`FaucetError::Auth`] when authentication or host-key verification
+/// fails, and [`FaucetError::Custom`] for transport / subsystem errors.
+pub async fn connect(cfg: &SftpConnectionConfig) -> Result<SftpSession, FaucetError> {
+    let config = Arc::new(russh::client::Config::default());
+    let handler = ClientHandler {
+        policy: cfg.known_hosts.clone(),
+        host: cfg.host.clone(),
+        port: cfg.port,
+    };
+
+    let mut session = russh::client::connect(config, (cfg.host.as_str(), cfg.port), handler)
+        .await
+        .map_err(map_handler_err)?;
+
+    let authenticated = match &cfg.auth {
+        SftpAuth::Password { password } => session
+            .authenticate_password(&cfg.username, password)
+            .await
+            .map_err(map_ssh_err)?,
+        SftpAuth::PrivateKey { path, passphrase } => {
+            let key = russh::keys::load_secret_key(path, passphrase.as_deref()).map_err(|e| {
+                FaucetError::Auth(format!("failed to load SFTP private key '{path}': {e}"))
+            })?;
+            let key = russh::keys::PrivateKeyWithHashAlg::new(Arc::new(key), None);
+            session
+                .authenticate_publickey(&cfg.username, key)
+                .await
+                .map_err(map_ssh_err)?
+        }
+    };
+
+    if !authenticated.success() {
+        return Err(FaucetError::Auth(format!(
+            "SFTP authentication failed for user '{}' on {}:{}",
+            cfg.username, cfg.host, cfg.port
+        )));
+    }
+
+    let channel = session.channel_open_session().await.map_err(map_ssh_err)?;
+    channel
+        .request_subsystem(true, "sftp")
+        .await
+        .map_err(map_ssh_err)?;
+
+    let sftp = SftpSession::new(channel.into_stream())
+        .await
+        .map_err(|e| FaucetError::Custom(format!("failed to start SFTP subsystem: {e}").into()))?;
+
+    // The `Handle` (`session`) can now be dropped: the `SftpSession` holds its
+    // own clone of the session message sender, so the SSH session task stays
+    // alive as long as the returned session is held.
+    Ok(sftp)
+}
+
+fn map_handler_err(e: HandlerError) -> FaucetError {
+    match e {
+        HandlerError::HostKey(m) => {
+            FaucetError::Auth(format!("SFTP host-key verification failed: {m}"))
+        }
+        HandlerError::Ssh(e) => FaucetError::Custom(format!("SFTP connection failed: {e}").into()),
+    }
+}
+
+fn map_ssh_err(e: russh::Error) -> FaucetError {
+    FaucetError::Custom(format!("SFTP SSH error: {e}").into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_port_is_22() {
+        let json = r#"{
+            "host": "example.com",
+            "username": "user",
+            "type": "password",
+            "config": { "password": "secret" }
+        }"#;
+        let cfg: SftpConnectionConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.port, DEFAULT_PORT);
+    }
+
+    #[test]
+    fn default_host_key_policy_is_accept_new() {
+        let json = r#"{
+            "host": "example.com",
+            "username": "user",
+            "type": "password",
+            "config": { "password": "secret" }
+        }"#;
+        let cfg: SftpConnectionConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(cfg.known_hosts, HostKeyPolicy::AcceptNew));
+    }
+
+    #[test]
+    fn password_auth_round_trips() {
+        let json = r#"{
+            "host": "h",
+            "port": 2222,
+            "username": "u",
+            "type": "password",
+            "config": { "password": "p" }
+        }"#;
+        let cfg: SftpConnectionConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.port, 2222);
+        match &cfg.auth {
+            SftpAuth::Password { password } => assert_eq!(password, "p"),
+            other => panic!("expected password auth, got {other:?}"),
+        }
+        // Serialize back and confirm the adjacently-tagged shape survives.
+        let value = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(value["type"], "password");
+        assert_eq!(value["config"]["password"], "p");
+    }
+
+    #[test]
+    fn private_key_auth_round_trips() {
+        let json = r#"{
+            "host": "h",
+            "username": "u",
+            "type": "private_key",
+            "config": { "path": "/home/u/.ssh/id_ed25519" }
+        }"#;
+        let cfg: SftpConnectionConfig = serde_json::from_str(json).unwrap();
+        match &cfg.auth {
+            SftpAuth::PrivateKey { path, passphrase } => {
+                assert_eq!(path, "/home/u/.ssh/id_ed25519");
+                assert!(passphrase.is_none());
+            }
+            other => panic!("expected private-key auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strict_policy_round_trips_with_path() {
+        let json = r#"{
+            "host": "h",
+            "username": "u",
+            "type": "password",
+            "config": { "password": "p" },
+            "known_hosts": { "mode": "strict", "known_hosts_path": "/etc/known_hosts" }
+        }"#;
+        let cfg: SftpConnectionConfig = serde_json::from_str(json).unwrap();
+        match &cfg.known_hosts {
+            HostKeyPolicy::Strict { known_hosts_path } => {
+                assert_eq!(known_hosts_path.as_deref(), Some("/etc/known_hosts"));
+            }
+            other => panic!("expected strict policy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn insecure_policy_round_trips() {
+        let json = r#"{
+            "host": "h",
+            "username": "u",
+            "type": "password",
+            "config": { "password": "p" },
+            "known_hosts": { "mode": "insecure" }
+        }"#;
+        let cfg: SftpConnectionConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(cfg.known_hosts, HostKeyPolicy::Insecure));
+    }
+
+    #[test]
+    fn debug_redacts_password() {
+        let cfg = SftpConnectionConfig::with_password("h", "u", "hunter2");
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("hunter2"), "password leaked in Debug: {dbg}");
+        assert!(dbg.contains("<redacted>"));
+    }
+
+    #[test]
+    fn debug_redacts_passphrase() {
+        let auth = SftpAuth::PrivateKey {
+            path: "/k".into(),
+            passphrase: Some("topsecret".into()),
+        };
+        let dbg = format!("{auth:?}");
+        assert!(!dbg.contains("topsecret"), "passphrase leaked: {dbg}");
+        assert!(dbg.contains("/k"), "path should still be visible");
+    }
+
+    #[test]
+    fn config_schema_is_object() {
+        let schema = serde_json::to_value(schemars::schema_for!(SftpConnectionConfig)).unwrap();
+        assert!(schema.is_object());
+    }
+}

--- a/crates/common/sftp/src/lib.rs
+++ b/crates/common/sftp/src/lib.rs
@@ -35,6 +35,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub use russh_sftp::client::SftpSession;
+// Re-exported so callers can open files for writing with explicit flags. The
+// `SftpSession::write` convenience opens with `WRITE` only (no `CREATE`), so it
+// cannot create a new file — writing one requires
+// `open_with_flags(path, OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::TRUNCATE)`.
+pub use russh_sftp::protocol::OpenFlags;
 
 /// Default SSH port.
 pub const DEFAULT_PORT: u16 = 22;

--- a/crates/common/sqs/CHANGELOG.md
+++ b/crates/common/sqs/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: shared `SqsCredentials` auth enum + `build_client` helper for
+  the AWS SQS source and sink connectors ([#412](https://github.com/PawanSikawat/faucet-stream/issues/412)).

--- a/crates/common/sqs/Cargo.toml
+++ b/crates/common/sqs/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "faucet-common-sqs"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared configuration types for the faucet-stream AWS SQS source and sink connectors"
+readme = "README.md"
+keywords = ["sqs", "aws", "queue", "etl", "faucet"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+aws-config.workspace = true
+aws-sdk-sqs.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_yaml = "0.9"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/sqs/README.md
+++ b/crates/common/sqs/README.md
@@ -1,0 +1,30 @@
+# faucet-common-sqs
+
+Shared configuration types for the faucet-stream AWS SQS **source**
+(`faucet-source-sqs`) and **sink** (`faucet-sink-sqs`) connectors.
+
+It exposes:
+
+- `SqsCredentials` — the AWS auth enum, serialized with the consistent
+  `{ type, config }` wire shape (`default` / `profile` / `access_key` /
+  `assume_role` / `web_identity`). Its `Debug` impl never prints key material.
+- `build_client` — assembles an `aws_sdk_sqs::Client` from an optional region,
+  an optional endpoint URL (LocalStack / VPC endpoints), and a `SqsCredentials`.
+
+Both connector crates re-export these, so end users import from
+`faucet-source-sqs` / `faucet-sink-sqs` directly and never depend on this crate
+by name.
+
+## Credentials
+
+```yaml
+credentials: { type: default }
+credentials: { type: profile, config: { name: prod } }
+credentials: { type: access_key, config: { access_key_id: AKIA…, secret_access_key: ${env:AWS_SECRET} } }
+credentials: { type: assume_role, config: { role_arn: arn:aws:iam::…:role/x, external_id: … } }
+credentials: { type: web_identity }
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/common/sqs/src/auth.rs
+++ b/crates/common/sqs/src/auth.rs
@@ -1,0 +1,214 @@
+//! Credential configuration + client construction shared by the SQS source
+//! and sink.
+
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How to authenticate with AWS SQS.
+///
+/// Serializes as `{ type: <method>, config: { … } }` (adjacent tagging,
+/// snake_case discriminators) — the consistent auth wire shape shared by
+/// every faucet connector.
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum SqsCredentials {
+    /// The AWS SDK default provider chain: environment variables, shared
+    /// config/credentials files, ECS/EKS container credentials, web-identity
+    /// tokens (`AWS_WEB_IDENTITY_TOKEN_FILE` / EKS IRSA), and EC2 instance
+    /// profiles — with automatic refresh/rotation.
+    #[default]
+    Default,
+    /// A named profile from the shared AWS config/credentials files.
+    Profile {
+        /// Profile name (as in `~/.aws/credentials`).
+        name: String,
+    },
+    /// Static access keys. Prefer `${env:…}` / secrets-manager interpolation
+    /// over literals in config files.
+    AccessKey {
+        /// AWS access key id.
+        access_key_id: String,
+        /// AWS secret access key.
+        secret_access_key: String,
+        /// Optional session token (for temporary credentials).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_token: Option<String>,
+    },
+    /// Assume an IAM role via STS on top of the default provider chain.
+    AssumeRole {
+        /// ARN of the role to assume.
+        role_arn: String,
+        /// Session name recorded in CloudTrail. Defaults to `faucet-stream`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_name: Option<String>,
+        /// Optional external id for cross-account trust policies.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        external_id: Option<String>,
+    },
+    /// Web-identity federation (e.g. EKS IRSA). Equivalent to the `default`
+    /// chain, which honors `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` —
+    /// kept as an explicit variant so intent is visible in configs.
+    WebIdentity,
+}
+
+impl std::fmt::Debug for SqsCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Default => write!(f, "Default"),
+            Self::Profile { name } => f.debug_struct("Profile").field("name", name).finish(),
+            // Never print key material.
+            Self::AccessKey { access_key_id, .. } => f
+                .debug_struct("AccessKey")
+                .field("access_key_id", access_key_id)
+                .field("secret_access_key", &"***")
+                .finish(),
+            Self::AssumeRole { role_arn, .. } => f
+                .debug_struct("AssumeRole")
+                .field("role_arn", role_arn)
+                .finish(),
+            Self::WebIdentity => write!(f, "WebIdentity"),
+        }
+    }
+}
+
+/// Build an `aws_sdk_sqs::Client` from region / endpoint / credentials.
+///
+/// `region: None` defers to the SDK default chain (env, profile, IMDS);
+/// `endpoint_url` overrides the endpoint for LocalStack / VPC endpoints.
+/// Credential resolution is delegated to `aws-config`, so rotating
+/// credentials (web identity, instance profiles, assumed roles) refresh
+/// automatically — the client never caches static credentials itself.
+pub async fn build_client(
+    region: Option<&str>,
+    endpoint_url: Option<&str>,
+    credentials: &SqsCredentials,
+) -> Result<aws_sdk_sqs::Client, FaucetError> {
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    if let Some(region) = region {
+        loader = loader.region(aws_config::Region::new(region.to_owned()));
+    }
+    match credentials {
+        SqsCredentials::Default | SqsCredentials::WebIdentity => {}
+        SqsCredentials::Profile { name } => {
+            loader = loader.profile_name(name);
+        }
+        SqsCredentials::AccessKey {
+            access_key_id,
+            secret_access_key,
+            session_token,
+        } => {
+            let creds = aws_sdk_sqs::config::Credentials::new(
+                access_key_id.clone(),
+                secret_access_key.clone(),
+                session_token.clone(),
+                None,
+                "faucet-config",
+            );
+            loader = loader.credentials_provider(creds);
+        }
+        SqsCredentials::AssumeRole {
+            role_arn,
+            session_name,
+            external_id,
+        } => {
+            let mut builder = aws_config::sts::AssumeRoleProvider::builder(role_arn)
+                .session_name(session_name.as_deref().unwrap_or("faucet-stream"));
+            if let Some(region) = region {
+                builder = builder.region(aws_config::Region::new(region.to_owned()));
+            }
+            if let Some(external_id) = external_id {
+                builder = builder.external_id(external_id);
+            }
+            loader = loader.credentials_provider(builder.build().await);
+        }
+    }
+    let sdk_config = loader.load().await;
+    let mut sqs_config = aws_sdk_sqs::config::Builder::from(&sdk_config);
+    if let Some(endpoint) = endpoint_url {
+        sqs_config = sqs_config.endpoint_url(endpoint);
+    }
+    Ok(aws_sdk_sqs::Client::from_conf(sqs_config.build()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_parse_the_consistent_wire_shape() {
+        let yaml = "type: default\n";
+        let c: SqsCredentials = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(c, SqsCredentials::Default));
+
+        let yaml = "type: profile\nconfig: { name: prod }\n";
+        let c: SqsCredentials = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(c, SqsCredentials::Profile { name } if name == "prod"));
+
+        let yaml =
+            "type: access_key\nconfig:\n  access_key_id: AKIA\n  secret_access_key: s3cr3t\n";
+        let c: SqsCredentials = serde_yaml::from_str(yaml).unwrap();
+        match &c {
+            SqsCredentials::AccessKey {
+                access_key_id,
+                session_token,
+                ..
+            } => {
+                assert_eq!(access_key_id, "AKIA");
+                assert!(session_token.is_none());
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        // Debug never leaks the secret.
+        let dbg = format!("{c:?}");
+        assert!(!dbg.contains("s3cr3t"), "{dbg}");
+
+        let yaml = "type: assume_role\nconfig: { role_arn: 'arn:aws:iam::1:role/x' }\n";
+        let c: SqsCredentials = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(c, SqsCredentials::AssumeRole { .. }));
+
+        let yaml = "type: web_identity\n";
+        let c: SqsCredentials = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(c, SqsCredentials::WebIdentity));
+    }
+
+    #[test]
+    fn default_is_default() {
+        assert!(matches!(SqsCredentials::default(), SqsCredentials::Default));
+    }
+
+    #[tokio::test]
+    async fn build_client_honors_endpoint_and_static_keys() {
+        // Offline: constructing the client performs no network I/O.
+        let creds = SqsCredentials::AccessKey {
+            access_key_id: "test".into(),
+            secret_access_key: "test".into(),
+            session_token: None,
+        };
+        let client = build_client(Some("us-east-1"), Some("http://127.0.0.1:4566"), &creds)
+            .await
+            .expect("client builds");
+        assert_eq!(
+            client.config().region().map(|r| r.as_ref()),
+            Some("us-east-1")
+        );
+
+        // Every other variant also constructs offline (no network I/O).
+        for creds in [
+            SqsCredentials::Default,
+            SqsCredentials::WebIdentity,
+            SqsCredentials::Profile {
+                name: "no-such-profile".into(),
+            },
+            SqsCredentials::AssumeRole {
+                role_arn: "arn:aws:iam::123456789012:role/x".into(),
+                session_name: Some("t".into()),
+                external_id: Some("e".into()),
+            },
+        ] {
+            build_client(Some("us-east-1"), None, &creds)
+                .await
+                .expect("client builds offline");
+        }
+    }
+}

--- a/crates/common/sqs/src/lib.rs
+++ b/crates/common/sqs/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-sqs
+//!
+//! Shared configuration types for the faucet-stream AWS SQS source
+//! (`faucet-source-sqs`) and sink (`faucet-sink-sqs`) connectors: the
+//! [`SqsCredentials`] auth enum and the [`build_client`] helper that assembles
+//! an `aws_sdk_sqs::Client` from region / endpoint / credential settings. Both
+//! connector crates re-export these so end-user imports do not change.
+
+mod auth;
+
+pub use auth::{SqsCredentials, build_client};

--- a/crates/sink/duckdb/CHANGELOG.md
+++ b/crates/sink/duckdb/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: DuckDB sink — writes JSON records to a DuckDB table via a
+  JSON column or auto-mapped columns, each batch a transaction-wrapped
+  multi-row INSERT. Conformance battery wired ([#413](https://github.com/PawanSikawat/faucet-stream/issues/413)).

--- a/crates/sink/duckdb/Cargo.toml
+++ b/crates/sink/duckdb/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "faucet-sink-duckdb"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "DuckDB sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["duckdb", "olap", "analytics", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+duckdb = { workspace = true, features = ["bundled"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+tempfile = "3"
+faucet-conformance.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/duckdb/README.md
+++ b/crates/sink/duckdb/README.md
@@ -1,0 +1,44 @@
+# faucet-sink-duckdb
+
+DuckDB sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream)
+data-movement platform. Writes JSON records to a DuckDB table using either a
+single JSON text column or dynamic column mapping. Each batch is one
+`BEGIN`/`COMMIT` transaction of `batch_size`-row multi-row `INSERT`s, rolled
+back on error.
+
+DuckDB is a synchronous embedded engine, so writes run on a blocking thread.
+The target table must already exist. The sink is **append-only**; keyed upsert
+and an Arrow-native columnar fast path are tracked as follow-ups.
+
+## Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `database` | string | — | Path to the `.duckdb` file, or `:memory:`. A `duckdb://` / `duckdb:` prefix is accepted and stripped. |
+| `table_name` | string | — | Target table (must already exist). |
+| `column_mapping` | enum | `{json: {column: "data"}}` | `json` stores each record as one JSON text column; `auto_map` maps top-level keys onto matching columns. |
+| `batch_size` | integer | `1000` | Rows per multi-row INSERT. `0` = one INSERT for the whole slice. |
+
+## Example
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: jsonl
+    config:
+      path: events.jsonl
+  sink:
+    type: duckdb
+    config:
+      database: warehouse.duckdb
+      table_name: events
+      column_mapping: auto_map
+      batch_size: 5000
+```
+
+## Conformance
+
+Wires the [`faucet-conformance`](https://docs.rs/faucet-conformance) battery in
+`tests/conformance.rs` — config-schema validity and truthful capabilities
+(append works; the sink honestly advertises no idempotency mechanism).

--- a/crates/sink/duckdb/src/config.rs
+++ b/crates/sink/duckdb/src/config.rs
@@ -1,0 +1,117 @@
+//! DuckDB sink configuration.
+
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How to map JSON records to table columns.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DuckdbColumnMapping {
+    /// Insert each record as a single JSON text column.
+    Json { column: String },
+    /// Map top-level JSON keys directly to table columns. Only keys that match
+    /// existing columns are inserted; extra keys are ignored.
+    AutoMap,
+}
+
+impl Default for DuckdbColumnMapping {
+    fn default() -> Self {
+        Self::Json {
+            column: "data".into(),
+        }
+    }
+}
+
+/// Configuration for the DuckDB sink.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DuckdbSinkConfig {
+    /// Path to the DuckDB database file, or `:memory:`. A `duckdb://` /
+    /// `duckdb:` scheme prefix is accepted and stripped. The target table must
+    /// already exist.
+    pub database: String,
+    /// Target table name.
+    pub table_name: String,
+    /// How to map JSON records to columns.
+    #[serde(default)]
+    pub column_mapping: DuckdbColumnMapping,
+    /// Maximum number of rows per multi-row INSERT. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`] (1000). `batch_size = 0` writes the entire
+    /// upstream slice as a single multi-row INSERT (no re-chunking).
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+impl DuckdbSinkConfig {
+    /// Create a new config with required fields and sensible defaults.
+    pub fn new(database: impl Into<String>, table_name: impl Into<String>) -> Self {
+        Self {
+            database: database.into(),
+            table_name: table_name.into(),
+            column_mapping: DuckdbColumnMapping::default(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Set the column mapping strategy.
+    pub fn column_mapping(mut self, mapping: DuckdbColumnMapping) -> Self {
+        self.column_mapping = mapping;
+        self
+    }
+
+    /// Set the maximum number of rows per multi-row INSERT. `0` disables
+    /// re-chunking.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// The filesystem path with any `duckdb://` / `duckdb:` scheme stripped.
+    pub(crate) fn resolved_path(&self) -> &str {
+        self.database
+            .trim_start_matches("duckdb://")
+            .trim_start_matches("duckdb:")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = DuckdbSinkConfig::new(":memory:", "events");
+        assert_eq!(config.table_name, "events");
+        assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(matches!(
+            config.column_mapping,
+            DuckdbColumnMapping::Json { ref column } if column == "data"
+        ));
+    }
+
+    #[test]
+    fn builder_methods() {
+        let config = DuckdbSinkConfig::new(":memory:", "events")
+            .column_mapping(DuckdbColumnMapping::AutoMap)
+            .with_batch_size(100);
+        assert_eq!(config.batch_size, 100);
+        assert!(matches!(
+            config.column_mapping,
+            DuckdbColumnMapping::AutoMap
+        ));
+    }
+
+    #[test]
+    fn batch_size_deserializes_and_defaults() {
+        let json = r#"{ "database": ":memory:", "table_name": "events" }"#;
+        let config: DuckdbSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
+        let json2 = r#"{ "database": ":memory:", "table_name": "e", "batch_size": 250 }"#;
+        let config2: DuckdbSinkConfig = serde_json::from_str(json2).unwrap();
+        assert_eq!(config2.batch_size, 250);
+    }
+}

--- a/crates/sink/duckdb/src/lib.rs
+++ b/crates/sink/duckdb/src/lib.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-duckdb
+//!
+//! DuckDB sink connector for the faucet-stream ecosystem.
+//!
+//! Writes `serde_json::Value` records to a DuckDB table using either a single
+//! JSON text column or dynamic column mapping, with each batch issued as a
+//! transaction-wrapped multi-row `INSERT`. Mirrors the
+//! [`faucet-sink-sqlite`](https://docs.rs/faucet-sink-sqlite) sink.
+
+pub mod config;
+pub mod sink;
+
+pub use faucet_core::{FaucetError, Sink};
+
+pub use config::{DuckdbColumnMapping, DuckdbSinkConfig};
+pub use sink::DuckdbSink;

--- a/crates/sink/duckdb/src/sink.rs
+++ b/crates/sink/duckdb/src/sink.rs
@@ -1,0 +1,401 @@
+//! DuckDB sink implementation — the one module that performs I/O.
+//!
+//! `duckdb` is synchronous, so every write runs inside
+//! [`tokio::task::spawn_blocking`]. Each `write_batch` is applied as one
+//! `BEGIN`/`COMMIT` transaction of `batch_size`-row multi-row `INSERT`s
+//! (rolled back on error). The sink is append-only; keyed upsert and an
+//! Arrow-native columnar fast path are tracked as follow-ups.
+
+use crate::config::{DuckdbColumnMapping, DuckdbSinkConfig};
+use async_trait::async_trait;
+use duckdb::types::Value as DuckValue;
+use duckdb::{AccessMode, Config, Connection};
+use faucet_core::FaucetError;
+use faucet_core::util::quote_ident;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+/// A sink that writes JSON records to a DuckDB table.
+pub struct DuckdbSink {
+    config: DuckdbSinkConfig,
+    conn: Arc<Mutex<Connection>>,
+}
+
+fn open(path: &str) -> Result<Connection, FaucetError> {
+    let flags = Config::default()
+        .access_mode(AccessMode::ReadWrite)
+        .map_err(|e| FaucetError::Config(format!("duckdb config: {e}")))?;
+    let conn = if path == ":memory:" {
+        Connection::open_in_memory_with_flags(flags)
+    } else {
+        Connection::open_with_flags(path, flags)
+    };
+    conn.map_err(|e| FaucetError::Sink(format!("DuckDB open failed ({path}): {e}")))
+}
+
+/// Convert a JSON value into an owned DuckDB parameter value.
+fn json_to_duck(v: &Value) -> DuckValue {
+    match v {
+        Value::Null => DuckValue::Null,
+        Value::Bool(b) => DuckValue::Boolean(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                DuckValue::BigInt(i)
+            } else if let Some(u) = n.as_u64() {
+                DuckValue::UBigInt(u)
+            } else if let Some(f) = n.as_f64() {
+                DuckValue::Double(f)
+            } else {
+                DuckValue::Null
+            }
+        }
+        Value::String(s) => DuckValue::Text(s.clone()),
+        // Arrays/objects have no scalar SQL form — store their JSON text.
+        other => DuckValue::Text(other.to_string()),
+    }
+}
+
+/// Insert records as a single JSON text column via one multi-row INSERT.
+fn insert_json(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    records: &[Value],
+) -> Result<usize, FaucetError> {
+    if records.is_empty() {
+        return Ok(0);
+    }
+    let placeholders = vec!["(?)"; records.len()].join(", ");
+    let sql = format!(
+        "INSERT INTO {} ({}) VALUES {}",
+        quote_ident(table),
+        quote_ident(column),
+        placeholders
+    );
+    let mut params: Vec<DuckValue> = Vec::with_capacity(records.len());
+    for r in records {
+        let text = serde_json::to_string(r)
+            .map_err(|e| FaucetError::Sink(format!("failed to serialize record: {e}")))?;
+        params.push(DuckValue::Text(text));
+    }
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| FaucetError::Sink(format!("DuckDB prepare failed: {e}")))?;
+    stmt.execute(duckdb::params_from_iter(params))
+        .map_err(|e| FaucetError::Sink(format!("DuckDB insert failed: {e}")))?;
+    Ok(records.len())
+}
+
+/// Insert records mapping top-level JSON keys onto existing table columns.
+fn insert_auto_map(
+    conn: &Connection,
+    table: &str,
+    records: &[Value],
+) -> Result<usize, FaucetError> {
+    if records.is_empty() {
+        return Ok(0);
+    }
+
+    // Discover the table's columns (in declared order) via information_schema.
+    let mut cstmt = conn
+        .prepare(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_name = ? ORDER BY ordinal_position",
+        )
+        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?;
+    let cols: Vec<String> = cstmt
+        .query_map([table], |row| row.get::<_, String>(0))
+        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
+        .collect::<Result<Vec<String>, _>>()
+        .map_err(|e| FaucetError::Sink(format!("failed to decode table columns: {e}")))?;
+
+    if cols.is_empty() {
+        return Err(FaucetError::Sink(format!(
+            "table '{table}' has no columns or does not exist"
+        )));
+    }
+
+    // Records with at least one matching column; the INSERT column set is the
+    // union of table columns present in any such record (declared order). A row
+    // missing a unioned column binds SQL NULL. Records with no matching key are
+    // skipped (mirrors the SQLite sink).
+    let mut used: HashSet<&str> = HashSet::new();
+    let mut rows: Vec<&serde_json::Map<String, Value>> = Vec::with_capacity(records.len());
+    for rec in records {
+        let obj = rec
+            .as_object()
+            .ok_or_else(|| FaucetError::Sink("AutoMap requires JSON object records".into()))?;
+        if !cols.iter().any(|c| obj.contains_key(c)) {
+            tracing::warn!(
+                record_keys = ?obj.keys().collect::<Vec<_>>(),
+                "record has no keys matching table columns, skipping"
+            );
+            continue;
+        }
+        for c in &cols {
+            if obj.contains_key(c) {
+                used.insert(c.as_str());
+            }
+        }
+        rows.push(obj);
+    }
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let insert_cols: Vec<&String> = cols.iter().filter(|c| used.contains(c.as_str())).collect();
+    let num_cols = insert_cols.len();
+    let col_list = insert_cols
+        .iter()
+        .map(|c| quote_ident(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let row_ph = format!("({})", vec!["?"; num_cols].join(", "));
+    let values = vec![row_ph.as_str(); rows.len()].join(", ");
+    let sql = format!(
+        "INSERT INTO {} ({}) VALUES {}",
+        quote_ident(table),
+        col_list,
+        values
+    );
+
+    let mut params: Vec<DuckValue> = Vec::with_capacity(rows.len() * num_cols);
+    for obj in &rows {
+        for c in &insert_cols {
+            params.push(obj.get(*c).map(json_to_duck).unwrap_or(DuckValue::Null));
+        }
+    }
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| FaucetError::Sink(format!("DuckDB prepare failed: {e}")))?;
+    stmt.execute(duckdb::params_from_iter(params))
+        .map_err(|e| FaucetError::Sink(format!("DuckDB insert failed: {e}")))?;
+    Ok(rows.len())
+}
+
+/// Apply the whole batch inside one `BEGIN`/`COMMIT` transaction, re-chunking
+/// into `batch_size` multi-row INSERTs. Any error rolls the transaction back.
+fn write_all_blocking(
+    conn: &Arc<Mutex<Connection>>,
+    config: &DuckdbSinkConfig,
+    records: &[Value],
+) -> Result<usize, FaucetError> {
+    let guard = conn
+        .lock()
+        .map_err(|_| FaucetError::Sink("duckdb connection mutex poisoned".into()))?;
+
+    let chunk = if config.batch_size == 0 {
+        records.len().max(1)
+    } else {
+        config.batch_size
+    };
+
+    guard
+        .execute_batch("BEGIN TRANSACTION")
+        .map_err(|e| FaucetError::Sink(format!("DuckDB begin failed: {e}")))?;
+
+    let applied = (|| -> Result<usize, FaucetError> {
+        let mut total = 0usize;
+        for c in records.chunks(chunk) {
+            total += match &config.column_mapping {
+                DuckdbColumnMapping::Json { column } => {
+                    insert_json(&guard, &config.table_name, column, c)?
+                }
+                DuckdbColumnMapping::AutoMap => insert_auto_map(&guard, &config.table_name, c)?,
+            };
+        }
+        Ok(total)
+    })();
+
+    match applied {
+        Ok(total) => {
+            guard
+                .execute_batch("COMMIT")
+                .map_err(|e| FaucetError::Sink(format!("DuckDB commit failed: {e}")))?;
+            Ok(total)
+        }
+        Err(e) => {
+            let _ = guard.execute_batch("ROLLBACK");
+            Err(e)
+        }
+    }
+}
+
+impl DuckdbSink {
+    /// Create a new DuckDB sink, opening (and reusing) one read-write connection.
+    pub async fn new(config: DuckdbSinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        let path = config.resolved_path().to_string();
+        let conn = tokio::task::spawn_blocking(move || open(&path))
+            .await
+            .map_err(|e| FaucetError::Sink(format!("duckdb open task panicked: {e}")))??;
+        Ok(Self {
+            config,
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Run an arbitrary SQL statement (e.g. DDL) on the sink's connection.
+    ///
+    /// Exposed for setup/introspection in tests and tooling — DuckDB permits a
+    /// single read-write handle per database, so callers that need to create a
+    /// table or inspect state must go through the sink's own connection.
+    #[doc(hidden)]
+    pub async fn run_sql(&self, sql: &str) -> Result<(), FaucetError> {
+        let conn = self.conn.clone();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn
+                .lock()
+                .map_err(|_| FaucetError::Sink("duckdb connection mutex poisoned".into()))?;
+            guard
+                .execute_batch(&sql)
+                .map_err(|e| FaucetError::Sink(format!("DuckDB statement failed: {e}")))
+        })
+        .await
+        .map_err(|e| FaucetError::Sink(format!("duckdb task panicked: {e}")))?
+    }
+
+    /// `SELECT count(*)` over `table` on the sink's connection.
+    #[doc(hidden)]
+    pub async fn scalar_count(&self, table: &str) -> Result<i64, FaucetError> {
+        let conn = self.conn.clone();
+        let sql = format!("SELECT count(*) FROM {}", quote_ident(table));
+        tokio::task::spawn_blocking(move || {
+            let guard = conn
+                .lock()
+                .map_err(|_| FaucetError::Sink("duckdb connection mutex poisoned".into()))?;
+            guard
+                .query_row(&sql, [], |r| r.get::<_, i64>(0))
+                .map_err(|e| FaucetError::Sink(format!("DuckDB count failed: {e}")))
+        })
+        .await
+        .map_err(|e| FaucetError::Sink(format!("duckdb task panicked: {e}")))?
+    }
+}
+
+#[async_trait]
+impl faucet_core::Sink for DuckdbSink {
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(DuckdbSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "duckdb"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "duckdb://{}?table={}",
+            self.config.resolved_path(),
+            self.config.table_name
+        )
+    }
+
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.conn.clone();
+        let config = self.config.clone();
+        let owned = records.to_vec();
+        let n = tokio::task::spawn_blocking(move || write_all_blocking(&conn, &config, &owned))
+            .await
+            .map_err(|e| FaucetError::Sink(format!("duckdb write task panicked: {e}")))??;
+        tracing::info!(
+            table = %self.config.table_name,
+            rows = n,
+            "DuckDB write complete"
+        );
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::Sink as _;
+    use serde_json::json;
+
+    async fn sink_with_table(ddl: &str, table: &str, mapping: DuckdbColumnMapping) -> DuckdbSink {
+        let sink =
+            DuckdbSink::new(DuckdbSinkConfig::new(":memory:", table).column_mapping(mapping))
+                .await
+                .unwrap();
+        sink.conn.lock().unwrap().execute_batch(ddl).expect("ddl");
+        sink
+    }
+
+    fn count(sink: &DuckdbSink, table: &str) -> i64 {
+        let guard = sink.conn.lock().unwrap();
+        guard
+            .query_row(
+                &format!("SELECT count(*) FROM {}", quote_ident(table)),
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn writes_json_column() {
+        let sink = sink_with_table(
+            "CREATE TABLE events (data TEXT)",
+            "events",
+            DuckdbColumnMapping::Json {
+                column: "data".into(),
+            },
+        )
+        .await;
+        let n = sink
+            .write_batch(&[json!({"a": 1}), json!({"a": 2})])
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(count(&sink, "events"), 2);
+        assert_eq!(sink.connector_name(), "duckdb");
+    }
+
+    #[tokio::test]
+    async fn writes_auto_mapped_columns() {
+        let sink = sink_with_table(
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "t",
+            DuckdbColumnMapping::AutoMap,
+        )
+        .await;
+        let n = sink
+            .write_batch(&[
+                json!({"id": 1, "name": "a", "extra": "ignored"}),
+                json!({"id": 2, "name": "b"}),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(count(&sink, "t"), 2);
+    }
+
+    #[tokio::test]
+    async fn empty_batch_is_noop() {
+        let sink = sink_with_table(
+            "CREATE TABLE t (data TEXT)",
+            "t",
+            DuckdbColumnMapping::default(),
+        )
+        .await;
+        assert_eq!(sink.write_batch(&[]).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_table_errors_not_panics() {
+        let sink = DuckdbSink::new(
+            DuckdbSinkConfig::new(":memory:", "nope").column_mapping(DuckdbColumnMapping::AutoMap),
+        )
+        .await
+        .unwrap();
+        assert!(sink.write_batch(&[json!({"a": 1})]).await.is_err());
+    }
+}

--- a/crates/sink/duckdb/tests/conformance.rs
+++ b/crates/sink/duckdb/tests/conformance.rs
@@ -1,0 +1,45 @@
+//! `faucet-conformance` battery against the real DuckDB sink (in-memory) — no
+//! Docker required.
+//!
+//! - check 1 `assert_config_schema_valid_value` (value form, for sinks);
+//! - check 5 `assert_capabilities_truthful` — Append adds rows, and the sink
+//!   honestly advertises no idempotency mechanism (so the pipeline correctly
+//!   refuses `delivery: exactly_once` for it).
+//!
+//! DuckDB permits only a single read-write handle per database, so the table is
+//! created and counted on the sink's own connection via its `#[doc(hidden)]`
+//! test helpers (the battery writes `{id, v}` records into an `auto_map` table).
+
+use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::Sink;
+use faucet_sink_duckdb::{DuckdbColumnMapping, DuckdbSink, DuckdbSinkConfig};
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(DuckdbSinkConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-sink-duckdb");
+}
+
+#[tokio::test]
+async fn conformance_capabilities_truthful() {
+    let sink = DuckdbSink::new(
+        DuckdbSinkConfig::new(":memory:", "t").column_mapping(DuckdbColumnMapping::AutoMap),
+    )
+    .await
+    .expect("sink");
+
+    // The battery writes {id: i64, v: string}; seed the matching table on the
+    // sink's own connection.
+    sink.run_sql("CREATE TABLE t (id BIGINT, v TEXT)")
+        .await
+        .expect("create table");
+
+    let sink_ref = &sink;
+    faucet_conformance::assert_capabilities_truthful(&sink, || async move {
+        sink_ref.scalar_count("t").await.expect("count") as usize
+    })
+    .await;
+
+    assert!(!sink.supports_idempotent_writes());
+    assert!(!sink.dedups_by_key());
+}

--- a/crates/sink/nats/CHANGELOG.md
+++ b/crates/sink/nats/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: NATS sink — publishes each record as a JSON message to a
+  fixed subject or a per-record subject (`subject_field`), flushing after each
+  batch. Append-only. Conformance battery wired
+  ([#411](https://github.com/PawanSikawat/faucet-stream/issues/411)).

--- a/crates/sink/nats/Cargo.toml
+++ b/crates/sink/nats/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "faucet-sink-nats"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "NATS sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["nats", "messaging", "streaming", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-nats.workspace = true
+async-nats.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+futures.workspace = true
+faucet-conformance.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["nats"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/nats/README.md
+++ b/crates/sink/nats/README.md
@@ -1,0 +1,54 @@
+# faucet-sink-nats
+
+A [NATS](https://nats.io) sink for [`faucet-stream`](https://crates.io/crates/faucet-stream).
+
+Publishes each record as a JSON message to a subject — fixed, or per-record via
+a configurable `subject_field`. The client is flushed after each batch, so
+nothing is left buffered when a write returns.
+
+Append-only: it does not override idempotency, upsert, or schema-evolution (the
+trait defaults hold).
+
+## Configuration
+
+The shared connection surface (`servers` / `auth` / `tls` / `name` — see
+[`faucet-common-nats`](https://crates.io/crates/faucet-common-nats)) is flattened
+in alongside these fields:
+
+| field           | type             | default | description                                                        |
+|-----------------|------------------|---------|--------------------------------------------------------------------|
+| `subject`       | `String`         | —       | default subject every record is published to. Required.            |
+| `subject_field` | `Option<String>` | —       | top-level record field whose string value overrides `subject` per record. |
+| `batch_size`    | `usize`          | `1000`  | records per publish batch (client flushed after each batch).       |
+
+## Example
+
+```yaml
+version: 1
+pipeline:
+  source:
+    kind: jsonl
+    config:
+      path: events.jsonl
+  sink:
+    kind: nats
+    config:
+      servers: ["nats://127.0.0.1:4222"]
+      subject: "events.ingested"
+      batch_size: 1000
+```
+
+### Subject per record
+
+```yaml
+  sink:
+    kind: nats
+    config:
+      servers: ["nats://127.0.0.1:4222"]
+      subject: "events.default"    # fallback / default
+      subject_field: "topic"        # each record's `topic` string is the subject
+```
+
+## License
+
+Licensed under either of Apache-2.0 or MIT at your option.

--- a/crates/sink/nats/src/config.rs
+++ b/crates/sink/nats/src/config.rs
@@ -1,0 +1,118 @@
+//! Configuration for the NATS sink.
+
+use faucet_common_nats::NatsConnectionConfig;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for [`NatsSink`](crate::NatsSink).
+///
+/// The [`NatsConnectionConfig`] surface (`servers` / `auth` / `tls` / `name`)
+/// is flattened in.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NatsSinkConfig {
+    /// Connection settings (servers, auth, tls, name).
+    #[serde(flatten)]
+    pub connection: NatsConnectionConfig,
+
+    /// Default subject every record is published to.
+    pub subject: String,
+
+    /// Optional top-level record field whose (string) value overrides
+    /// [`subject`](Self::subject) on a per-record basis — the subject-per-record
+    /// pattern. When the field is missing or is not a string the sink errors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_field: Option<String>,
+
+    /// Records per publish batch. Records are published one NATS message each;
+    /// after every `batch_size` records the client is flushed so nothing is
+    /// lost. Defaults to [`DEFAULT_BATCH_SIZE`]. `0` publishes the whole batch
+    /// handed by the pipeline, flushing once at the end.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+impl NatsSinkConfig {
+    /// Convenience constructor for a fixed-subject sink.
+    pub fn new(subject: impl Into<String>) -> Self {
+        Self {
+            connection: NatsConnectionConfig::default(),
+            subject: subject.into(),
+            subject_field: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Validate the config at construction time.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        if self.subject.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "nats sink: `subject` must not be empty".into(),
+            ));
+        }
+        if let Some(field) = &self.subject_field
+            && field.trim().is_empty()
+        {
+            return Err(FaucetError::Config(
+                "nats sink: `subject_field` must not be empty when set".into(),
+            ));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validate_accepts_minimal() {
+        assert!(NatsSinkConfig::new("events.out").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_subject() {
+        let mut c = NatsSinkConfig::new("x");
+        c.subject = " ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_subject_field() {
+        let mut c = NatsSinkConfig::new("x");
+        c.subject_field = Some("".into());
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_batch_size_over_max() {
+        let mut c = NatsSinkConfig::new("x");
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(matches!(c.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn deserialize_flattened() {
+        let c: NatsSinkConfig = serde_json::from_value(json!({
+            "servers": ["nats://a:4222"],
+            "subject": "events.out",
+            "subject_field": "topic"
+        }))
+        .unwrap();
+        assert_eq!(c.subject, "events.out");
+        assert_eq!(c.subject_field.as_deref(), Some("topic"));
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn schema_compiles() {
+        let _ = schemars::schema_for!(NatsSinkConfig);
+    }
+}

--- a/crates/sink/nats/src/lib.rs
+++ b/crates/sink/nats/src/lib.rs
@@ -1,0 +1,30 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-nats
+//!
+//! A [NATS](https://nats.io) sink for `faucet-stream`. Publishes each record as
+//! a JSON message to a subject — fixed, or per-record via a configurable
+//! `subject_field`. The client is flushed after each batch so nothing is left
+//! buffered when the write returns.
+//!
+//! Append-only: it does not override idempotency, upsert, or schema-evolution
+//! (the trait defaults hold).
+//!
+//! ```no_run
+//! use faucet_sink_nats::{NatsSink, NatsSinkConfig};
+//! # async fn ex() -> Result<(), faucet_core::FaucetError> {
+//! let sink = NatsSink::new(NatsSinkConfig::new("events.out")).await?;
+//! # let _ = sink;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod config;
+pub mod sink;
+
+pub use config::NatsSinkConfig;
+pub use sink::NatsSink;
+
+// Re-export shared config types so downstream users import from one place.
+pub use faucet_common_nats::{NatsAuth, NatsConnectionConfig};
+pub use faucet_core::{FaucetError, Sink};

--- a/crates/sink/nats/src/sink.rs
+++ b/crates/sink/nats/src/sink.rs
@@ -1,0 +1,198 @@
+//! `NatsSink` — the NATS producer implementation (the one module that does I/O).
+//!
+//! Append-only: each record is serialized to JSON and published to a subject
+//! (fixed, or per-record from `subject_field`). After each batch the client is
+//! flushed so no message is left buffered when `write_batch` returns.
+
+use crate::config::NatsSinkConfig;
+use async_trait::async_trait;
+use bytes::Bytes;
+use faucet_core::{FaucetError, Sink};
+use serde_json::Value;
+use tokio::sync::OnceCell;
+
+/// A sink that publishes each record as a JSON NATS message.
+///
+/// The client is built lazily on the first write (see [`NatsSink::new`]), so an
+/// unreachable server fails on the first `write_batch` rather than at
+/// construction time. The client is reused across batches.
+pub struct NatsSink {
+    config: NatsSinkConfig,
+    client: OnceCell<async_nats::Client>,
+}
+
+impl NatsSink {
+    /// Create a new NATS sink. Validates the config but does **not** connect —
+    /// the client is built lazily on the first write.
+    pub async fn new(config: NatsSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            client: OnceCell::new(),
+        })
+    }
+
+    /// Lazily build (once) and return the shared NATS client.
+    async fn client(&self) -> Result<async_nats::Client, FaucetError> {
+        self.client
+            .get_or_try_init(|| faucet_common_nats::connect(&self.config.connection))
+            .await
+            .cloned()
+    }
+
+    /// Resolve the destination subject for a record: the per-record
+    /// `subject_field` value when configured, else the fixed `subject`.
+    fn resolve_subject(&self, record: &Value) -> Result<String, FaucetError> {
+        match &self.config.subject_field {
+            None => Ok(self.config.subject.clone()),
+            Some(field) => match record.get(field) {
+                Some(Value::String(s)) if !s.is_empty() => Ok(s.clone()),
+                Some(Value::String(_)) => Err(FaucetError::Sink(format!(
+                    "nats sink: subject_field '{field}' resolved to an empty string"
+                ))),
+                Some(other) => Err(FaucetError::Sink(format!(
+                    "nats sink: subject_field '{field}' must be a string, got {other}"
+                ))),
+                None => Err(FaucetError::Sink(format!(
+                    "nats sink: subject_field '{field}' is absent from record"
+                ))),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Sink for NatsSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let client = self.client().await?;
+
+        let mut written = 0usize;
+        for record in records {
+            let subject = self.resolve_subject(record)?;
+            let payload = serde_json::to_vec(record)?;
+            client
+                .publish(subject, Bytes::from(payload))
+                .await
+                .map_err(|e| FaucetError::Sink(format!("nats publish: {e}")))?;
+            written += 1;
+        }
+
+        // Flush before returning so the batch is on the wire — nothing is left
+        // buffered in the client when the pipeline advances.
+        self.flush().await?;
+        Ok(written)
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        let client = self.client().await?;
+        client
+            .flush()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("nats flush: {e}")))?;
+        Ok(())
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(NatsSinkConfig)).unwrap_or(Value::Null)
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "nats"
+    }
+
+    fn dataset_uri(&self) -> String {
+        let server = self
+            .config
+            .connection
+            .servers
+            .first()
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        let subject = match &self.config.subject_field {
+            Some(f) => format!("(from_field:{f})"),
+            None => self.config.subject.clone(),
+        };
+        format!("nats://{server}?subject={subject}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn new_validates_config() {
+        let mut cfg = NatsSinkConfig::new("x");
+        cfg.subject = " ".into();
+        assert!(NatsSink::new(cfg).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_subject_fixed() {
+        let sink = NatsSink::new(NatsSinkConfig::new("events.out"))
+            .await
+            .unwrap();
+        let s = sink.resolve_subject(&json!({"id": 1})).unwrap();
+        assert_eq!(s, "events.out");
+    }
+
+    #[tokio::test]
+    async fn resolve_subject_from_field() {
+        let mut cfg = NatsSinkConfig::new("events.out");
+        cfg.subject_field = Some("topic".into());
+        let sink = NatsSink::new(cfg).await.unwrap();
+        let s = sink
+            .resolve_subject(&json!({"topic": "orders.new", "id": 1}))
+            .unwrap();
+        assert_eq!(s, "orders.new");
+    }
+
+    #[tokio::test]
+    async fn resolve_subject_missing_field_errors() {
+        let mut cfg = NatsSinkConfig::new("events.out");
+        cfg.subject_field = Some("topic".into());
+        let sink = NatsSink::new(cfg).await.unwrap();
+        let err = sink.resolve_subject(&json!({"id": 1})).unwrap_err();
+        assert!(matches!(err, FaucetError::Sink(_)));
+    }
+
+    #[tokio::test]
+    async fn resolve_subject_non_string_field_errors() {
+        let mut cfg = NatsSinkConfig::new("events.out");
+        cfg.subject_field = Some("topic".into());
+        let sink = NatsSink::new(cfg).await.unwrap();
+        let err = sink.resolve_subject(&json!({"topic": 42})).unwrap_err();
+        assert!(matches!(err, FaucetError::Sink(_)));
+    }
+
+    #[tokio::test]
+    async fn connector_name_and_uri() {
+        let sink = NatsSink::new(NatsSinkConfig::new("events.out"))
+            .await
+            .unwrap();
+        assert_eq!(sink.connector_name(), "nats");
+        assert!(sink.dataset_uri().contains("subject=events.out"));
+    }
+
+    #[tokio::test]
+    async fn write_batch_empty_is_noop_no_connect() {
+        // No connect happens on an empty batch, so an unreachable server is fine.
+        let mut cfg = NatsSinkConfig::new("events.out");
+        cfg.connection.servers = vec!["nats://127.0.0.1:1".into()];
+        let sink = NatsSink::new(cfg).await.unwrap();
+        assert_eq!(sink.write_batch(&[]).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn write_batch_unreachable_errors_not_panics() {
+        let mut cfg = NatsSinkConfig::new("events.out");
+        cfg.connection.servers = vec!["nats://127.0.0.1:1".into()];
+        let sink = NatsSink::new(cfg).await.unwrap();
+        let err = sink.write_batch(&[json!({"id": 1})]).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Custom(_)));
+    }
+}

--- a/crates/sink/nats/tests/conformance.rs
+++ b/crates/sink/nats/tests/conformance.rs
@@ -1,0 +1,77 @@
+//! `faucet-conformance` Tier-1 battery for the NATS sink.
+//!
+//! - **Check 1** (`conformance_config_schema_valid`) — pure/offline, MUST pass.
+//! - **Check 5** (`conformance_capabilities_truthful`) — boots a real NATS
+//!   server via `testcontainers-modules` (Docker) and verifies the append-only
+//!   capability surface against real behaviour. Docker-gated; runs only where a
+//!   Docker daemon is available.
+//!
+//! Idempotency checks (3/4) do not apply — the NATS sink is append-only and
+//! advertises no idempotency/keyed-upsert mechanism.
+
+use faucet_conformance::assert_config_schema_valid_value;
+use faucet_sink_nats::NatsSinkConfig;
+
+// ── Check 1: config schema (offline) ────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(NatsSinkConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-sink-nats");
+}
+
+// ── Check 5: capabilities truthful (Docker) ──────────────────────────────────
+
+#[cfg(test)]
+mod docker {
+    use super::*;
+    use faucet_sink_nats::NatsSink;
+    use futures::StreamExt;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::nats::Nats;
+
+    async fn start_nats() -> (testcontainers::ContainerAsync<Nats>, String) {
+        let container = Nats::default().start().await.expect("nats container start");
+        let host = container.get_host().await.expect("nats host");
+        let port = container.get_host_port_ipv4(4222).await.expect("nats port");
+        (container, format!("nats://{host}:{port}"))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn conformance_capabilities_truthful() {
+        let (_container, server) = start_nats().await;
+        let subject = "conformance.sink";
+
+        // A background subscriber counts every message the sink publishes; the
+        // distinct_count closure settles briefly then reports the running total.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let sub_client = async_nats::connect(&server).await.expect("sub connect");
+        let mut subscriber = sub_client
+            .subscribe(subject.to_string())
+            .await
+            .expect("subscribe");
+        let counter_bg = counter.clone();
+        tokio::spawn(async move {
+            while subscriber.next().await.is_some() {
+                counter_bg.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let mut cfg = NatsSinkConfig::new(subject);
+        cfg.connection.servers = vec![server.clone()];
+        let sink = NatsSink::new(cfg).await.expect("sink new");
+
+        let counter_cl = counter.clone();
+        faucet_conformance::assert_capabilities_truthful(&sink, move || {
+            let c = counter_cl.clone();
+            async move {
+                // Let in-flight deliveries settle before reading the count.
+                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                c.load(Ordering::SeqCst)
+            }
+        })
+        .await;
+    }
+}

--- a/crates/sink/sftp/CHANGELOG.md
+++ b/crates/sink/sftp/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: SFTP sink connector — writes records to an SFTP server as
+  JSON Lines objects under a remote directory. Atomic writes (upload to a
+  temporary name, then rename into place), append-only, lazy connect with a
+  reused session, conformance battery wired ([#410](https://github.com/PawanSikawat/faucet-stream/issues/410)).

--- a/crates/sink/sftp/Cargo.toml
+++ b/crates/sink/sftp/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "faucet-sink-sftp"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SFTP sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["sftp", "ssh", "file", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-sftp.workspace = true
+russh-sftp.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "io-util", "net", "sync"] }
+uuid.workspace = true
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+faucet-common-sftp.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+schemars.workspace = true
+futures = { workspace = true }
+testcontainers = "0.27"
+tempfile = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/sftp/README.md
+++ b/crates/sink/sftp/README.md
@@ -1,0 +1,58 @@
+# faucet-sink-sftp
+
+SFTP sink connector for the [faucet-stream](https://crates.io/crates/faucet-stream)
+ecosystem.
+
+Writes records to an SFTP server as JSON Lines objects under a remote
+directory. Append-only.
+
+## Atomic writes
+
+Each object is uploaded to a hidden temporary name (`<uuid>.jsonl.tmp`) and then
+**renamed** to its final name (`<uuid>.jsonl`). A consumer watching the
+directory therefore never observes a partially-written file — a downstream
+reader either sees the complete object or does not see it at all.
+
+Connection, authentication, and host-key verification come from
+[`faucet-common-sftp`](https://crates.io/crates/faucet-common-sftp).
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | string | — | Server hostname or IP. |
+| `port` | integer | `22` | Server port. |
+| `username` | string | — | SSH username. |
+| `type` / `config` | auth | — | `password` or `private_key` (see `faucet-common-sftp`). |
+| `known_hosts` | policy | `{ mode: accept_new }` | Host-key verification policy. |
+| `path` | string | — | Remote directory prefix under which objects are written. |
+| `file_extension` | string | `.jsonl` | Extension for written objects. |
+| `batch_size` | integer | `1000` | Records per object; `0` = one object per `write_batch` call. |
+
+The sink opens the SSH connection lazily on the first write and reuses it. It
+attempts to create the target directory on first connect (best-effort).
+
+## Example
+
+```yaml
+version: 1
+pipeline:
+  source:
+    kind: stdout   # replace with a real source
+    config: {}
+  sink:
+    kind: sftp
+    config:
+      host: sftp.example.com
+      username: uploader
+      type: private_key
+      config:
+        path: /home/uploader/.ssh/id_ed25519
+      known_hosts:
+        mode: strict
+      path: /incoming/events
+      file_extension: .jsonl
+      batch_size: 0
+```
+
+Licensed under MIT OR Apache-2.0.

--- a/crates/sink/sftp/src/config.rs
+++ b/crates/sink/sftp/src/config.rs
@@ -1,0 +1,99 @@
+//! SFTP sink configuration.
+
+use faucet_common_sftp::SftpConnectionConfig;
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the SFTP sink connector.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SftpSinkConfig {
+    /// Shared SFTP connection settings (host, port, username, auth, host-key
+    /// policy). Flattened, so its fields sit at the top level of the config.
+    #[serde(flatten)]
+    pub connection: SftpConnectionConfig,
+    /// Remote directory prefix under which JSON Lines objects are written.
+    pub path: String,
+    /// File extension for written objects (default: `.jsonl`).
+    #[serde(default = "default_file_extension")]
+    pub file_extension: String,
+    /// Records per written object. When a `write_batch` call hands the sink
+    /// `N` records with `batch_size = M > 0`, the sink writes `ceil(N / M)`
+    /// objects. `batch_size = 0` writes whatever upstream hands it as a single
+    /// object. Defaults to [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_file_extension() -> String {
+    ".jsonl".to_string()
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+impl SftpSinkConfig {
+    /// Build a sink config from a connection and a remote directory prefix.
+    pub fn new(connection: SftpConnectionConfig, path: impl Into<String>) -> Self {
+        Self {
+            connection,
+            path: path.into(),
+            file_extension: default_file_extension(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Set the file extension for written objects.
+    pub fn file_extension(mut self, ext: impl Into<String>) -> Self {
+        self.file_extension = ext.into();
+        self
+    }
+
+    /// Set the per-object record count.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_sftp::SftpConnectionConfig;
+
+    fn conn() -> SftpConnectionConfig {
+        SftpConnectionConfig::with_password("h", "u", "p")
+    }
+
+    #[test]
+    fn defaults() {
+        let cfg = SftpSinkConfig::new(conn(), "/out");
+        assert_eq!(cfg.path, "/out");
+        assert_eq!(cfg.file_extension, ".jsonl");
+        assert_eq!(cfg.batch_size, DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn deserializes_flat_shape() {
+        let json = r#"{
+            "host": "sftp.example.com",
+            "username": "user",
+            "type": "password",
+            "config": { "password": "secret" },
+            "path": "/upload",
+            "batch_size": 0
+        }"#;
+        let cfg: SftpSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.connection.host, "sftp.example.com");
+        assert_eq!(cfg.path, "/upload");
+        assert_eq!(cfg.batch_size, 0);
+        assert_eq!(cfg.file_extension, ".jsonl");
+    }
+
+    #[test]
+    fn batch_size_zero_is_valid_sentinel() {
+        let cfg = SftpSinkConfig::new(conn(), "/o").with_batch_size(0);
+        assert!(faucet_core::validate_batch_size(cfg.batch_size).is_ok());
+    }
+}

--- a/crates/sink/sftp/src/lib.rs
+++ b/crates/sink/sftp/src/lib.rs
@@ -1,0 +1,20 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-sftp
+//!
+//! SFTP sink connector for the faucet-stream ecosystem.
+//!
+//! Writes `serde_json::Value` records to an SFTP server as JSON Lines objects
+//! under a remote directory. Writes are **atomic** — each object is uploaded to
+//! a temporary name and renamed into place, so consumers never observe a
+//! partial file. Append-only. Connection, authentication, and host-key
+//! verification come from [`faucet-common-sftp`](https://docs.rs/faucet-common-sftp).
+
+pub mod config;
+pub mod sink;
+
+pub use faucet_core::{FaucetError, Sink};
+
+pub use config::SftpSinkConfig;
+pub use faucet_common_sftp::{HostKeyPolicy, SftpAuth, SftpConnectionConfig};
+pub use sink::SftpSink;

--- a/crates/sink/sftp/src/sink.rs
+++ b/crates/sink/sftp/src/sink.rs
@@ -1,0 +1,245 @@
+//! SFTP sink executor.
+//!
+//! Writes each `write_batch` chunk as a JSON Lines object under a remote
+//! directory. Writes are **atomic**: each object is uploaded to a hidden
+//! temporary name and then renamed to its final name, so a consumer watching
+//! the directory never observes a partially-written file. Construction is lazy
+//! — [`SftpSink::new`] performs no I/O; the SSH transport is opened on the
+//! first `write_batch` and reused for the life of the sink.
+
+use crate::config::SftpSinkConfig;
+use async_trait::async_trait;
+use faucet_common_sftp::{SftpSession, connect};
+use faucet_core::FaucetError;
+use russh_sftp::protocol::OpenFlags;
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+/// A sink that writes JSON records to an SFTP server as JSON Lines objects.
+pub struct SftpSink {
+    config: SftpSinkConfig,
+    /// Reused SFTP session, opened on first write. Behind a `Mutex` so writes
+    /// share one SSH connection instead of reconnecting per page.
+    session: Mutex<Option<SftpSession>>,
+}
+
+impl SftpSink {
+    /// Create a new SFTP sink. Lazy: performs no I/O and never connects here.
+    /// The batch size is validated up front so a bad config fails fast.
+    pub fn new(config: SftpSinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        Ok(Self {
+            config,
+            session: Mutex::new(None),
+        })
+    }
+
+    /// Serialize a slice of records as JSON Lines bytes.
+    fn serialize_jsonl(records: &[Value]) -> Result<Vec<u8>, FaucetError> {
+        let mut buf: Vec<u8> = Vec::new();
+        for record in records {
+            let line = serde_json::to_vec(record)
+                .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?;
+            buf.extend_from_slice(&line);
+            buf.push(b'\n');
+        }
+        Ok(buf)
+    }
+
+    /// Join the configured directory prefix with a file name using POSIX `/`.
+    fn join_path(&self, name: &str) -> String {
+        let dir = &self.config.path;
+        if dir.is_empty() {
+            name.to_string()
+        } else if dir.ends_with('/') {
+            format!("{dir}{name}")
+        } else {
+            format!("{dir}/{name}")
+        }
+    }
+
+    /// Generate the final object key: `{path}/{uuid}{ext}`.
+    fn final_key(&self) -> String {
+        let id = uuid::Uuid::new_v4();
+        self.join_path(&format!("{id}{}", self.config.file_extension))
+    }
+
+    /// Upload `body` to `final_key` atomically: write a temporary object and
+    /// rename it into place, so consumers never see a partial file.
+    async fn upload_atomic(
+        sftp: &SftpSession,
+        final_key: &str,
+        body: &[u8],
+    ) -> Result<(), FaucetError> {
+        let temp_key = format!("{final_key}.tmp");
+
+        let mut file = sftp
+            .open_with_flags(
+                temp_key.as_str(),
+                OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::TRUNCATE,
+            )
+            .await
+            .map_err(|e| {
+                FaucetError::Sink(format!("SFTP open '{temp_key}' for write failed: {e}"))
+            })?;
+
+        file.write_all(body)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SFTP write to '{temp_key}' failed: {e}")))?;
+        file.flush()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SFTP flush of '{temp_key}' failed: {e}")))?;
+        file.shutdown()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SFTP close of '{temp_key}' failed: {e}")))?;
+
+        sftp.rename(temp_key.as_str(), final_key)
+            .await
+            .map_err(|e| {
+                FaucetError::Sink(format!(
+                    "SFTP rename '{temp_key}' -> '{final_key}' failed: {e}"
+                ))
+            })?;
+
+        tracing::debug!(key = %final_key, "wrote SFTP object");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl faucet_core::Sink for SftpSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+
+        let mut guard = self.session.lock().await;
+        if guard.is_none() {
+            let sftp = connect(&self.config.connection).await?;
+            // Best-effort: ensure the target directory exists. Ignore errors
+            // (it usually already exists; a real permission/path problem
+            // surfaces on the first write with a clear message).
+            if let Err(e) = sftp.create_dir(self.config.path.as_str()).await {
+                tracing::debug!(path = %self.config.path, error = %e, "SFTP create_dir (best-effort)");
+            }
+            *guard = Some(sftp);
+        }
+        let sftp = guard.as_ref().expect("session initialized above");
+
+        let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
+            vec![records]
+        } else {
+            records.chunks(self.config.batch_size).collect()
+        };
+
+        let files = chunks.len();
+        for chunk in chunks {
+            let body = Self::serialize_jsonl(chunk)?;
+            let key = self.final_key();
+            Self::upload_atomic(sftp, &key, &body).await?;
+        }
+
+        tracing::info!(records = records.len(), files, "SFTP batch write complete");
+        Ok(records.len())
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SftpSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "sftp"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "sftp://{}:{}/{}",
+            self.config.connection.host,
+            self.config.connection.port,
+            self.config.path.trim_start_matches('/')
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_sftp::SftpConnectionConfig;
+    use faucet_core::Sink;
+
+    fn cfg() -> SftpSinkConfig {
+        SftpSinkConfig::new(SftpConnectionConfig::with_password("h", "u", "p"), "/out")
+    }
+
+    #[test]
+    fn new_is_lazy_and_validates_batch_size() {
+        assert!(SftpSink::new(cfg()).is_ok());
+        let bad = cfg().with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(SftpSink::new(bad), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn serialize_jsonl_is_newline_delimited() {
+        let records = vec![
+            serde_json::json!({"id": 1, "name": "Alice"}),
+            serde_json::json!({"id": 2, "name": "Bob"}),
+        ];
+        let bytes = SftpSink::serialize_jsonl(&records).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        let first: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["id"], 1);
+    }
+
+    #[test]
+    fn serialize_jsonl_empty() {
+        assert!(SftpSink::serialize_jsonl(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn join_path_handles_trailing_slash() {
+        let sink = SftpSink::new(cfg()).unwrap();
+        assert_eq!(sink.join_path("f.jsonl"), "/out/f.jsonl");
+
+        let sink2 = SftpSink::new(SftpSinkConfig::new(
+            SftpConnectionConfig::with_password("h", "u", "p"),
+            "/out/",
+        ))
+        .unwrap();
+        assert_eq!(sink2.join_path("f.jsonl"), "/out/f.jsonl");
+    }
+
+    #[test]
+    fn final_key_uses_prefix_and_extension() {
+        let sink = SftpSink::new(cfg()).unwrap();
+        let key = sink.final_key();
+        assert!(key.starts_with("/out/"), "got {key}");
+        assert!(key.ends_with(".jsonl"), "got {key}");
+    }
+
+    #[test]
+    fn connector_name_is_sftp() {
+        let sink = SftpSink::new(cfg()).unwrap();
+        assert_eq!(sink.connector_name(), "sftp");
+    }
+
+    #[test]
+    fn dataset_uri_has_no_credentials() {
+        let sink = SftpSink::new(cfg()).unwrap();
+        assert_eq!(sink.dataset_uri(), "sftp://h:22/out");
+    }
+
+    #[test]
+    fn append_only_capabilities() {
+        let sink = SftpSink::new(cfg()).unwrap();
+        assert!(!sink.supports_idempotent_writes());
+        assert!(!sink.dedups_by_key());
+        assert!(
+            sink.supported_write_modes()
+                .contains(&faucet_core::write_mode::WriteMode::Append)
+        );
+    }
+}

--- a/crates/sink/sftp/tests/conformance.rs
+++ b/crates/sink/sftp/tests/conformance.rs
@@ -1,0 +1,105 @@
+//! `faucet-conformance` battery against the SFTP sink.
+//!
+//! The SFTP sink writes JSON Lines objects and is append-only — it advertises
+//! no idempotency mechanism, so check 5 exercises the **honest branch**: Append
+//! works, and the sink does not claim idempotent/keyed dedup.
+//!
+//! Check 1 (`assert_config_schema_valid_value`) is offline and always runs.
+//! Check 5 (`assert_capabilities_truthful`) boots an `atmoz/sftp` container via
+//! `testcontainers` and so requires Docker; it skips cleanly when Docker is
+//! unavailable.
+
+use faucet_common_sftp::{HostKeyPolicy, SftpAuth, SftpConnectionConfig};
+use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::Sink;
+use faucet_sink_sftp::{SftpSink, SftpSinkConfig};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+const USER: &str = "faucet";
+const PASS: &str = "faucetpass";
+const UPLOAD_DIR: &str = "upload";
+
+// ── Check 1: config schema (offline) ────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(SftpSinkConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "sftp");
+}
+
+// ── Check 5: capabilities truthful (Docker) ─────────────────────────────────
+
+async fn start_sftp() -> Option<(ContainerAsync<GenericImage>, u16)> {
+    let image = GenericImage::new("atmoz/sftp", "latest")
+        .with_exposed_port(22.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server listening on"))
+        .with_cmd(vec![format!("{USER}:{PASS}:::{UPLOAD_DIR}")]);
+    let container = match image.start().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Skipping: Docker not available ({e})");
+            return None;
+        }
+    };
+    let port = container.get_host_port_ipv4(22).await.ok()?;
+    Some((container, port))
+}
+
+fn connection(port: u16) -> SftpConnectionConfig {
+    SftpConnectionConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: USER.to_string(),
+        auth: SftpAuth::Password {
+            password: PASS.to_string(),
+        },
+        known_hosts: HostKeyPolicy::Insecure,
+    }
+}
+
+/// Count durable records: sum the JSONL lines across every object under the
+/// upload directory.
+async fn count_records(conn: &SftpConnectionConfig) -> usize {
+    let sftp = faucet_common_sftp::connect(conn)
+        .await
+        .expect("count connect");
+    let entries = sftp.read_dir(UPLOAD_DIR).await.expect("read_dir");
+    let mut total = 0usize;
+    for entry in entries {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        // Skip any in-flight temporary object.
+        if entry.file_name().ends_with(".tmp") {
+            continue;
+        }
+        let bytes = sftp.read(entry.path()).await.expect("read object");
+        let body = String::from_utf8(bytes).expect("utf-8");
+        total += body.lines().filter(|l| !l.trim().is_empty()).count();
+    }
+    total
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_capabilities_truthful() {
+    let Some((_container, port)) = start_sftp().await else {
+        return;
+    };
+    let conn = connection(port);
+
+    let sink = SftpSink::new(SftpSinkConfig::new(conn.clone(), UPLOAD_DIR)).expect("SftpSink::new");
+
+    let conn_ref = &conn;
+    faucet_conformance::assert_capabilities_truthful(&sink, || async move {
+        count_records(conn_ref).await
+    })
+    .await;
+
+    // The honest branch must leave the append-only sink non-idempotent.
+    assert!(!sink.supports_idempotent_writes());
+    assert!(!sink.dedups_by_key());
+}

--- a/crates/sink/sqs/CHANGELOG.md
+++ b/crates/sink/sqs/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: AWS SQS sink — batched `SendMessageBatch` writes (≤10 entries
+  / ≤256 KiB per request), bounded request concurrency, per-entry
+  partial-failure retry, optional FIFO `message_group_id` /
+  `message_deduplication_id`, and DLQ-routable per-record outcomes. Conformance
+  battery wired ([#412](https://github.com/PawanSikawat/faucet-stream/issues/412)).

--- a/crates/sink/sqs/Cargo.toml
+++ b/crates/sink/sqs/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "faucet-sink-sqs"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "AWS SQS sink connector for faucet-stream (batched SendMessageBatch, per-entry partial-failure retry, FIFO support)"
+readme = "README.md"
+keywords = ["sqs", "aws", "queue", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-sqs.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+aws-sdk-sqs.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tracing.workspace = true
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+serde_json.workspace = true
+schemars.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_yaml = "0.9"
+# LocalStack-backed integration tests (Docker), mirroring the kinesis pair.
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["localstack"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/sqs/README.md
+++ b/crates/sink/sqs/README.md
@@ -1,0 +1,71 @@
+# faucet-sink-sqs
+
+AWS SQS **sink** connector for
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream): batched
+`SendMessageBatch` writes with bounded request concurrency, per-entry
+partial-failure retry, and optional FIFO routing.
+
+```yaml
+sink:
+  type: sqs
+  config:
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/events
+    region: us-east-1
+    batch_size: 10
+```
+
+FIFO queue:
+
+```yaml
+sink:
+  type: sqs
+  config:
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/events.fifo
+    region: us-east-1
+    message_group_id: orders
+    message_deduplication_id_field: order_id   # a record field used as the dedup id
+```
+
+## Configuration
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `queue_url` | — | Required. Full SQS queue URL. |
+| `region` | SDK default chain | |
+| `endpoint_url` | — | LocalStack / VPC endpoint override. |
+| `credentials` | `{ type: default }` | `default` \| `profile` \| `access_key` \| `assume_role` \| `web_identity` — see `faucet-common-sqs`. |
+| `message_group_id` | — | Applied to every message. Required by FIFO queues. |
+| `message_deduplication_id_field` | — | Record field whose stringified value is the `MessageDeduplicationId`. Missing / non-scalar → per-record failure (DLQ-routable). |
+| `batch_size` | `10` | Entries per `SendMessageBatch` (1–10, the API cap). |
+| `concurrency` | `4` | Bounded concurrent in-flight requests. |
+| `retry_max_attempts` | `5` | Per-record retry budget for partial failures. |
+| `retry_initial_backoff_ms` / `retry_max_backoff_ms` | `100` / `30000` | Exponential backoff bounds. |
+
+Each record is serialized to a JSON string as the message body. A body over
+256 KiB (the SQS limit) fails per-record (never sent) rather than panicking.
+Requests are re-chunked to both the 10-entry and 256 KiB request ceilings.
+
+## Delivery semantics
+
+**At-least-once.** A whole-request failure that is retried after the messages
+actually landed can duplicate them. On a FIFO queue, set
+`message_deduplication_id_field` (or enable content-based dedup on the queue)
+so replays within the 5-minute dedup window converge. This is an append-only
+sink — it advertises no idempotent-write or keyed-dedup capability, so the
+pipeline correctly refuses `delivery: exactly_once`.
+
+Partial failures come back per-record: with a DLQ configured, individual
+rejected messages are routed to the DLQ while the rest of the page proceeds.
+
+## LocalStack
+
+```yaml
+config:
+  endpoint_url: http://localhost:4566
+  region: us-east-1
+  credentials: { type: access_key, config: { access_key_id: test, secret_access_key: test } }
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/sink/sqs/src/config.rs
+++ b/crates/sink/sqs/src/config.rs
@@ -1,0 +1,189 @@
+//! Configuration for the SQS sink. No I/O here.
+
+use faucet_common_sqs::SqsCredentials;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// SQS hard limit: `SendMessageBatch` accepts at most 10 entries per request.
+pub const MAX_ENTRIES_PER_REQUEST: usize = 10;
+/// SQS hard limit: 256 KiB per message body.
+pub const MAX_MESSAGE_BYTES: usize = 262_144;
+/// SQS hard limit: 256 KiB total payload per `SendMessageBatch` request.
+pub const MAX_BATCH_BYTES: usize = 262_144;
+
+/// Configuration for [`SqsSink`](crate::SqsSink).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SqsSinkConfig {
+    /// SQS queue URL (e.g. `https://sqs.us-east-1.amazonaws.com/1234/my-q`).
+    pub queue_url: String,
+    /// AWS region. `None` uses the SDK default chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Custom endpoint URL for LocalStack / VPC endpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_url: Option<String>,
+    /// AWS credentials. Defaults to the SDK default provider chain.
+    #[serde(default)]
+    pub credentials: SqsCredentials,
+
+    /// FIFO message group id, applied to every message. Required by FIFO
+    /// queues; omit for standard queues. Default: none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_group_id: Option<String>,
+    /// Record field whose (stringified) value becomes each message's
+    /// `MessageDeduplicationId` on a FIFO queue. A record missing the field
+    /// (or with a non-scalar value) fails per-record (DLQ-routable). Only used
+    /// when set. Default: none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_deduplication_id_field: Option<String>,
+
+    /// Max entries per `SendMessageBatch` request (1–10). Default 10.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+
+    /// Bounded concurrent in-flight `SendMessageBatch` requests. Default 4.
+    #[serde(default = "default_concurrency")]
+    pub concurrency: usize,
+    /// Per-record retry budget for partial failures. Default 5.
+    #[serde(default = "default_retry_max_attempts")]
+    pub retry_max_attempts: usize,
+    /// Initial retry backoff (milliseconds). Default 100.
+    #[serde(default = "default_retry_initial_backoff_ms")]
+    pub retry_initial_backoff_ms: u64,
+    /// Backoff ceiling (milliseconds). Default 30000.
+    #[serde(default = "default_retry_max_backoff_ms")]
+    pub retry_max_backoff_ms: u64,
+}
+
+fn default_batch_size() -> usize {
+    MAX_ENTRIES_PER_REQUEST
+}
+fn default_concurrency() -> usize {
+    4
+}
+fn default_retry_max_attempts() -> usize {
+    5
+}
+fn default_retry_initial_backoff_ms() -> u64 {
+    100
+}
+fn default_retry_max_backoff_ms() -> u64 {
+    30_000
+}
+
+impl SqsSinkConfig {
+    /// Minimal config with defaults for everything but the queue URL.
+    pub fn new(queue_url: impl Into<String>) -> Self {
+        Self {
+            queue_url: queue_url.into(),
+            region: None,
+            endpoint_url: None,
+            credentials: SqsCredentials::default(),
+            message_group_id: None,
+            message_deduplication_id_field: None,
+            batch_size: default_batch_size(),
+            concurrency: default_concurrency(),
+            retry_max_attempts: default_retry_max_attempts(),
+            retry_initial_backoff_ms: default_retry_initial_backoff_ms(),
+            retry_max_backoff_ms: default_retry_max_backoff_ms(),
+        }
+    }
+
+    /// Fail-fast validation, called from `SqsSink::new`.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        use faucet_core::FaucetError;
+        if self.queue_url.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "sqs sink: queue_url must not be empty".into(),
+            ));
+        }
+        if self.batch_size == 0 || self.batch_size > MAX_ENTRIES_PER_REQUEST {
+            return Err(FaucetError::Config(format!(
+                "sqs sink: batch_size must be 1..={MAX_ENTRIES_PER_REQUEST} (got {}) — the \
+                 SendMessageBatch API limit",
+                self.batch_size
+            )));
+        }
+        if self.concurrency == 0 {
+            return Err(FaucetError::Config(
+                "sqs sink: concurrency must be at least 1".into(),
+            ));
+        }
+        if self.retry_max_attempts == 0 {
+            return Err(FaucetError::Config(
+                "sqs sink: retry_max_attempts must be at least 1".into(),
+            ));
+        }
+        if let Some(field) = &self.message_deduplication_id_field
+            && field.is_empty()
+        {
+            return Err(FaucetError::Config(
+                "sqs sink: message_deduplication_id_field must not be empty".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_the_api_limits() {
+        let c = SqsSinkConfig::new("https://q");
+        c.validate().unwrap();
+        assert_eq!(c.batch_size, 10);
+        assert_eq!(c.concurrency, 4);
+        assert!(c.message_group_id.is_none());
+        assert!(c.message_deduplication_id_field.is_none());
+    }
+
+    #[test]
+    fn validation_bounds() {
+        let mut c = SqsSinkConfig::new("https://q");
+        c.batch_size = 11;
+        assert!(c.validate().is_err(), "SendMessageBatch cap is 10");
+        c.batch_size = 0;
+        assert!(c.validate().is_err());
+
+        let mut c = SqsSinkConfig::new("https://q");
+        c.concurrency = 0;
+        assert!(c.validate().is_err());
+
+        let mut c = SqsSinkConfig::new("https://q");
+        c.retry_max_attempts = 0;
+        assert!(c.validate().is_err());
+
+        let mut c = SqsSinkConfig::new("https://q");
+        c.message_deduplication_id_field = Some(String::new());
+        assert!(c.validate().is_err());
+
+        let mut c = SqsSinkConfig::new("  ");
+        c.batch_size = 5;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn full_config_parses_from_yaml() {
+        let yaml = r#"
+queue_url: https://sqs.us-east-1.amazonaws.com/1/events.fifo
+region: us-east-1
+endpoint_url: http://127.0.0.1:4566
+credentials: { type: default }
+message_group_id: orders
+message_deduplication_id_field: order_id
+batch_size: 5
+concurrency: 2
+retry_max_attempts: 3
+"#;
+        let c: SqsSinkConfig = serde_yaml::from_str(yaml).unwrap();
+        c.validate().unwrap();
+        assert_eq!(c.message_group_id.as_deref(), Some("orders"));
+        assert_eq!(
+            c.message_deduplication_id_field.as_deref(),
+            Some("order_id")
+        );
+        assert_eq!(c.batch_size, 5);
+    }
+}

--- a/crates/sink/sqs/src/lib.rs
+++ b/crates/sink/sqs/src/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-sqs
+//!
+//! AWS SQS sink connector for
+//! [faucet-stream](https://github.com/PawanSikawat/faucet-stream): batched
+//! `SendMessageBatch` writes (≤10 entries / ≤256 KiB per request), bounded
+//! concurrent in-flight requests, per-entry partial-failure retry, optional
+//! FIFO `message_group_id` / `message_deduplication_id`, and DLQ-routable
+//! per-record outcomes.
+//!
+//! Delivery is **at-least-once**: an ambiguous whole-request failure that is
+//! retried can double-write messages that actually landed. On a FIFO queue set
+//! `message_deduplication_id_field` (or enable content-based dedup on the
+//! queue) so replays within the 5-minute dedup window converge.
+
+mod config;
+mod sink;
+
+pub use config::{MAX_BATCH_BYTES, MAX_ENTRIES_PER_REQUEST, MAX_MESSAGE_BYTES, SqsSinkConfig};
+pub use sink::SqsSink;
+
+// Shared connection types, re-exported so users need only this crate.
+pub use faucet_common_sqs::{SqsCredentials, build_client};

--- a/crates/sink/sqs/src/sink.rs
+++ b/crates/sink/sqs/src/sink.rs
@@ -1,0 +1,539 @@
+//! The SQS `Sink` implementation: encode → size-aware chunking →
+//! bounded-concurrency `SendMessageBatch` → per-entry partial-failure retry.
+
+use crate::config::SqsSinkConfig;
+use aws_sdk_sqs::Client;
+use aws_sdk_sqs::types::SendMessageBatchRequestEntry;
+use faucet_core::{FaucetError, RowOutcome};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashSet};
+use std::time::Duration;
+
+/// One record encoded and ready to ship, tagged with its input position so
+/// outcomes can be reported in input order.
+#[derive(Debug, Clone)]
+pub(crate) struct Encoded {
+    pub index: usize,
+    pub body: String,
+    pub group_id: Option<String>,
+    pub dedup_id: Option<String>,
+}
+
+impl Encoded {
+    /// Bytes this entry contributes to a request (the message body — the
+    /// quantity SQS counts against its 256 KiB request ceiling).
+    pub fn request_bytes(&self) -> usize {
+        self.body.len()
+    }
+}
+
+/// Deterministic exponential backoff: `initial * 2^attempt`, capped. Pure.
+pub(crate) fn backoff_delay(initial_ms: u64, max_ms: u64, attempt: usize) -> Duration {
+    let exp = initial_ms.saturating_mul(1u64 << attempt.min(20));
+    Duration::from_millis(exp.min(max_ms))
+}
+
+/// Stringify a top-level record field for use as a `MessageDeduplicationId`.
+/// Missing / null / non-scalar fields are per-record errors.
+pub(crate) fn dedup_id_for(record: &Value, field: &str) -> Result<String, FaucetError> {
+    match record.get(field) {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(Value::Number(n)) => Ok(n.to_string()),
+        Some(Value::Bool(b)) => Ok(b.to_string()),
+        Some(Value::Null) | None => Err(FaucetError::Sink(format!(
+            "sqs: record is missing dedup field '{field}'"
+        ))),
+        Some(other) => Err(FaucetError::Sink(format!(
+            "sqs: dedup field '{field}' is not a scalar (got {other})"
+        ))),
+    }
+}
+
+/// Chunk encoded entries into `SendMessageBatch` requests honouring both the
+/// entry-count and request-byte ceilings. Pure. Entries above the byte ceiling
+/// are assumed to have been filtered out already.
+pub(crate) fn chunk_requests(
+    entries: Vec<Encoded>,
+    max_entries: usize,
+    max_request_bytes: usize,
+) -> Vec<Vec<Encoded>> {
+    let mut out = Vec::new();
+    let mut current: Vec<Encoded> = Vec::new();
+    let mut current_bytes = 0usize;
+    for e in entries {
+        let bytes = e.request_bytes();
+        if !current.is_empty()
+            && (current.len() >= max_entries || current_bytes + bytes > max_request_bytes)
+        {
+            out.push(std::mem::take(&mut current));
+            current_bytes = 0;
+        }
+        current_bytes += bytes;
+        current.push(e);
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// AWS SQS sink. See the crate README for semantics.
+pub struct SqsSink {
+    config: SqsSinkConfig,
+    client: Client,
+}
+
+impl SqsSink {
+    /// Create a new SQS sink. Validates the config and builds the AWS client
+    /// (no network I/O).
+    pub async fn new(config: SqsSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = faucet_common_sqs::build_client(
+            config.region.as_deref(),
+            config.endpoint_url.as_deref(),
+            &config.credentials,
+        )
+        .await?;
+        Ok(Self { config, client })
+    }
+
+    /// Encode every record; per-record failures (serialization, oversized body,
+    /// unresolvable dedup id) land in the error map keyed by input index.
+    pub(crate) fn encode_records(
+        &self,
+        records: &[Value],
+    ) -> (Vec<Encoded>, BTreeMap<usize, FaucetError>) {
+        let mut encoded = Vec::with_capacity(records.len());
+        let mut failures = BTreeMap::new();
+        for (index, record) in records.iter().enumerate() {
+            let body = match serde_json::to_string(record) {
+                Ok(b) => b,
+                Err(e) => {
+                    failures.insert(
+                        index,
+                        FaucetError::Sink(format!("sqs: record does not serialize to JSON: {e}")),
+                    );
+                    continue;
+                }
+            };
+            if body.len() > crate::config::MAX_MESSAGE_BYTES {
+                failures.insert(
+                    index,
+                    FaucetError::Sink(format!(
+                        "sqs: message body is {} bytes, above the SQS {} byte limit — never sent",
+                        body.len(),
+                        crate::config::MAX_MESSAGE_BYTES
+                    )),
+                );
+                continue;
+            }
+            let dedup_id = match &self.config.message_deduplication_id_field {
+                Some(field) => match dedup_id_for(record, field) {
+                    Ok(id) => Some(id),
+                    Err(err) => {
+                        failures.insert(index, err);
+                        continue;
+                    }
+                },
+                None => None,
+            };
+            encoded.push(Encoded {
+                index,
+                body,
+                group_id: self.config.message_group_id.clone(),
+                dedup_id,
+            });
+        }
+        (encoded, failures)
+    }
+
+    /// Send one chunk, retrying per-entry partial failures with backoff.
+    /// Returns per-entry outcomes keyed by input index; a whole-request failure
+    /// that outlives the retry budget is the outer `Err`.
+    async fn put_chunk(
+        &self,
+        mut pending: Vec<Encoded>,
+    ) -> Result<BTreeMap<usize, Result<(), FaucetError>>, FaucetError> {
+        let mut outcomes: BTreeMap<usize, Result<(), FaucetError>> = BTreeMap::new();
+        let mut attempt = 0usize;
+        loop {
+            let entries: Vec<SendMessageBatchRequestEntry> = pending
+                .iter()
+                .map(|e| {
+                    let mut b = SendMessageBatchRequestEntry::builder()
+                        .id(e.index.to_string())
+                        .message_body(&e.body);
+                    if let Some(g) = &e.group_id {
+                        b = b.message_group_id(g);
+                    }
+                    if let Some(d) = &e.dedup_id {
+                        b = b.message_deduplication_id(d);
+                    }
+                    b.build()
+                        .map_err(|err| FaucetError::Sink(format!("sqs: entry build failed: {err}")))
+                })
+                .collect::<Result<_, _>>()?;
+
+            let response = self
+                .client
+                .send_message_batch()
+                .queue_url(&self.config.queue_url)
+                .set_entries(Some(entries))
+                .send()
+                .await;
+
+            match response {
+                Ok(out) => {
+                    for s in out.successful() {
+                        if let Ok(idx) = s.id().parse::<usize>() {
+                            outcomes.insert(idx, Ok(()));
+                        }
+                    }
+                    let mut retry_indices: HashSet<usize> = HashSet::new();
+                    for f in out.failed() {
+                        let Ok(idx) = f.id().parse::<usize>() else {
+                            continue;
+                        };
+                        // sender_fault ⇒ a client-side problem that will not
+                        // succeed on retry; treat as permanent.
+                        if f.sender_fault() || attempt + 1 >= self.config.retry_max_attempts {
+                            outcomes.insert(
+                                idx,
+                                Err(FaucetError::Sink(format!(
+                                    "sqs: message rejected after {} attempt(s): {}: {}",
+                                    attempt + 1,
+                                    f.code(),
+                                    f.message().unwrap_or("(no message)")
+                                ))),
+                            );
+                        } else {
+                            retry_indices.insert(idx);
+                        }
+                    }
+                    if retry_indices.is_empty() {
+                        return Ok(outcomes);
+                    }
+                    pending.retain(|e| retry_indices.contains(&e.index));
+                    attempt += 1;
+                    let delay = backoff_delay(
+                        self.config.retry_initial_backoff_ms,
+                        self.config.retry_max_backoff_ms,
+                        attempt,
+                    );
+                    tracing::debug!(
+                        queue = %self.config.queue_url,
+                        retrying = pending.len(),
+                        attempt,
+                        delay_ms = delay.as_millis() as u64,
+                        "sqs: retrying partially-failed SendMessageBatch entries"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(err) => {
+                    attempt += 1;
+                    let service = err.into_service_error();
+                    if attempt >= self.config.retry_max_attempts {
+                        return Err(FaucetError::Sink(format!(
+                            "sqs: SendMessageBatch to '{}' failed after {} attempt(s): {service}",
+                            self.config.queue_url, self.config.retry_max_attempts
+                        )));
+                    }
+                    let delay = backoff_delay(
+                        self.config.retry_initial_backoff_ms,
+                        self.config.retry_max_backoff_ms,
+                        attempt,
+                    );
+                    tracing::warn!(
+                        queue = %self.config.queue_url,
+                        error = %service,
+                        attempt,
+                        delay_ms = delay.as_millis() as u64,
+                        "sqs: SendMessageBatch request failed; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    /// Ship all encoded entries with bounded request concurrency, merging
+    /// per-entry outcomes.
+    async fn ship(
+        &self,
+        encoded: Vec<Encoded>,
+    ) -> Result<BTreeMap<usize, Result<(), FaucetError>>, FaucetError> {
+        use futures::StreamExt;
+        let chunks = chunk_requests(
+            encoded,
+            self.config.batch_size,
+            crate::config::MAX_BATCH_BYTES,
+        );
+        let mut merged: BTreeMap<usize, Result<(), FaucetError>> = BTreeMap::new();
+        let mut stream =
+            futures::stream::iter(chunks.into_iter().map(|chunk| self.put_chunk(chunk)))
+                .buffer_unordered(self.config.concurrency);
+        while let Some(result) = stream.next().await {
+            merged.extend(result?);
+        }
+        Ok(merged)
+    }
+}
+
+#[faucet_core::async_trait]
+impl faucet_core::Sink for SqsSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let (encoded, encode_failures) = self.encode_records(records);
+        let outcomes = self.ship(encoded).await?;
+        let delivered = outcomes.values().filter(|o| o.is_ok()).count();
+        let failed = encode_failures.len() + outcomes.len() - delivered;
+        if failed > 0 {
+            let first = encode_failures
+                .values()
+                .next()
+                .map(ToString::to_string)
+                .or_else(|| {
+                    outcomes
+                        .values()
+                        .find_map(|o| o.as_ref().err().map(ToString::to_string))
+                })
+                .unwrap_or_default();
+            return Err(FaucetError::Sink(format!(
+                "sqs: {failed} of {} record(s) failed (first: {first})",
+                records.len()
+            )));
+        }
+        tracing::info!(
+            queue = %self.config.queue_url,
+            records = delivered,
+            "sqs sink write complete"
+        );
+        Ok(delivered)
+    }
+
+    /// Per-row outcomes in input order: encode failures, oversized bodies, and
+    /// per-entry `SendMessageBatch` rejections (after the retry budget) come
+    /// back as `Err` rows for the DLQ router; a whole-request failure that
+    /// outlives every retry propagates as the outer `Err`.
+    async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<RowOutcome>, FaucetError> {
+        let (encoded, mut encode_failures) = self.encode_records(records);
+        let mut shipped = self.ship(encoded).await?;
+        Ok((0..records.len())
+            .map(|i| {
+                if let Some(err) = encode_failures.remove(&i) {
+                    Err(err)
+                } else {
+                    shipped.remove(&i).unwrap_or(Ok(()))
+                }
+            })
+            .collect())
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SqsSinkConfig)).expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "sqs"
+    }
+
+    fn dataset_uri(&self) -> String {
+        let name = self
+            .config
+            .queue_url
+            .rsplit('/')
+            .find(|s| !s.is_empty())
+            .unwrap_or(self.config.queue_url.as_str());
+        format!(
+            "sqs://{}/{}",
+            self.config.region.as_deref().unwrap_or("default"),
+            name
+        )
+    }
+
+    /// Side-effect-free probe: `GetQueueAttributes` (no messages written).
+    async fn check(
+        &self,
+        ctx: &faucet_core::CheckContext,
+    ) -> Result<faucet_core::CheckReport, FaucetError> {
+        use faucet_core::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let fut = self
+            .client
+            .get_queue_attributes()
+            .queue_url(&self.config.queue_url)
+            .send();
+        let probe = match tokio::time::timeout(ctx.timeout, fut).await {
+            Err(_) => Probe::fail("get_queue_attributes", start.elapsed(), "timed out"),
+            Ok(Ok(_)) => Probe::pass("get_queue_attributes", start.elapsed()),
+            Ok(Err(e)) => Probe::fail(
+                "get_queue_attributes",
+                start.elapsed(),
+                e.into_service_error().to_string(),
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn enc(index: usize, bytes: usize) -> Encoded {
+        Encoded {
+            index,
+            body: "x".repeat(bytes),
+            group_id: None,
+            dedup_id: None,
+        }
+    }
+
+    #[test]
+    fn backoff_doubles_and_caps() {
+        assert_eq!(backoff_delay(100, 30_000, 0), Duration::from_millis(100));
+        assert_eq!(backoff_delay(100, 30_000, 1), Duration::from_millis(200));
+        assert_eq!(backoff_delay(100, 30_000, 4), Duration::from_millis(1600));
+        assert_eq!(backoff_delay(100, 30_000, 20), Duration::from_secs(30));
+        assert_eq!(
+            backoff_delay(100, 30_000, usize::MAX),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn chunker_honours_count_and_byte_limits() {
+        // Count limit.
+        let entries: Vec<Encoded> = (0..7).map(|i| enc(i, 10)).collect();
+        let chunks = chunk_requests(entries, 3, 1_000_000);
+        assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), [3, 3, 1]);
+
+        // Byte limit: each entry is 10 bytes.
+        let entries: Vec<Encoded> = (0..6).map(|i| enc(i, 10)).collect();
+        let chunks = chunk_requests(entries, 10, 20);
+        assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), [2, 2, 2]);
+
+        assert!(chunk_requests(Vec::new(), 10, 100).is_empty());
+    }
+
+    #[test]
+    fn dedup_id_extraction() {
+        assert_eq!(
+            dedup_id_for(&json!({"id": "abc"}), "id").unwrap(),
+            "abc".to_string()
+        );
+        assert_eq!(dedup_id_for(&json!({"id": 42}), "id").unwrap(), "42");
+        assert_eq!(dedup_id_for(&json!({"id": true}), "id").unwrap(), "true");
+        assert!(dedup_id_for(&json!({"other": 1}), "id").is_err());
+        assert!(dedup_id_for(&json!({"id": null}), "id").is_err());
+        assert!(dedup_id_for(&json!({"id": {"nested": 1}}), "id").is_err());
+    }
+
+    async fn offline_sink(mut config: SqsSinkConfig) -> SqsSink {
+        config.endpoint_url = Some("http://127.0.0.1:1".into());
+        config.region = Some("us-east-1".into());
+        config.credentials = faucet_common_sqs::SqsCredentials::AccessKey {
+            access_key_id: "test".into(),
+            secret_access_key: "test".into(),
+            session_token: None,
+        };
+        SqsSink::new(config).await.expect("sink builds")
+    }
+
+    #[tokio::test]
+    async fn encode_records_partitions_failures_by_index() {
+        let mut cfg = SqsSinkConfig::new("https://q");
+        cfg.message_deduplication_id_field = Some("id".into());
+        let sink = offline_sink(cfg).await;
+
+        let records = vec![
+            json!({"id": "a", "v": 1}), // ok
+            json!({"v": 2}),            // missing dedup field
+            json!({"id": "c", "v": 3}), // ok
+        ];
+        let (encoded, failures) = sink.encode_records(&records);
+        assert_eq!(encoded.len(), 2);
+        assert_eq!(encoded[0].index, 0);
+        assert_eq!(encoded[1].index, 2);
+        assert_eq!(encoded[0].dedup_id.as_deref(), Some("a"));
+        assert_eq!(failures.len(), 1);
+        assert!(failures[&1].to_string().contains("dedup field"));
+    }
+
+    #[tokio::test]
+    async fn oversized_body_is_a_per_record_failure() {
+        let sink = offline_sink(SqsSinkConfig::new("https://q")).await;
+        let big = json!({ "blob": "x".repeat(crate::config::MAX_MESSAGE_BYTES) });
+        let (encoded, failures) = sink.encode_records(&[big]);
+        assert!(encoded.is_empty());
+        assert!(failures[&0].to_string().contains("byte limit"));
+    }
+
+    #[tokio::test]
+    async fn identity_overrides_and_empty_write() {
+        use faucet_core::Sink as _;
+        let sink = offline_sink(SqsSinkConfig::new(
+            "https://sqs.us-east-1.amazonaws.com/1/events",
+        ))
+        .await;
+        assert_eq!(sink.connector_name(), "sqs");
+        assert_eq!(sink.dataset_uri(), "sqs://us-east-1/events");
+        assert!(!sink.supports_idempotent_writes());
+        assert!(!sink.dedups_by_key());
+        assert_eq!(
+            sink.supported_write_modes(),
+            &[faucet_core::WriteMode::Append]
+        );
+        assert_eq!(sink.write_batch(&[]).await.unwrap(), 0, "empty is a no-op");
+        let schema = sink.config_schema();
+        assert!(schema["properties"]["queue_url"].is_object());
+    }
+
+    #[tokio::test]
+    async fn whole_request_failure_propagates_as_outer_err() {
+        use faucet_core::Sink as _;
+        let mut cfg = SqsSinkConfig::new("https://q");
+        cfg.retry_max_attempts = 1; // fail fast against the unroutable endpoint
+        cfg.retry_initial_backoff_ms = 1;
+        let sink = offline_sink(cfg).await;
+        let err = sink.write_batch(&[json!({"a": 1})]).await.unwrap_err();
+        assert!(err.to_string().contains("SendMessageBatch"), "{err}");
+        let err = sink
+            .write_batch_partial(&[json!({"a": 1})])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("SendMessageBatch"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn encode_only_failures_need_no_request() {
+        use faucet_core::Sink as _;
+        // Every record fails encoding (missing dedup field), so no network
+        // request is attempted → per-record errors, outer Ok.
+        let mut cfg = SqsSinkConfig::new("https://q");
+        cfg.message_deduplication_id_field = Some("id".into());
+        let sink = offline_sink(cfg).await;
+        let outcomes = sink
+            .write_batch_partial(&[json!({"no": "id"}), json!({"also": "none"})])
+            .await
+            .expect("no request attempted");
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes.iter().all(Result::is_err));
+    }
+
+    #[tokio::test]
+    async fn check_probe_fails_cleanly_offline() {
+        use faucet_core::Sink as _;
+        let sink = offline_sink(SqsSinkConfig::new("https://q")).await;
+        let report = sink
+            .check(&faucet_core::CheckContext {
+                timeout: Duration::from_millis(500),
+            })
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 1);
+    }
+}

--- a/crates/sink/sqs/tests/conformance.rs
+++ b/crates/sink/sqs/tests/conformance.rs
@@ -1,0 +1,110 @@
+//! `faucet-conformance` battery against the real SQS sink (via LocalStack).
+//!
+//! The SQS sink is append-only — it advertises no idempotency mechanism, so the
+//! battery exercises the **honest branch**:
+//! - check 1 `assert_config_schema_valid_value` (value form, for sinks) — pure /
+//!   offline, always runs;
+//! - check 5 `assert_capabilities_truthful` — Append works, and the sink does
+//!   *not* claim idempotent / keyed dedup (so the pipeline correctly refuses
+//!   `delivery: exactly_once`).
+//!
+//! Check 5 requires Docker (LocalStack via testcontainers), mirroring `sink.rs`.
+
+use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::Sink;
+use faucet_sink_sqs::{SqsCredentials, SqsSink, SqsSinkConfig};
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::localstack::LocalStack;
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(SqsSinkConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "sqs");
+}
+
+// ── Check 5: capabilities truthful (Docker) ─────────────────────────────────
+
+async fn start_localstack() -> (ContainerAsync<LocalStack>, String) {
+    use testcontainers::ImageExt;
+    let image = LocalStack::default().with_env_var("SERVICES", "sqs");
+    let container = image.start().await.expect("localstack start");
+    let port = container
+        .get_host_port_ipv4(4566)
+        .await
+        .expect("localstack port");
+    (container, format!("http://127.0.0.1:{port}"))
+}
+
+fn test_credentials() -> SqsCredentials {
+    SqsCredentials::AccessKey {
+        access_key_id: "test".into(),
+        secret_access_key: "test".into(),
+        session_token: None,
+    }
+}
+
+async fn raw_client(endpoint: &str) -> aws_sdk_sqs::Client {
+    faucet_sink_sqs::build_client(Some("us-east-1"), Some(endpoint), &test_credentials())
+        .await
+        .expect("client")
+}
+
+async fn create_queue(client: &aws_sdk_sqs::Client, name: &str) -> String {
+    for _ in 0..120 {
+        match client.create_queue().queue_name(name).send().await {
+            Ok(out) => return out.queue_url().expect("queue url").to_string(),
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+        }
+    }
+    panic!("localstack sqs never became ready");
+}
+
+/// Count durable messages currently visible in the queue via the
+/// `ApproximateNumberOfMessages` attribute. LocalStack updates this promptly
+/// after a `SendMessageBatch`.
+async fn count_messages(client: &aws_sdk_sqs::Client, queue_url: &str) -> usize {
+    use aws_sdk_sqs::types::QueueAttributeName;
+    for _ in 0..40 {
+        let out = client
+            .get_queue_attributes()
+            .queue_url(queue_url)
+            .attribute_names(QueueAttributeName::ApproximateNumberOfMessages)
+            .send()
+            .await
+            .expect("get_queue_attributes");
+        if let Some(v) = out
+            .attributes()
+            .and_then(|a| a.get(&QueueAttributeName::ApproximateNumberOfMessages))
+            && let Ok(n) = v.parse::<usize>()
+        {
+            return n;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    0
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_capabilities_truthful() {
+    let (_container, endpoint) = start_localstack().await;
+    let client = raw_client(&endpoint).await;
+    let queue_url = create_queue(&client, "conformance").await;
+
+    let mut cfg = SqsSinkConfig::new(&queue_url);
+    cfg.region = Some("us-east-1".into());
+    cfg.endpoint_url = Some(endpoint.clone());
+    cfg.credentials = test_credentials();
+    let sink = SqsSink::new(cfg).await.expect("sink");
+
+    let client_ref = &client;
+    let url = queue_url.clone();
+    faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let url = url.clone();
+        async move { count_messages(client_ref, &url).await }
+    })
+    .await;
+
+    // The honest branch must have left the append-only sink non-idempotent.
+    assert!(!sink.supports_idempotent_writes());
+    assert!(!sink.dedups_by_key());
+}

--- a/crates/source/duckdb/CHANGELOG.md
+++ b/crates/source/duckdb/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: DuckDB query source — opens a DuckDB file or in-memory
+  database, runs a configured SQL query, and streams rows as JSON with
+  bounded memory. Conformance battery wired ([#413](https://github.com/PawanSikawat/faucet-stream/issues/413)).

--- a/crates/source/duckdb/Cargo.toml
+++ b/crates/source/duckdb/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "faucet-source-duckdb"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "DuckDB query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["duckdb", "olap", "analytics", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+duckdb = { workspace = true, features = ["bundled"] }
+base64.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+tempfile = "3"
+futures.workspace = true
+faucet-conformance.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/duckdb/README.md
+++ b/crates/source/duckdb/README.md
@@ -1,0 +1,50 @@
+# faucet-source-duckdb
+
+DuckDB query source connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream)
+data-movement platform. Opens a DuckDB database (a file, or in-memory), runs a
+configured SQL query, and streams rows as JSON with bounded memory.
+
+DuckDB is a synchronous embedded engine, so every database call runs on a
+blocking thread; streaming hands bounded pages to the async pipeline over a
+small channel rather than buffering the whole result set.
+
+## Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `database` | string | — | Path to the `.duckdb` file, or `:memory:`. A `duckdb://` / `duckdb:` prefix is accepted and stripped. |
+| `query` | string | — | SQL query to execute. Supports `{placeholder}` tokens bound as parameters (safe against injection). |
+| `read_only` | bool | `false` | Open read-only. DuckDB allows many read-only connections to one file but only a single read-write connection. |
+| `batch_size` | integer | `1000` | Rows per emitted page. `0` = emit the entire result set as one page. |
+
+## Example
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: duckdb
+    config:
+      database: analytics.duckdb
+      query: "SELECT id, name, amount FROM sales WHERE amount > 0 ORDER BY id"
+      batch_size: 5000
+  sink:
+    type: jsonl
+    config:
+      path: sales.jsonl
+```
+
+## Type mapping
+
+Scalar DuckDB types map exactly to JSON (integers → number, `DOUBLE`/`FLOAT` →
+number, `BOOLEAN` → bool, `VARCHAR` → string). `BLOB` is base64-encoded so
+binary survives the JSON round-trip. Temporal (`TIMESTAMP`/`DATE`/`TIME`),
+`DECIMAL`, and nested (`LIST`/`STRUCT`/`MAP`) values are best-effort: temporal
+types surface their raw integer representation and the rest fall back to a
+stable string. A future Arrow-native columnar fast path is tracked separately.
+
+## Conformance
+
+This crate wires the reusable [`faucet-conformance`](https://docs.rs/faucet-conformance)
+battery in `tests/conformance.rs` — config-schema validity, bounded-memory
+streaming (seeded temp database), and errors-not-panics.

--- a/crates/source/duckdb/src/config.rs
+++ b/crates/source/duckdb/src/config.rs
@@ -1,0 +1,125 @@
+//! DuckDB source configuration.
+
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the DuckDB query source.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DuckdbSourceConfig {
+    /// Path to the DuckDB database file, or `:memory:` for an in-memory
+    /// database. A `duckdb://` / `duckdb:` scheme prefix is accepted and
+    /// stripped.
+    pub database: String,
+    /// SQL query to execute.
+    pub query: String,
+    /// Open the database read-only. Defaults to `false` (read-write).
+    ///
+    /// Set `true` to attach to a database file another process holds open —
+    /// DuckDB permits multiple read-only connections to one file but only a
+    /// single read-write connection.
+    #[serde(default)]
+    pub read_only: bool,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). Rows are
+    /// drained from the DuckDB result and yielded whenever the buffer reaches
+    /// this size. Defaults to [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// `batch_size = 0` is the "no batching" sentinel: the entire result set is
+    /// emitted in a single page. Useful for small lookup tables.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+impl DuckdbSourceConfig {
+    /// Create a new config with the required database path and query.
+    pub fn new(database: impl Into<String>, query: impl Into<String>) -> Self {
+        Self {
+            database: database.into(),
+            query: query.into(),
+            read_only: false,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Set the per-page row count for
+    /// [`Source::stream_pages`](faucet_core::Source::stream_pages).
+    ///
+    /// Pass `0` to opt out of batching — the entire result set is emitted in a
+    /// single [`StreamPage`](faucet_core::StreamPage).
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Open the database read-only.
+    pub fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    /// The filesystem path with any `duckdb://` / `duckdb:` scheme stripped.
+    pub(crate) fn resolved_path(&self) -> &str {
+        self.database
+            .trim_start_matches("duckdb://")
+            .trim_start_matches("duckdb:")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = DuckdbSourceConfig::new("data.duckdb", "SELECT * FROM events");
+        assert_eq!(config.database, "data.duckdb");
+        assert_eq!(config.query, "SELECT * FROM events");
+        assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(!config.read_only);
+    }
+
+    #[test]
+    fn resolved_path_strips_scheme() {
+        assert_eq!(
+            DuckdbSourceConfig::new("duckdb:///tmp/a.duckdb", "SELECT 1").resolved_path(),
+            "/tmp/a.duckdb"
+        );
+        assert_eq!(
+            DuckdbSourceConfig::new("duckdb::memory:", "SELECT 1").resolved_path(),
+            ":memory:"
+        );
+        assert_eq!(
+            DuckdbSourceConfig::new(":memory:", "SELECT 1").resolved_path(),
+            ":memory:"
+        );
+    }
+
+    #[test]
+    fn with_batch_size_overrides_default() {
+        let config = DuckdbSourceConfig::new(":memory:", "SELECT 1").with_batch_size(500);
+        assert_eq!(config.batch_size, 500);
+    }
+
+    #[test]
+    fn batch_size_zero_is_accepted_as_no_batching_sentinel() {
+        let config = DuckdbSourceConfig::new(":memory:", "SELECT 1").with_batch_size(0);
+        assert_eq!(config.batch_size, 0);
+        assert!(faucet_core::validate_batch_size(config.batch_size).is_ok());
+    }
+
+    #[test]
+    fn batch_size_deserializes_from_json() {
+        let json = r#"{
+            "database": ":memory:",
+            "query": "SELECT 1",
+            "batch_size": 250
+        }"#;
+        let config: DuckdbSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.batch_size, 250);
+        assert!(!config.read_only);
+    }
+}

--- a/crates/source/duckdb/src/lib.rs
+++ b/crates/source/duckdb/src/lib.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-duckdb
+//!
+//! DuckDB query source connector for the faucet-stream ecosystem.
+//!
+//! Opens a DuckDB database (a file, or in-memory), executes a configurable SQL
+//! query, and streams rows as `serde_json::Value` records with bounded memory.
+//! DuckDB is the de-facto embedded analytics engine; this connector mirrors the
+//! [`faucet-source-sqlite`](https://docs.rs/faucet-source-sqlite) query source.
+
+pub mod config;
+pub mod stream;
+
+pub use faucet_core::{FaucetError, Source};
+
+pub use config::DuckdbSourceConfig;
+pub use stream::DuckdbSource;

--- a/crates/source/duckdb/src/stream.rs
+++ b/crates/source/duckdb/src/stream.rs
@@ -1,0 +1,491 @@
+//! DuckDB source implementation — the one module that performs I/O.
+//!
+//! `duckdb` is a synchronous, embedded engine, so every database call runs
+//! inside [`tokio::task::spawn_blocking`]. Streaming stays bounded-memory: a
+//! dedicated blocking task holds the connection, iterates the result row by
+//! row, and hands finished [`StreamPage`]s to the async side over a small
+//! bounded channel — never buffering the whole result set.
+
+use crate::config::DuckdbSourceConfig;
+use async_trait::async_trait;
+use base64::Engine as _;
+use duckdb::types::{Value as DuckValue, ValueRef};
+use duckdb::{AccessMode, Config, Connection};
+use faucet_core::{FaucetError, Stream, StreamPage};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+/// A source that executes a SQL query against DuckDB and returns rows as JSON.
+///
+/// The connection is opened once in [`DuckdbSource::new`] and reused for every
+/// fetch/stream, wrapped in `Arc<Mutex<_>>` so it can move into the blocking
+/// task that runs each query.
+pub struct DuckdbSource {
+    config: DuckdbSourceConfig,
+    conn: Arc<Mutex<Connection>>,
+}
+
+/// Open a DuckDB connection honouring the config's path and access mode.
+fn open(config: &DuckdbSourceConfig) -> Result<Connection, FaucetError> {
+    let path = config.resolved_path();
+    let mode = if config.read_only {
+        AccessMode::ReadOnly
+    } else {
+        AccessMode::ReadWrite
+    };
+    let flags = Config::default()
+        .access_mode(mode)
+        .map_err(|e| FaucetError::Config(format!("duckdb config: {e}")))?;
+    let conn = if path == ":memory:" {
+        Connection::open_in_memory_with_flags(flags)
+    } else {
+        Connection::open_with_flags(path, flags)
+    };
+    conn.map_err(|e| FaucetError::Config(format!("DuckDB open failed ({path}): {e}")))
+}
+
+impl DuckdbSource {
+    /// Create a new DuckDB source, opening (and reusing) one connection.
+    pub async fn new(config: DuckdbSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        let cfg = config.clone();
+        let conn = tokio::task::spawn_blocking(move || open(&cfg))
+            .await
+            .map_err(|e| FaucetError::Source(format!("duckdb open task panicked: {e}")))??;
+        Ok(Self {
+            config,
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+}
+
+/// Build the effective SQL query and ordered context-bind values for a given
+/// parent context. Returns the literal query when there is no context.
+///
+/// DuckDB accepts positional `?` placeholders, so the bind-marker formatter
+/// ignores the index (mirrors the SQLite source).
+fn resolve_query(
+    config: &DuckdbSourceConfig,
+    context: &HashMap<String, Value>,
+) -> (String, Vec<Value>) {
+    if context.is_empty() {
+        (config.query.clone(), Vec::new())
+    } else {
+        faucet_core::util::substitute_context_bind_params(&config.query, context, 1, |_| {
+            "?".to_string()
+        })
+    }
+}
+
+/// Convert a JSON context value into an owned DuckDB parameter value.
+fn json_to_duck(v: &Value) -> DuckValue {
+    match v {
+        Value::Null => DuckValue::Null,
+        Value::Bool(b) => DuckValue::Boolean(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                DuckValue::BigInt(i)
+            } else if let Some(u) = n.as_u64() {
+                DuckValue::UBigInt(u)
+            } else if let Some(f) = n.as_f64() {
+                DuckValue::Double(f)
+            } else {
+                DuckValue::Null
+            }
+        }
+        Value::String(s) => DuckValue::Text(s.clone()),
+        // Arrays/objects have no scalar SQL form — bind their JSON text.
+        other => DuckValue::Text(other.to_string()),
+    }
+}
+
+/// Convert a DuckDB column value to a `serde_json::Value`.
+///
+/// Scalar types map exactly. `Text` becomes a UTF-8 (lossy) string and `Blob`
+/// becomes base64 so binary survives the JSON round-trip. Temporal, decimal,
+/// and nested (LIST / STRUCT / MAP / …) types are best-effort: temporal values
+/// surface their raw integer, and everything else falls back to a stable
+/// debug string — documented in the crate README.
+fn value_ref_to_json(v: ValueRef<'_>) -> Value {
+    use serde_json::json;
+    match v {
+        ValueRef::Null => Value::Null,
+        ValueRef::Boolean(b) => Value::Bool(b),
+        ValueRef::TinyInt(n) => json!(n),
+        ValueRef::SmallInt(n) => json!(n),
+        ValueRef::Int(n) => json!(n),
+        ValueRef::BigInt(n) => json!(n),
+        ValueRef::HugeInt(n) => i64::try_from(n)
+            .map(|x| json!(x))
+            .unwrap_or_else(|_| Value::String(n.to_string())),
+        ValueRef::UTinyInt(n) => json!(n),
+        ValueRef::USmallInt(n) => json!(n),
+        ValueRef::UInt(n) => json!(n),
+        ValueRef::UBigInt(n) => json!(n),
+        ValueRef::Float(f) => serde_json::Number::from_f64(f as f64)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        ValueRef::Double(f) => serde_json::Number::from_f64(f)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        ValueRef::Text(bytes) => Value::String(String::from_utf8_lossy(bytes).into_owned()),
+        ValueRef::Blob(bytes) => {
+            Value::String(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+        ValueRef::Decimal(d) => {
+            // DuckDB types bare fractional literals (e.g. `2.5`) as DECIMAL.
+            // Represent as a JSON number when the canonical string parses
+            // (f64-precision), else keep the exact decimal text.
+            let s = d.to_string();
+            serde_json::from_str::<serde_json::Number>(&s)
+                .map(Value::Number)
+                .unwrap_or(Value::String(s))
+        }
+        ValueRef::Timestamp(_, n) => json!(n),
+        ValueRef::Date32(n) => json!(n),
+        ValueRef::Time64(_, n) => json!(n),
+        ValueRef::Interval {
+            months,
+            days,
+            nanos,
+        } => json!({ "months": months, "days": days, "nanos": nanos }),
+        // List, Struct, Map, Array, Enum, Union — best-effort.
+        other => Value::String(format!("{other:?}")),
+    }
+}
+
+/// Build a JSON object from the current row using the pre-fetched column names.
+fn row_to_json(row: &duckdb::Row<'_>, col_names: &[String]) -> Result<Value, FaucetError> {
+    let mut map = serde_json::Map::with_capacity(col_names.len());
+    for (i, name) in col_names.iter().enumerate() {
+        let vr = row
+            .get_ref(i)
+            .map_err(|e| FaucetError::Source(format!("DuckDB column {name} read failed: {e}")))?;
+        map.insert(name.clone(), value_ref_to_json(vr));
+    }
+    Ok(Value::Object(map))
+}
+
+/// Run the query on the blocking thread and drain every row into a `Vec`
+/// (used by `fetch_with_context`).
+fn collect_blocking(
+    conn: &Arc<Mutex<Connection>>,
+    query: &str,
+    binds: &[Value],
+) -> Result<Vec<Value>, FaucetError> {
+    let guard = conn
+        .lock()
+        .map_err(|_| FaucetError::Source("duckdb connection mutex poisoned".into()))?;
+    let mut stmt = guard
+        .prepare(query)
+        .map_err(|e| FaucetError::Source(format!("DuckDB prepare failed: {e}")))?;
+    let params: Vec<DuckValue> = binds.iter().map(json_to_duck).collect();
+    let mut rows = stmt
+        .query(duckdb::params_from_iter(params))
+        .map_err(|e| FaucetError::Source(format!("DuckDB query failed: {e}")))?;
+    // DuckDB populates column metadata only after execution, so column names are
+    // read from the first row (via `Row: AsRef<Statement>`), not the prepared
+    // statement.
+    let mut col_names: Vec<String> = Vec::new();
+    let mut out = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| FaucetError::Source(format!("DuckDB row read failed: {e}")))?
+    {
+        if col_names.is_empty() {
+            col_names = row.as_ref().column_names();
+        }
+        out.push(row_to_json(row, &col_names)?);
+    }
+    Ok(out)
+}
+
+/// Run the query on the blocking thread, sending bounded pages over `tx`.
+fn stream_blocking(
+    conn: &Arc<Mutex<Connection>>,
+    query: &str,
+    binds: &[Value],
+    batch_size: usize,
+    tx: &mpsc::Sender<Result<StreamPage, FaucetError>>,
+) -> Result<(), FaucetError> {
+    let guard = conn
+        .lock()
+        .map_err(|_| FaucetError::Source("duckdb connection mutex poisoned".into()))?;
+    let mut stmt = guard
+        .prepare(query)
+        .map_err(|e| FaucetError::Source(format!("DuckDB prepare failed: {e}")))?;
+    let params: Vec<DuckValue> = binds.iter().map(json_to_duck).collect();
+    let mut rows = stmt
+        .query(duckdb::params_from_iter(params))
+        .map_err(|e| FaucetError::Source(format!("DuckDB query failed: {e}")))?;
+
+    let chunk = if batch_size == 0 {
+        usize::MAX
+    } else {
+        batch_size
+    };
+    let cap = if batch_size == 0 { 1024 } else { batch_size };
+    let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+    // Column names come from the first row (see `collect_blocking`).
+    let mut col_names: Vec<String> = Vec::new();
+
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| FaucetError::Source(format!("DuckDB row read failed: {e}")))?
+    {
+        if col_names.is_empty() {
+            col_names = row.as_ref().column_names();
+        }
+        buffer.push(row_to_json(row, &col_names)?);
+        if buffer.len() >= chunk {
+            let page = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+            // Receiver dropped (stream cancelled) → stop cleanly.
+            if tx
+                .blocking_send(Ok(StreamPage {
+                    records: page,
+                    bookmark: None,
+                }))
+                .is_err()
+            {
+                return Ok(());
+            }
+        }
+    }
+    if !buffer.is_empty() {
+        let _ = tx.blocking_send(Ok(StreamPage {
+            records: buffer,
+            bookmark: None,
+        }));
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl faucet_core::Source for DuckdbSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let conn = self.conn.clone();
+        let (query_str, binds) = resolve_query(&self.config, context);
+        let query_label = self.config.query.clone();
+        let records =
+            tokio::task::spawn_blocking(move || collect_blocking(&conn, &query_str, &binds))
+                .await
+                .map_err(|e| FaucetError::Source(format!("duckdb query task panicked: {e}")))??;
+        tracing::info!(
+            rows = records.len(),
+            query = %query_label,
+            "DuckDB source fetch complete"
+        );
+        Ok(records)
+    }
+
+    /// Stream rows in bounded-memory pages. A blocking task holds the
+    /// connection and pushes each finished page over a small channel; the async
+    /// side never holds more than a couple of pages at once.
+    ///
+    /// The trait-level `batch_size` argument is ignored in favour of the config
+    /// field (the user-facing knob). `batch_size = 0` drains the whole result
+    /// into a single page. This is a full-query source with no incremental
+    /// mode, so every page carries `bookmark: None`.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let conn = self.conn.clone();
+        let (query_str, binds) = resolve_query(&self.config, context);
+        let batch_size = self.config.batch_size;
+        let query_label = self.config.query.clone();
+        let (tx, mut rx) = mpsc::channel::<Result<StreamPage, FaucetError>>(4);
+
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = stream_blocking(&conn, &query_str, &binds, batch_size, &tx) {
+                let _ = tx.blocking_send(Err(e));
+            }
+        });
+
+        Box::pin(async_stream::try_stream! {
+            let mut total = 0usize;
+            while let Some(item) = rx.recv().await {
+                let page = item?;
+                total += page.records.len();
+                yield page;
+            }
+            tracing::info!(
+                rows = total,
+                batch_size,
+                query = %query_label,
+                "DuckDB source stream complete",
+            );
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(DuckdbSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "duckdb"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "duckdb://{}?query={}",
+            self.config.resolved_path(),
+            self.config.query
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::Source;
+
+    async fn memory_source(setup: &str, query: &str) -> DuckdbSource {
+        let source = DuckdbSource::new(DuckdbSourceConfig::new(":memory:", query))
+            .await
+            .unwrap();
+        source
+            .conn
+            .lock()
+            .unwrap()
+            .execute_batch(setup)
+            .expect("seed");
+        source
+    }
+
+    #[tokio::test]
+    async fn fetch_scalar_row() {
+        let source = DuckdbSource::new(DuckdbSourceConfig::new(
+            ":memory:",
+            "SELECT 1 AS val, 'hello' AS msg, true AS flag, 2.5 AS score",
+        ))
+        .await
+        .unwrap();
+        let records = source.fetch_all().await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["val"], 1);
+        assert_eq!(records[0]["msg"], "hello");
+        assert_eq!(records[0]["flag"], true);
+        assert_eq!(records[0]["score"], 2.5);
+        assert_eq!(source.connector_name(), "duckdb");
+    }
+
+    #[tokio::test]
+    async fn fetch_from_table() {
+        let source = memory_source(
+            "CREATE TABLE items (id INTEGER, name TEXT); \
+             INSERT INTO items VALUES (1, 'Alice'), (2, 'Bob');",
+            "SELECT * FROM items ORDER BY id",
+        )
+        .await;
+        let records = source.fetch_all().await.unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["id"], 1);
+        assert_eq!(records[1]["name"], "Bob");
+    }
+
+    #[tokio::test]
+    async fn blob_column_decodes_to_base64() {
+        let source = DuckdbSource::new(DuckdbSourceConfig::new(
+            ":memory:",
+            "SELECT '\\x00\\xFF'::BLOB AS data",
+        ))
+        .await
+        .unwrap();
+        let records = source.fetch_all().await.unwrap();
+        assert_eq!(records[0]["data"], "AP8=");
+    }
+
+    #[tokio::test]
+    async fn streaming_pages_are_bounded() {
+        let source = {
+            let s = memory_source(
+                "CREATE TABLE t (id INTEGER); \
+                 INSERT INTO t SELECT * FROM range(0, 250);",
+                "SELECT id FROM t ORDER BY id",
+            )
+            .await;
+            DuckdbSource {
+                config: s.config.with_batch_size(100),
+                conn: s.conn,
+            }
+        };
+        let ctx = HashMap::new();
+        let mut stream = source.stream_pages(&ctx, 100);
+        let mut seen = 0usize;
+        let mut peak = 0usize;
+        while let Some(page) = futures::StreamExt::next(&mut stream).await {
+            let page = page.unwrap();
+            peak = peak.max(page.records.len());
+            seen += page.records.len();
+        }
+        assert_eq!(seen, 250);
+        assert!(peak <= 100, "peak page {peak} exceeds batch_size");
+        assert!(peak < 250, "buffered everything into one page");
+    }
+
+    #[tokio::test]
+    async fn empty_result() {
+        let source = DuckdbSource::new(DuckdbSourceConfig::new(
+            ":memory:",
+            "SELECT 1 AS x WHERE 1 = 0",
+        ))
+        .await
+        .unwrap();
+        assert!(source.fetch_all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_query_returns_error() {
+        let source = DuckdbSource::new(DuckdbSourceConfig::new(":memory:", "NOT VALID SQL"))
+            .await
+            .unwrap();
+        assert!(source.fetch_all().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_with_context_binds_params_safely() {
+        let source = DuckdbSource::new(DuckdbSourceConfig::new(
+            ":memory:",
+            "SELECT {val} AS result",
+        ))
+        .await
+        .unwrap();
+        let mut context = HashMap::new();
+        context.insert("val".to_string(), serde_json::json!("1; DROP TABLE x; --"));
+        let records = source.fetch_with_context(&context).await.unwrap();
+        assert_eq!(records[0]["result"], "1; DROP TABLE x; --");
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let config = DuckdbSourceConfig::new(":memory:", "SELECT 1")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(
+            DuckdbSource::new(config).await,
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn value_ref_json_scalars() {
+        assert_eq!(value_ref_to_json(ValueRef::Null), Value::Null);
+        assert_eq!(
+            value_ref_to_json(ValueRef::Boolean(true)),
+            Value::Bool(true)
+        );
+        assert_eq!(value_ref_to_json(ValueRef::Int(7)), serde_json::json!(7));
+        assert_eq!(
+            value_ref_to_json(ValueRef::Text(b"hi")),
+            Value::String("hi".into())
+        );
+    }
+}

--- a/crates/source/duckdb/tests/conformance.rs
+++ b/crates/source/duckdb/tests/conformance.rs
@@ -1,0 +1,64 @@
+//! Runs the reusable `faucet-conformance` battery against the real DuckDB query
+//! source, seeded from a tempfile database — no Docker required.
+//!
+//! - check 1 `assert_config_schema_valid`
+//! - check 2 `assert_bounded_memory` (real paging over a seeded table)
+//! - check 6 `assert_errors_not_panics` (query against a missing table → typed
+//!   error, no panic)
+//!
+//! DuckDB query is full-table (no bookmark), so check 3 does not apply; checks
+//! 4/5 are sink-only.
+
+use duckdb::Connection;
+use faucet_source_duckdb::{DuckdbSource, DuckdbSourceConfig};
+use tempfile::TempDir;
+
+fn seed(rows: usize) -> (TempDir, String) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("t.duckdb");
+    let path_str = path.to_string_lossy().into_owned();
+    {
+        let conn = Connection::open(&path).expect("open");
+        conn.execute_batch("CREATE TABLE t (id INTEGER, name TEXT)")
+            .expect("create");
+        // range(0, rows) → one row per id; append the name column.
+        conn.execute_batch(&format!(
+            "INSERT INTO t SELECT i AS id, 'row-' || i AS name FROM range(0, {rows}) t(i)"
+        ))
+        .expect("insert");
+    } // connection dropped → file released for the source to open
+    (dir, path_str)
+}
+
+#[tokio::test]
+async fn conformance_config_schema_valid() {
+    let (_dir, path) = seed(1);
+    let source = DuckdbSource::new(DuckdbSourceConfig::new(path, "SELECT * FROM t"))
+        .await
+        .expect("source");
+    faucet_conformance::assert_config_schema_valid(&source);
+}
+
+#[tokio::test]
+async fn conformance_bounded_memory() {
+    let total = 500;
+    let batch = 100;
+    let (_dir, path) = seed(total);
+    let source = DuckdbSource::new(
+        DuckdbSourceConfig::new(path, "SELECT id, name FROM t ORDER BY id").with_batch_size(batch),
+    )
+    .await
+    .expect("source");
+    faucet_conformance::assert_bounded_memory(&source, batch, total).await;
+}
+
+#[tokio::test]
+async fn conformance_errors_not_panics() {
+    // Valid database, but the query references a table that does not exist — the
+    // read path must surface a typed FaucetError, never a panic.
+    let (_dir, path) = seed(1);
+    let source = DuckdbSource::new(DuckdbSourceConfig::new(path, "SELECT * FROM missing_table"))
+        .await
+        .expect("source builds; the query only fails at read time");
+    faucet_conformance::assert_errors_not_panics(&source).await;
+}

--- a/crates/source/nats/CHANGELOG.md
+++ b/crates/source/nats/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: NATS source — subscribes to a subject (core NATS with
+  `*`/`>` wildcards and optional queue groups) or pulls from a durable
+  JetStream consumer, drains with `max_messages` / `idle_timeout_secs`
+  termination, and streams payloads as JSON with bounded memory. Conformance
+  battery wired ([#411](https://github.com/PawanSikawat/faucet-stream/issues/411)).

--- a/crates/source/nats/Cargo.toml
+++ b/crates/source/nats/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "faucet-source-nats"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "NATS source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["nats", "messaging", "streaming", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-nats.workspace = true
+async-nats.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "signal"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+futures.workspace = true
+faucet-conformance.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["nats"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/nats/README.md
+++ b/crates/source/nats/README.md
@@ -1,0 +1,67 @@
+# faucet-source-nats
+
+A [NATS](https://nats.io) source for [`faucet-stream`](https://crates.io/crates/faucet-stream).
+
+Subscribes to a subject (core NATS, with `*`/`>` wildcards and optional queue
+groups) or pulls from a durable JetStream consumer, drains until `max_messages`
+or `idle_timeout_secs` fires, and yields each message payload as a JSON record —
+valid JSON passes through, anything else becomes a JSON string.
+
+Core NATS is fire-and-forget at-least-once, so runs carry **no bookmark** and
+are not resumable/exactly-once. In JetStream mode each page's messages are
+**acked after the page is written**, giving at-least-once delivery.
+
+## Configuration
+
+The shared connection surface (`servers` / `auth` / `tls` / `name` — see
+[`faucet-common-nats`](https://crates.io/crates/faucet-common-nats)) is flattened
+in alongside these fields:
+
+| field               | type             | default | description                                                        |
+|---------------------|------------------|---------|--------------------------------------------------------------------|
+| `subject`           | `String`         | —       | subject to subscribe to (`*`/`>` wildcards). Required.             |
+| `queue_group`       | `Option<String>` | —       | core-NATS queue group for load-balanced subscriptions.             |
+| `jetstream_stream`  | `Option<String>` | —       | JetStream stream name (enables JetStream mode).                    |
+| `jetstream_consumer`| `Option<String>` | —       | durable pull-consumer name; required with `jetstream_stream`.      |
+| `max_messages`      | `Option<usize>`  | —       | stop after this many messages.                                     |
+| `idle_timeout_secs` | `Option<u64>`    | —       | stop after this many seconds with no new message.                  |
+| `batch_size`        | `usize`          | `1000`  | records per emitted page (`0` = one page for the whole run window).|
+
+At least one of `max_messages` / `idle_timeout_secs` must be set so the run
+terminates.
+
+## Example (core NATS)
+
+```yaml
+version: 1
+pipeline:
+  source:
+    kind: nats
+    config:
+      servers: ["nats://127.0.0.1:4222"]
+      subject: "events.>"
+      idle_timeout_secs: 5
+      batch_size: 500
+  sink:
+    kind: stdout
+    config: {}
+```
+
+## Example (JetStream durable consumer)
+
+```yaml
+pipeline:
+  source:
+    kind: nats
+    config:
+      servers: ["nats://127.0.0.1:4222"]
+      subject: "orders.>"
+      jetstream_stream: ORDERS
+      jetstream_consumer: faucet-worker
+      max_messages: 10000
+      idle_timeout_secs: 10
+```
+
+## License
+
+Licensed under either of Apache-2.0 or MIT at your option.

--- a/crates/source/nats/src/config.rs
+++ b/crates/source/nats/src/config.rs
@@ -1,0 +1,228 @@
+//! Configuration for the NATS source.
+
+use faucet_common_nats::NatsConnectionConfig;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for [`NatsSource`](crate::NatsSource).
+///
+/// The [`NatsConnectionConfig`] surface (`servers` / `auth` / `tls` / `name`)
+/// is flattened in, so a config looks like:
+///
+/// ```yaml
+/// servers: ["nats://127.0.0.1:4222"]
+/// subject: "events.>"
+/// idle_timeout_secs: 5
+/// batch_size: 500
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NatsSourceConfig {
+    /// Connection settings (servers, auth, tls, name).
+    #[serde(flatten)]
+    pub connection: NatsConnectionConfig,
+
+    /// Subject to subscribe to. Supports NATS wildcards (`*` for one token,
+    /// `>` for the remaining tokens). In JetStream mode the durable consumer's
+    /// own filter subject governs delivery and this field is informational.
+    pub subject: String,
+
+    /// Optional queue group for core-NATS load-balanced subscriptions — all
+    /// subscribers sharing a group split the subject's messages. Ignored in
+    /// JetStream mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_group: Option<String>,
+
+    /// JetStream stream name. When set together with
+    /// [`jetstream_consumer`](Self::jetstream_consumer) the source pulls from a
+    /// durable JetStream consumer instead of a core-NATS subscription.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jetstream_stream: Option<String>,
+
+    /// Name of the durable JetStream (pull) consumer to bind to. Required when
+    /// [`jetstream_stream`](Self::jetstream_stream) is set; the consumer must
+    /// already exist on the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jetstream_consumer: Option<String>,
+
+    /// Stop after this many messages have been drained. At least one of
+    /// `max_messages` / `idle_timeout_secs` must be set so a run terminates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_messages: Option<usize>,
+
+    /// Stop after this many seconds elapse with no new message. At least one of
+    /// `max_messages` / `idle_timeout_secs` must be set so a run terminates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
+
+    /// Messages per emitted [`StreamPage`](faucet_core::StreamPage). Drained
+    /// messages accumulate in an in-memory buffer and a page is yielded when
+    /// the buffer reaches this size (or when the run terminates with a partial
+    /// buffer). Defaults to [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// `batch_size = 0` is the "drain-entire-run-window" sentinel: every
+    /// message produced before the terminator fires goes into a single page.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+impl NatsSourceConfig {
+    /// Convenience constructor for a minimal core-NATS subscription with an
+    /// idle-timeout terminator.
+    pub fn new(subject: impl Into<String>) -> Self {
+        Self {
+            connection: NatsConnectionConfig::default(),
+            subject: subject.into(),
+            queue_group: None,
+            jetstream_stream: None,
+            jetstream_consumer: None,
+            max_messages: None,
+            idle_timeout_secs: Some(5),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Whether this config selects JetStream (pull-consumer) mode.
+    pub fn is_jetstream(&self) -> bool {
+        self.jetstream_stream.is_some()
+    }
+
+    /// Validate the config at construction time.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+
+        if self.subject.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "nats source: `subject` must not be empty".into(),
+            ));
+        }
+
+        match (&self.jetstream_stream, &self.jetstream_consumer) {
+            (Some(s), _) if s.trim().is_empty() => {
+                return Err(FaucetError::Config(
+                    "nats source: `jetstream_stream` must not be empty".into(),
+                ));
+            }
+            (Some(_), None) => {
+                return Err(FaucetError::Config(
+                    "nats source: `jetstream_consumer` is required when `jetstream_stream` is set"
+                        .into(),
+                ));
+            }
+            (Some(_), Some(c)) if c.trim().is_empty() => {
+                return Err(FaucetError::Config(
+                    "nats source: `jetstream_consumer` must not be empty".into(),
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(FaucetError::Config(
+                    "nats source: `jetstream_stream` is required when `jetstream_consumer` is set"
+                        .into(),
+                ));
+            }
+            _ => {}
+        }
+
+        if self.max_messages.is_none() && self.idle_timeout_secs.is_none() {
+            return Err(FaucetError::Config(
+                "nats source: at least one of `max_messages` or `idle_timeout_secs` must be set \
+                 so the run terminates"
+                    .into(),
+            ));
+        }
+
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validate_accepts_minimal() {
+        assert!(NatsSourceConfig::new("events.>").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_subject() {
+        let mut c = NatsSourceConfig::new("x");
+        c.subject = "  ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_missing_terminator() {
+        let mut c = NatsSourceConfig::new("x");
+        c.idle_timeout_secs = None;
+        c.max_messages = None;
+        let err = c.validate().unwrap_err();
+        assert!(format!("{err}").contains("max_messages"));
+    }
+
+    #[test]
+    fn validate_requires_consumer_with_stream() {
+        let mut c = NatsSourceConfig::new("x");
+        c.jetstream_stream = Some("ORDERS".into());
+        let err = c.validate().unwrap_err();
+        assert!(format!("{err}").contains("jetstream_consumer"));
+    }
+
+    #[test]
+    fn validate_requires_stream_with_consumer() {
+        let mut c = NatsSourceConfig::new("x");
+        c.jetstream_consumer = Some("worker".into());
+        let err = c.validate().unwrap_err();
+        assert!(format!("{err}").contains("jetstream_stream"));
+    }
+
+    #[test]
+    fn validate_accepts_full_jetstream() {
+        let mut c = NatsSourceConfig::new("orders.>");
+        c.jetstream_stream = Some("ORDERS".into());
+        c.jetstream_consumer = Some("worker".into());
+        c.max_messages = Some(100);
+        assert!(c.validate().is_ok());
+        assert!(c.is_jetstream());
+    }
+
+    #[test]
+    fn validate_rejects_batch_size_over_max() {
+        let mut c = NatsSourceConfig::new("x");
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(matches!(c.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn deserialize_flattened_connection() {
+        let c: NatsSourceConfig = serde_json::from_value(json!({
+            "servers": ["nats://a:4222"],
+            "auth": {"type": "token", "config": {"token": "t"}},
+            "subject": "events.>",
+            "max_messages": 10
+        }))
+        .unwrap();
+        assert_eq!(c.subject, "events.>");
+        assert_eq!(c.connection.servers, vec!["nats://a:4222".to_string()]);
+        assert_eq!(c.max_messages, Some(10));
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn batch_size_zero_is_accepted() {
+        let mut c = NatsSourceConfig::new("x");
+        c.batch_size = 0;
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn schema_compiles() {
+        let _ = schemars::schema_for!(NatsSourceConfig);
+    }
+}

--- a/crates/source/nats/src/lib.rs
+++ b/crates/source/nats/src/lib.rs
@@ -1,0 +1,32 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-nats
+//!
+//! A [NATS](https://nats.io) source for `faucet-stream`. Subscribes to a
+//! subject (core NATS, with `*`/`>` wildcards and optional queue groups) or
+//! pulls from a durable JetStream consumer, drains until `max_messages` or
+//! `idle_timeout_secs` fires, and yields each message payload as a JSON record
+//! (valid JSON passes through; anything else becomes a JSON string).
+//!
+//! Core NATS is fire-and-forget at-least-once, so runs carry no bookmark and
+//! are not resumable/exactly-once. In JetStream mode each page's messages are
+//! acked after the page is written, giving at-least-once delivery.
+//!
+//! ```no_run
+//! use faucet_source_nats::{NatsSource, NatsSourceConfig};
+//! # async fn ex() -> Result<(), faucet_core::FaucetError> {
+//! let source = NatsSource::new(NatsSourceConfig::new("events.>")).await?;
+//! # let _ = source;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod config;
+pub mod stream;
+
+pub use config::NatsSourceConfig;
+pub use stream::NatsSource;
+
+// Re-export shared config types so downstream users import from one place.
+pub use faucet_common_nats::{NatsAuth, NatsConnectionConfig};
+pub use faucet_core::{FaucetError, Source};

--- a/crates/source/nats/src/stream.rs
+++ b/crates/source/nats/src/stream.rs
@@ -1,0 +1,426 @@
+//! `NatsSource` — the NATS consumer implementation (the one module that does I/O).
+//!
+//! Two modes, selected by config:
+//! - **Core NATS** — `client.subscribe(subject)` (optionally a queue group).
+//!   Fire-and-forget delivery: no bookmark, not resumable.
+//! - **JetStream** — pull from a durable consumer bound to an existing stream.
+//!   Each page's messages are acked *after* the page is yielded (i.e. after the
+//!   pipeline has written the previous page to the sink), giving at-least-once
+//!   delivery without claiming exactly-once.
+//!
+//! Both drain until `max_messages` or `idle_timeout_secs` fires, buffering up to
+//! `batch_size` records per [`StreamPage`] so memory stays bounded.
+
+use crate::config::NatsSourceConfig;
+use async_trait::async_trait;
+use faucet_core::{FaucetError, Source, Stream, StreamPage};
+use futures::StreamExt;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+use tokio::sync::OnceCell;
+
+/// A source that drains messages from a NATS subject (or a JetStream durable
+/// consumer) and emits each payload as a JSON record.
+///
+/// The client is built lazily on the first fetch/stream (see
+/// [`NatsSource::new`]), so an unreachable server fails on the first poll rather
+/// than at construction time.
+pub struct NatsSource {
+    config: NatsSourceConfig,
+    client: OnceCell<async_nats::Client>,
+}
+
+impl NatsSource {
+    /// Create a new NATS source. Validates the config but does **not** connect —
+    /// the client is built lazily on the first fetch/stream.
+    pub async fn new(config: NatsSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            client: OnceCell::new(),
+        })
+    }
+
+    /// Lazily build (once) and return the shared NATS client.
+    async fn client(&self) -> Result<async_nats::Client, FaucetError> {
+        self.client
+            .get_or_try_init(|| faucet_common_nats::connect(&self.config.connection))
+            .await
+            .cloned()
+    }
+}
+
+/// Parse a raw NATS payload into a JSON record: valid JSON is passed through,
+/// anything else becomes a JSON string of the (lossy) UTF-8 text.
+fn payload_to_value(payload: &[u8]) -> Value {
+    match serde_json::from_slice::<Value>(payload) {
+        Ok(v) => v,
+        Err(_) => Value::String(String::from_utf8_lossy(payload).into_owned()),
+    }
+}
+
+/// The per-message poll outcome fed to the shared drain loop.
+enum Polled {
+    /// A decoded record (JetStream carries the message for a deferred ack).
+    Record(Value),
+    /// The underlying subscription/stream closed.
+    Closed,
+    /// The poll budget elapsed with no message.
+    Idle,
+}
+
+#[async_trait]
+impl Source for NatsSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        // Reuse the streaming path so there is a single drain implementation.
+        let mut pages = self.stream_pages(context, self.config.batch_size);
+        let mut out = Vec::new();
+        while let Some(page) = pages.next().await {
+            out.extend(page?.records);
+        }
+        Ok(out)
+    }
+
+    /// Stream messages page-by-page. The trait-level `batch_size` argument is
+    /// ignored in favour of the config field (the user-facing knob).
+    ///
+    /// No page carries a bookmark: core NATS is fire-and-forget and the
+    /// JetStream path acks rather than persisting a resumable position, so this
+    /// source is not resumable / exactly-once (the defaults hold).
+    fn stream_pages<'a>(
+        &'a self,
+        _context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+        let page_chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
+        let cap = if batch_size == 0 { 1024 } else { batch_size };
+        let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
+        let idle = self.config.idle_timeout_secs.map(Duration::from_secs);
+        let poll_fallback = Duration::from_millis(500);
+
+        Box::pin(async_stream::try_stream! {
+            let client = self.client().await?;
+
+            if self.config.is_jetstream() {
+                // ── JetStream pull-consumer mode ────────────────────────────
+                let stream_name = self
+                    .config
+                    .jetstream_stream
+                    .as_deref()
+                    .expect("validated: jetstream_stream is Some in JetStream mode");
+                let consumer_name = self
+                    .config
+                    .jetstream_consumer
+                    .as_deref()
+                    .expect("validated: jetstream_consumer is Some in JetStream mode");
+
+                let js = async_nats::jetstream::new(client);
+                let js_stream = js
+                    .get_stream(stream_name)
+                    .await
+                    .map_err(|e| FaucetError::Source(format!("nats jetstream get_stream '{stream_name}': {e}")))?;
+                let consumer: async_nats::jetstream::consumer::PullConsumer = js_stream
+                    .get_consumer(consumer_name)
+                    .await
+                    .map_err(|e| FaucetError::Source(format!("nats jetstream get_consumer '{consumer_name}': {e}")))?;
+                let mut messages = consumer
+                    .messages()
+                    .await
+                    .map_err(|e| FaucetError::Source(format!("nats jetstream messages(): {e}")))?;
+
+                let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+                // Messages for the page currently being buffered, acked after
+                // the page is yielded (i.e. once the pipeline has written it).
+                let mut page_msgs: Vec<async_nats::jetstream::Message> = Vec::with_capacity(cap);
+                let mut to_ack: Vec<async_nats::jetstream::Message> = Vec::new();
+                let mut total = 0usize;
+                let mut last_at = Instant::now();
+
+                loop {
+                    ack_all(std::mem::take(&mut to_ack)).await;
+
+                    let (budget, deadline) = poll_budget(idle, last_at, poll_fallback);
+                    let mut stop = false;
+                    let mut fatal: Option<FaucetError> = None;
+
+                    let polled = tokio::select! {
+                        biased;
+                        _ = tokio::signal::ctrl_c() => {
+                            tracing::info!("nats source: ctrl_c received, stopping");
+                            Polled::Closed
+                        }
+                        next = tokio::time::timeout(budget, messages.next()) => match next {
+                            Ok(Some(Ok(msg))) => {
+                                last_at = Instant::now();
+                                let record = payload_to_value(&msg.payload);
+                                page_msgs.push(msg);
+                                Polled::Record(record)
+                            }
+                            Ok(Some(Err(e))) => {
+                                fatal = Some(FaucetError::Source(format!("nats jetstream recv: {e}")));
+                                Polled::Idle
+                            }
+                            Ok(None) => Polled::Closed,
+                            Err(_elapsed) => Polled::Idle,
+                        }
+                    };
+
+                    if let Some(e) = fatal {
+                        Err(e)?;
+                    }
+
+                    match polled {
+                        Polled::Record(record) => {
+                            buffer.push(record);
+                            total += 1;
+                            if total >= max_messages {
+                                stop = true;
+                            }
+                        }
+                        Polled::Closed => stop = true,
+                        Polled::Idle => {
+                            if idle_expired(deadline) {
+                                stop = true;
+                            }
+                        }
+                    }
+
+                    if !buffer.is_empty() && buffer.len() >= page_chunk {
+                        let records = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+                        yield StreamPage { records, bookmark: None };
+                        // Resumed ⇒ the page was written; ack its messages next iteration.
+                        to_ack = std::mem::take(&mut page_msgs);
+                    }
+
+                    if stop {
+                        break;
+                    }
+                }
+
+                // Flush any acks pending from the last full page, then the
+                // trailing partial page (and its acks).
+                ack_all(std::mem::take(&mut to_ack)).await;
+                if !buffer.is_empty() {
+                    yield StreamPage { records: buffer, bookmark: None };
+                    ack_all(std::mem::take(&mut page_msgs)).await;
+                }
+                tracing::info!(messages = total, "nats source: jetstream stream complete");
+            } else {
+                // ── Core NATS subscription mode ─────────────────────────────
+                let mut sub: Pin<Box<async_nats::Subscriber>> = Box::pin(match &self.config.queue_group {
+                    Some(group) => client
+                        .queue_subscribe(self.config.subject.clone(), group.clone())
+                        .await
+                        .map_err(|e| FaucetError::Source(format!("nats queue_subscribe '{}': {e}", self.config.subject)))?,
+                    None => client
+                        .subscribe(self.config.subject.clone())
+                        .await
+                        .map_err(|e| FaucetError::Source(format!("nats subscribe '{}': {e}", self.config.subject)))?,
+                });
+
+                let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+                let mut total = 0usize;
+                let mut last_at = Instant::now();
+
+                loop {
+                    let (budget, deadline) = poll_budget(idle, last_at, poll_fallback);
+                    let mut stop = false;
+
+                    let polled = tokio::select! {
+                        biased;
+                        _ = tokio::signal::ctrl_c() => {
+                            tracing::info!("nats source: ctrl_c received, stopping");
+                            Polled::Closed
+                        }
+                        next = tokio::time::timeout(budget, sub.next()) => match next {
+                            Ok(Some(msg)) => {
+                                last_at = Instant::now();
+                                Polled::Record(payload_to_value(&msg.payload))
+                            }
+                            Ok(None) => Polled::Closed,
+                            Err(_elapsed) => Polled::Idle,
+                        }
+                    };
+
+                    match polled {
+                        Polled::Record(record) => {
+                            buffer.push(record);
+                            total += 1;
+                            if total >= max_messages {
+                                stop = true;
+                            }
+                        }
+                        Polled::Closed => stop = true,
+                        Polled::Idle => {
+                            if idle_expired(deadline) {
+                                stop = true;
+                            }
+                        }
+                    }
+
+                    if !buffer.is_empty() && buffer.len() >= page_chunk {
+                        let records = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+                        yield StreamPage { records, bookmark: None };
+                    }
+
+                    if stop {
+                        break;
+                    }
+                }
+
+                if !buffer.is_empty() {
+                    yield StreamPage { records: buffer, bookmark: None };
+                }
+                tracing::info!(messages = total, "nats source: core stream complete");
+            }
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(NatsSourceConfig)).unwrap_or(Value::Null)
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "nats"
+    }
+
+    fn dataset_uri(&self) -> String {
+        let server = self
+            .config
+            .connection
+            .servers
+            .first()
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        format!("nats://{server}?subject={}", self.config.subject)
+    }
+}
+
+/// Compute the poll timeout for this iteration and the idle deadline (if any).
+/// With no idle timeout configured we poll in short bursts so `ctrl_c` and
+/// `max_messages` termination stay responsive.
+fn poll_budget(
+    idle: Option<Duration>,
+    last_at: Instant,
+    fallback: Duration,
+) -> (Duration, Option<Instant>) {
+    match idle {
+        Some(t) => {
+            let deadline = last_at + t;
+            let budget = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            (budget, Some(deadline))
+        }
+        None => (fallback, None),
+    }
+}
+
+/// Whether the idle deadline (if set) has passed.
+fn idle_expired(deadline: Option<Instant>) -> bool {
+    deadline.is_some_and(|d| Instant::now() >= d)
+}
+
+/// Ack a page's JetStream messages best-effort — a failed ack triggers at most
+/// a redelivery (at-least-once), never data loss, so it is logged not fatal.
+async fn ack_all(messages: Vec<async_nats::jetstream::Message>) {
+    for msg in messages {
+        if let Err(e) = msg.ack().await {
+            tracing::warn!(error = %e, "nats source: jetstream ack failed (message may be redelivered)");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_json_passthrough() {
+        let v = payload_to_value(br#"{"id":1,"name":"a"}"#);
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["name"], "a");
+    }
+
+    #[test]
+    fn payload_non_json_becomes_string() {
+        let v = payload_to_value(b"hello world");
+        assert_eq!(v, Value::String("hello world".into()));
+    }
+
+    #[test]
+    fn payload_invalid_utf8_lossy_string() {
+        let v = payload_to_value(&[0xff, 0xfe, 0x00]);
+        assert!(v.is_string());
+    }
+
+    #[test]
+    fn poll_budget_none_uses_fallback() {
+        let (budget, deadline) = poll_budget(None, Instant::now(), Duration::from_millis(500));
+        assert_eq!(budget, Duration::from_millis(500));
+        assert!(deadline.is_none());
+    }
+
+    #[test]
+    fn poll_budget_idle_sets_deadline() {
+        let (_budget, deadline) = poll_budget(
+            Some(Duration::from_secs(5)),
+            Instant::now(),
+            Duration::from_millis(500),
+        );
+        assert!(deadline.is_some());
+    }
+
+    #[test]
+    fn idle_expired_true_when_past() {
+        let past = Instant::now() - Duration::from_secs(1);
+        assert!(idle_expired(Some(past)));
+    }
+
+    #[test]
+    fn idle_expired_false_when_none() {
+        assert!(!idle_expired(None));
+    }
+
+    #[tokio::test]
+    async fn new_validates_config() {
+        let mut cfg = NatsSourceConfig::new("x");
+        cfg.idle_timeout_secs = None;
+        cfg.max_messages = None;
+        assert!(NatsSource::new(cfg).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn connector_name_and_uri() {
+        let source = NatsSource::new(NatsSourceConfig::new("events.>"))
+            .await
+            .unwrap();
+        assert_eq!(source.connector_name(), "nats");
+        assert!(source.dataset_uri().contains("subject=events.>"));
+    }
+
+    #[tokio::test]
+    async fn unreachable_server_errors_on_first_poll() {
+        let mut cfg = NatsSourceConfig::new("events.>");
+        cfg.connection.servers = vec!["nats://127.0.0.1:1".into()];
+        cfg.idle_timeout_secs = Some(1);
+        let source = NatsSource::new(cfg)
+            .await
+            .expect("lazy construction succeeds");
+        // First poll connects and must surface a typed error, not panic.
+        let ctx = HashMap::new();
+        let mut pages = source.stream_pages(&ctx, 10);
+        let first = pages.next().await;
+        assert!(matches!(first, Some(Err(FaucetError::Custom(_)))));
+    }
+}

--- a/crates/source/nats/tests/conformance.rs
+++ b/crates/source/nats/tests/conformance.rs
@@ -1,0 +1,110 @@
+//! `faucet-conformance` Tier-1 battery for the NATS source.
+//!
+//! - **Check 1** (`conformance_config_schema_valid`) — pure/offline, MUST pass.
+//! - **Check 6** (`conformance_errors_not_panics`) — points at an unreachable
+//!   server (`nats://127.0.0.1:1`); connect fails on the first poll, so this
+//!   runs offline and MUST pass.
+//! - **Check 2** (`conformance_bounded_memory`) — boots a real NATS server via
+//!   `testcontainers-modules` (Docker); publishes N messages, then drains with
+//!   `max_messages = N` so the bounded-memory check can assert `seen == total`.
+//!
+//! Bookmark/idempotency checks (3/4/5) do not apply: core NATS is
+//! fire-and-forget (no bookmark) and 4/5 are sink-only.
+
+use faucet_conformance::{assert_config_schema_valid_value, assert_errors_not_panics};
+use faucet_source_nats::{NatsSource, NatsSourceConfig};
+
+// ── Check 1: config schema (offline) ────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(NatsSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-nats");
+}
+
+// ── Check 6: errors, not panics (offline — unreachable server) ───────────────
+
+#[tokio::test]
+async fn conformance_errors_not_panics() {
+    let mut cfg = NatsSourceConfig::new("events.>");
+    cfg.connection.servers = vec!["nats://127.0.0.1:1".into()];
+    // A short terminator keeps the run bounded even on the (unreachable) happy
+    // path; the connect failure surfaces before it ever matters.
+    cfg.idle_timeout_secs = Some(1);
+    let source = NatsSource::new(cfg)
+        .await
+        .expect("lazy construction succeeds");
+    assert_errors_not_panics(&source).await;
+}
+
+// ── Check 2: bounded-memory streaming (Docker) ───────────────────────────────
+
+#[cfg(test)]
+mod docker {
+    use super::*;
+    use faucet_source_nats::Source;
+    use futures::StreamExt;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::nats::Nats;
+
+    async fn start_nats() -> (testcontainers::ContainerAsync<Nats>, String) {
+        let container = Nats::default().start().await.expect("nats container start");
+        let host = container.get_host().await.expect("nats host");
+        let port = container.get_host_port_ipv4(4222).await.expect("nats port");
+        (container, format!("nats://{host}:{port}"))
+    }
+
+    async fn publish_json(server: &str, subject: &str, count: usize) {
+        let client = async_nats::connect(server).await.expect("connect");
+        for i in 1..=count {
+            let payload = format!(r#"{{"id":{i}}}"#);
+            client
+                .publish(subject.to_string(), payload.into_bytes().into())
+                .await
+                .expect("publish");
+        }
+        client.flush().await.expect("flush");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn conformance_bounded_memory() {
+        let (_container, server) = start_nats().await;
+        let subject = "conformance.bounded";
+        const N: usize = 5_000;
+
+        // Subscribe first (core NATS drops messages published before a
+        // subscription exists), then publish, then drain.
+        let mut cfg = NatsSourceConfig::new(subject);
+        cfg.connection.servers = vec![server.clone()];
+        cfg.max_messages = Some(N);
+        cfg.idle_timeout_secs = Some(30);
+        cfg.batch_size = 250;
+        let source = NatsSource::new(cfg).await.expect("source new");
+
+        // Drive the drain concurrently with the publisher: start streaming so the
+        // subscription is live, then publish the N messages.
+        let ctx = std::collections::HashMap::new();
+        let publisher = {
+            let server = server.clone();
+            tokio::spawn(async move {
+                // Small delay so the subscription is established first.
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                publish_json(&server, subject, N).await;
+            })
+        };
+
+        let mut stream = source.stream_pages(&ctx, 250);
+        let mut seen = 0usize;
+        let mut peak = 0usize;
+        while let Some(page) = stream.next().await {
+            let page = page.expect("page");
+            peak = peak.max(page.records.len());
+            seen += page.records.len();
+        }
+        publisher.await.expect("publisher");
+
+        assert_eq!(seen, N, "streamed {seen}, expected {N}");
+        assert!(peak <= 250, "peak page {peak} exceeds batch_size");
+        assert!(peak < N, "buffered everything into one page");
+    }
+}

--- a/crates/source/sftp/CHANGELOG.md
+++ b/crates/source/sftp/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: SFTP source connector — lists a remote directory (or reads a
+  single file) over SFTP and streams the files as JSON Lines, JSON arrays, or
+  raw text with bounded memory. Filename glob filter, lazy connect, conformance
+  battery wired ([#410](https://github.com/PawanSikawat/faucet-stream/issues/410)).

--- a/crates/source/sftp/Cargo.toml
+++ b/crates/source/sftp/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "faucet-source-sftp"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SFTP source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["sftp", "ssh", "file", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-sftp.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "io-util", "net"] }
+async-stream = { workspace = true }
+futures.workspace = true
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+faucet-common-sftp.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+schemars.workspace = true
+futures = { workspace = true }
+testcontainers = "0.27"
+tempfile = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/sftp/Cargo.toml
+++ b/crates/source/sftp/Cargo.toml
@@ -25,7 +25,7 @@ futures.workspace = true
 [dev-dependencies]
 faucet-conformance.workspace = true
 faucet-common-sftp.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util"] }
 serde_json.workspace = true
 schemars.workspace = true
 futures = { workspace = true }

--- a/crates/source/sftp/README.md
+++ b/crates/source/sftp/README.md
@@ -1,0 +1,58 @@
+# faucet-source-sftp
+
+SFTP source connector for the [faucet-stream](https://crates.io/crates/faucet-stream)
+ecosystem.
+
+Lists a remote directory (or reads a single file) over SFTP and streams the
+files as JSON Lines, JSON arrays, or raw text. JSON Lines and raw text are
+decoded incrementally, so memory stays bounded regardless of file size; JSON
+arrays are buffered per file (the closing `]` is needed to validate the
+structure) and then chunked.
+
+Connection, authentication, and host-key verification come from
+[`faucet-common-sftp`](https://crates.io/crates/faucet-common-sftp).
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | string | — | Server hostname or IP. |
+| `port` | integer | `22` | Server port. |
+| `username` | string | — | SSH username. |
+| `type` / `config` | auth | — | `password` or `private_key` (see `faucet-common-sftp`). |
+| `known_hosts` | policy | `{ mode: accept_new }` | Host-key verification policy. |
+| `path` | string | — | Remote directory to list, or a single file. |
+| `glob` | string | none | Filename glob (`*` / `?`) applied to basenames when `path` is a directory. |
+| `format` | enum | `jsonl` | `jsonl` \| `json_array` \| `raw_text`. |
+| `batch_size` | integer | `1000` | Records per page; `0` = one page per file. |
+
+`raw_text` emits one record per file: `{ "path": <remote path>, "content": <file text> }`.
+
+The SFTP source is not resumable — every page carries no bookmark.
+
+## Example
+
+```yaml
+version: 1
+pipeline:
+  source:
+    kind: sftp
+    config:
+      host: sftp.example.com
+      port: 22
+      username: reporting
+      type: password
+      config:
+        password: ${env:SFTP_PASSWORD}
+      known_hosts:
+        mode: accept_new
+      path: /exports/daily
+      glob: "*.jsonl"
+      format: jsonl
+      batch_size: 1000
+  sink:
+    kind: stdout
+    config: {}
+```
+
+Licensed under MIT OR Apache-2.0.

--- a/crates/source/sftp/src/config.rs
+++ b/crates/source/sftp/src/config.rs
@@ -1,0 +1,199 @@
+//! SFTP source configuration.
+
+use faucet_common_sftp::SftpConnectionConfig;
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Format of the remote files read by the SFTP source.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SftpFormat {
+    /// Each line in the file is a separate JSON record (the default).
+    /// Streamed line-by-line with bounded memory.
+    #[default]
+    Jsonl,
+    /// The entire file is a JSON array of records. Buffered fully per file
+    /// (the closing `]` is required to validate the structure), then chunked.
+    JsonArray,
+    /// Each file becomes a single record with `"path"` and `"content"` fields.
+    RawText,
+}
+
+/// Configuration for the SFTP source connector.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SftpSourceConfig {
+    /// Shared SFTP connection settings (host, port, username, auth, host-key
+    /// policy). Flattened, so its fields sit at the top level of the config.
+    #[serde(flatten)]
+    pub connection: SftpConnectionConfig,
+    /// Remote path to read: a directory whose files are listed and streamed,
+    /// or a single file.
+    pub path: String,
+    /// Optional filename glob (`*` / `?`) applied to the basenames of files in
+    /// a directory listing. Ignored when `path` points at a single file.
+    #[serde(default)]
+    pub glob: Option<String>,
+    /// Format of the files to read (default: `jsonl`).
+    #[serde(default)]
+    pub format: SftpFormat,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). For
+    /// `jsonl` / `raw_text`, files are decoded incrementally and a page is
+    /// yielded whenever the buffer reaches this size (bounded memory). For
+    /// `json_array`, each file is buffered fully, then its records are chunked
+    /// into pages of this size. Defaults to [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// `batch_size = 0` is the "no batching" sentinel: one page is emitted per
+    /// file.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+impl SftpSourceConfig {
+    /// Build a source config from a connection and a remote path, with default
+    /// format (`jsonl`) and batch size.
+    pub fn new(connection: SftpConnectionConfig, path: impl Into<String>) -> Self {
+        Self {
+            connection,
+            path: path.into(),
+            glob: None,
+            format: SftpFormat::default(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Set the filename glob filter.
+    pub fn glob(mut self, glob: impl Into<String>) -> Self {
+        self.glob = Some(glob.into());
+        self
+    }
+
+    /// Set the file format.
+    pub fn format(mut self, format: SftpFormat) -> Self {
+        self.format = format;
+        self
+    }
+
+    /// Set the per-page record count.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+/// Match `name` against a `*` / `?` glob `pattern`.
+///
+/// `*` matches any run of characters (including empty); `?` matches exactly one
+/// character. All other characters match literally. Pure and allocation-light
+/// (linear backtracking), used to filter directory listings by basename.
+pub fn glob_match(pattern: &str, name: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let n: Vec<char> = name.chars().collect();
+    let (mut pi, mut ni) = (0usize, 0usize);
+    // Position to backtrack to on a `*` mismatch.
+    let (mut star, mut star_n) = (None, 0usize);
+
+    while ni < n.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == n[ni]) {
+            pi += 1;
+            ni += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            star_n = ni;
+            pi += 1;
+        } else if let Some(s) = star {
+            pi = s + 1;
+            star_n += 1;
+            ni = star_n;
+        } else {
+            return false;
+        }
+    }
+    // Consume trailing `*`s.
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_sftp::SftpConnectionConfig;
+
+    fn conn() -> SftpConnectionConfig {
+        SftpConnectionConfig::with_password("h", "u", "p")
+    }
+
+    #[test]
+    fn defaults() {
+        let cfg = SftpSourceConfig::new(conn(), "/data");
+        assert_eq!(cfg.path, "/data");
+        assert!(cfg.glob.is_none());
+        assert_eq!(cfg.format, SftpFormat::Jsonl);
+        assert_eq!(cfg.batch_size, DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn format_default_is_jsonl() {
+        assert_eq!(SftpFormat::default(), SftpFormat::Jsonl);
+    }
+
+    #[test]
+    fn deserializes_flat_shape() {
+        let json = r#"{
+            "host": "sftp.example.com",
+            "port": 2222,
+            "username": "user",
+            "type": "password",
+            "config": { "password": "secret" },
+            "path": "/incoming",
+            "glob": "*.jsonl",
+            "format": "jsonl",
+            "batch_size": 250
+        }"#;
+        let cfg: SftpSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.connection.host, "sftp.example.com");
+        assert_eq!(cfg.connection.port, 2222);
+        assert_eq!(cfg.path, "/incoming");
+        assert_eq!(cfg.glob.as_deref(), Some("*.jsonl"));
+        assert_eq!(cfg.batch_size, 250);
+    }
+
+    #[test]
+    fn batch_size_zero_is_valid_sentinel() {
+        let cfg = SftpSourceConfig::new(conn(), "/d").with_batch_size(0);
+        assert_eq!(cfg.batch_size, 0);
+        assert!(faucet_core::validate_batch_size(cfg.batch_size).is_ok());
+    }
+
+    #[test]
+    fn format_parses_all_variants() {
+        for (s, want) in [
+            ("jsonl", SftpFormat::Jsonl),
+            ("json_array", SftpFormat::JsonArray),
+            ("raw_text", SftpFormat::RawText),
+        ] {
+            let got: SftpFormat = serde_json::from_str(&format!("\"{s}\"")).unwrap();
+            assert_eq!(got, want);
+        }
+    }
+
+    #[test]
+    fn glob_literal_and_wildcards() {
+        assert!(glob_match("*.jsonl", "orders.jsonl"));
+        assert!(glob_match("*.jsonl", ".jsonl"));
+        assert!(!glob_match("*.jsonl", "orders.json"));
+        assert!(glob_match("data-?.csv", "data-1.csv"));
+        assert!(!glob_match("data-?.csv", "data-12.csv"));
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("exact.txt", "exact.txt"));
+        assert!(!glob_match("exact.txt", "other.txt"));
+        assert!(glob_match("a*b*c", "axxbyyc"));
+        assert!(!glob_match("a*b*c", "axxbyy"));
+    }
+}

--- a/crates/source/sftp/src/lib.rs
+++ b/crates/source/sftp/src/lib.rs
@@ -1,0 +1,19 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-sftp
+//!
+//! SFTP source connector for the faucet-stream ecosystem.
+//!
+//! Lists a remote directory (or reads a single file) over SFTP and streams the
+//! files as JSON Lines, JSON arrays, or raw text — with bounded memory for the
+//! line- and record-oriented formats. Connection, authentication, and host-key
+//! verification come from [`faucet-common-sftp`](https://docs.rs/faucet-common-sftp).
+
+pub mod config;
+pub mod stream;
+
+pub use faucet_core::{FaucetError, Source};
+
+pub use config::{SftpFormat, SftpSourceConfig};
+pub use faucet_common_sftp::{HostKeyPolicy, SftpAuth, SftpConnectionConfig};
+pub use stream::SftpSource;

--- a/crates/source/sftp/src/stream.rs
+++ b/crates/source/sftp/src/stream.rs
@@ -1,0 +1,308 @@
+//! SFTP source stream executor.
+//!
+//! The one place that performs SFTP I/O. Construction is lazy — [`SftpSource::new`]
+//! only stores (and validates) the config; the SSH transport is opened on the
+//! first `fetch_*` / `stream_pages` call, so an unreachable host surfaces as a
+//! typed error on first poll rather than at construction time.
+
+use crate::config::{SftpFormat, SftpSourceConfig, glob_match};
+use async_trait::async_trait;
+use faucet_common_sftp::{SftpSession, connect};
+use faucet_core::{FaucetError, Stream, StreamPage};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use tokio::io::AsyncBufReadExt;
+
+/// An SFTP source that lists and reads remote files.
+pub struct SftpSource {
+    config: SftpSourceConfig,
+}
+
+impl SftpSource {
+    /// Create a new SFTP source. Lazy: performs no I/O and never connects here.
+    /// The batch size is validated up front so a bad config fails fast.
+    pub fn new(config: SftpSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        Ok(Self { config })
+    }
+
+    /// Resolve the effective remote path, substituting parent-context tokens
+    /// when a non-empty context is supplied (parent/child matrix runs).
+    fn effective_path(&self, context: &HashMap<String, Value>) -> String {
+        if context.is_empty() {
+            self.config.path.clone()
+        } else {
+            faucet_core::util::substitute_context(&self.config.path, context)
+        }
+    }
+
+    /// List the files to read for `path`: the directory's regular files
+    /// (glob-filtered, sorted for a deterministic order) when `path` is a
+    /// directory, or `[path]` when it is a single file.
+    async fn resolve_files(
+        &self,
+        sftp: &SftpSession,
+        path: &str,
+    ) -> Result<Vec<String>, FaucetError> {
+        let meta = sftp
+            .metadata(path)
+            .await
+            .map_err(|e| FaucetError::Source(format!("SFTP stat '{path}' failed: {e}")))?;
+
+        if !meta.file_type().is_dir() {
+            return Ok(vec![path.to_string()]);
+        }
+
+        let entries = sftp
+            .read_dir(path)
+            .await
+            .map_err(|e| FaucetError::Source(format!("SFTP read_dir '{path}' failed: {e}")))?;
+
+        let mut files = Vec::new();
+        for entry in entries {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let name = entry.file_name();
+            if let Some(pattern) = &self.config.glob
+                && !glob_match(pattern, &name)
+            {
+                continue;
+            }
+            files.push(entry.path());
+        }
+        files.sort();
+        Ok(files)
+    }
+
+    /// Read a whole remote file into a UTF-8 `String` (used by `raw_text` and
+    /// `json_array`, which cannot be parsed incrementally).
+    async fn read_file_text(sftp: &SftpSession, path: &str) -> Result<String, FaucetError> {
+        let bytes = sftp
+            .read(path)
+            .await
+            .map_err(|e| FaucetError::Source(format!("SFTP read '{path}' failed: {e}")))?;
+        String::from_utf8(bytes)
+            .map_err(|e| FaucetError::Source(format!("SFTP file '{path}' is not valid UTF-8: {e}")))
+    }
+}
+
+#[async_trait]
+impl faucet_core::Source for SftpSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut all = Vec::new();
+        let mut pages = self.stream_pages(context, self.config.batch_size);
+        while let Some(page) = pages.next().await {
+            all.extend(page?.records);
+        }
+        Ok(all)
+    }
+
+    /// Stream records from the resolved remote files without buffering the full
+    /// scan. Each emitted [`StreamPage`] holds up to
+    /// [`SftpSourceConfig::batch_size`] records.
+    ///
+    /// - `jsonl` / `raw_text`: files are decoded incrementally (line-by-line
+    ///   for JSONL; one record per file for raw text) so client memory is
+    ///   bounded regardless of file size. Multi-file scans flatten — a page
+    ///   may carry records from more than one file.
+    /// - `json_array`: each file is buffered fully, then its records chunked.
+    ///
+    /// `batch_size = 0` emits one page per file. Every page carries
+    /// `bookmark: None` — the SFTP source is not resumable.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+
+        Box::pin(async_stream::try_stream! {
+            let sftp = connect(&self.config.connection).await?;
+            let path = self.effective_path(context);
+            let files = self.resolve_files(&sftp, &path).await?;
+            tracing::info!(path = %path, files = files.len(), "SFTP source listed files");
+
+            let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+            let initial_capacity = if batch_size == 0 { 1024 } else { batch_size };
+            let mut buffer: Vec<Value> = Vec::with_capacity(initial_capacity);
+            let mut total = 0usize;
+
+            for file in &files {
+                match self.config.format {
+                    SftpFormat::Jsonl => {
+                        let handle = sftp.open(file.as_str()).await.map_err(|e| {
+                            FaucetError::Source(format!("SFTP open '{file}' failed: {e}"))
+                        })?;
+                        let reader = tokio::io::BufReader::new(handle);
+                        let mut lines = reader.lines();
+                        let mut line_num = 0usize;
+                        while let Some(line) = lines.next_line().await.map_err(|e| {
+                            FaucetError::Source(format!("SFTP read '{file}' failed: {e}"))
+                        })? {
+                            line_num += 1;
+                            let trimmed = line.trim();
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+                                FaucetError::Source(format!(
+                                    "SFTP JSON parse error in '{file}' at line {line_num}: {e}"
+                                ))
+                            })?;
+                            buffer.push(value);
+                            if batch_size != 0 && buffer.len() >= chunk {
+                                let page = std::mem::replace(
+                                    &mut buffer,
+                                    Vec::with_capacity(initial_capacity),
+                                );
+                                total += page.len();
+                                yield StreamPage { records: page, bookmark: None };
+                            }
+                        }
+                        if batch_size == 0 && !buffer.is_empty() {
+                            let page = std::mem::take(&mut buffer);
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        }
+                    }
+                    SftpFormat::RawText => {
+                        let text = Self::read_file_text(&sftp, file).await?;
+                        buffer.push(serde_json::json!({ "path": file, "content": text }));
+                        if batch_size == 0 {
+                            let page = std::mem::take(&mut buffer);
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        } else if buffer.len() >= chunk {
+                            let page = std::mem::replace(
+                                &mut buffer,
+                                Vec::with_capacity(initial_capacity),
+                            );
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        }
+                    }
+                    SftpFormat::JsonArray => {
+                        let text = Self::read_file_text(&sftp, file).await?;
+                        let value: Value = serde_json::from_str(&text).map_err(|e| {
+                            FaucetError::Source(format!("SFTP JSON parse error in '{file}': {e}"))
+                        })?;
+                        let array = match value {
+                            Value::Array(arr) => arr,
+                            other => Err(FaucetError::Source(format!(
+                                "SFTP expected JSON array in '{file}', got {}",
+                                value_type_name(&other)
+                            )))?,
+                        };
+                        if batch_size == 0 {
+                            if !buffer.is_empty() {
+                                let page = std::mem::take(&mut buffer);
+                                total += page.len();
+                                yield StreamPage { records: page, bookmark: None };
+                            }
+                            total += array.len();
+                            yield StreamPage { records: array, bookmark: None };
+                        } else {
+                            for record in array {
+                                buffer.push(record);
+                                if buffer.len() >= chunk {
+                                    let page = std::mem::replace(
+                                        &mut buffer,
+                                        Vec::with_capacity(initial_capacity),
+                                    );
+                                    total += page.len();
+                                    yield StreamPage { records: page, bookmark: None };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !buffer.is_empty() {
+                let page = std::mem::take(&mut buffer);
+                total += page.len();
+                yield StreamPage { records: page, bookmark: None };
+            }
+
+            tracing::info!(total_records = total, files = files.len(), "SFTP source stream complete");
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SftpSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "sftp"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "sftp://{}:{}/{}",
+            self.config.connection.host,
+            self.config.connection.port,
+            self.config.path.trim_start_matches('/')
+        )
+    }
+}
+
+/// Return a human-readable name for a JSON value type.
+fn value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_sftp::SftpConnectionConfig;
+    use faucet_core::Source;
+
+    fn cfg() -> SftpSourceConfig {
+        SftpSourceConfig::new(SftpConnectionConfig::with_password("h", "u", "p"), "/data")
+    }
+
+    #[test]
+    fn new_is_lazy_and_validates_batch_size() {
+        // Valid config constructs with no I/O.
+        assert!(SftpSource::new(cfg()).is_ok());
+        // Out-of-range batch size is rejected up front.
+        let bad = cfg().with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(SftpSource::new(bad), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn connector_name_is_sftp() {
+        let src = SftpSource::new(cfg()).unwrap();
+        assert_eq!(src.connector_name(), "sftp");
+    }
+
+    #[test]
+    fn dataset_uri_has_no_credentials() {
+        let src = SftpSource::new(cfg()).unwrap();
+        let uri = src.dataset_uri();
+        assert_eq!(uri, "sftp://h:22/data");
+        assert!(!uri.contains('p') || !uri.contains("password"));
+    }
+
+    #[test]
+    fn config_schema_is_valid_object() {
+        let src = SftpSource::new(cfg()).unwrap();
+        let schema = src.config_schema();
+        assert!(schema.is_object());
+        assert!(schema.get("properties").is_some());
+    }
+}

--- a/crates/source/sftp/tests/conformance.rs
+++ b/crates/source/sftp/tests/conformance.rs
@@ -1,0 +1,119 @@
+//! `faucet-conformance` battery for the SFTP source.
+//!
+//! Check 1 (config-schema validity) and check 6 (errors-not-panics) are pure /
+//! offline and always run. Check 2 (bounded-memory streaming) boots an
+//! `atmoz/sftp` container via `testcontainers` and so requires Docker — it runs
+//! in CI alongside the other integration tests and skips cleanly when Docker is
+//! unavailable.
+
+use faucet_common_sftp::{HostKeyPolicy, SftpAuth, SftpConnectionConfig};
+use faucet_conformance::{
+    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+};
+use faucet_source_sftp::{SftpSource, SftpSourceConfig};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+const USER: &str = "faucet";
+const PASS: &str = "faucetpass";
+const UPLOAD_DIR: &str = "upload";
+
+// ── Check 1: config schema (offline) ────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(SftpSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-sftp");
+}
+
+// ── Check 2: bounded-memory streaming (Docker) ──────────────────────────────
+
+/// Start an `atmoz/sftp` container with user `faucet:faucetpass` and a writable
+/// `upload` directory. Returns the container handle and mapped port, or `None`
+/// when Docker is unavailable so the test skips cleanly.
+async fn start_sftp() -> Option<(ContainerAsync<GenericImage>, u16)> {
+    let image = GenericImage::new("atmoz/sftp", "latest")
+        .with_exposed_port(22.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server listening on"))
+        .with_cmd(vec![format!("{USER}:{PASS}:::{UPLOAD_DIR}")]);
+    let container = match image.start().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Skipping: Docker not available ({e})");
+            return None;
+        }
+    };
+    let port = container.get_host_port_ipv4(22).await.ok()?;
+    Some((container, port))
+}
+
+fn connection(port: u16) -> SftpConnectionConfig {
+    SftpConnectionConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: USER.to_string(),
+        auth: SftpAuth::Password {
+            password: PASS.to_string(),
+        },
+        // The container's host key is ephemeral, so verification is disabled
+        // for the test only.
+        known_hosts: HostKeyPolicy::Insecure,
+    }
+}
+
+fn jsonl_body(start: i64, end_inclusive: i64) -> String {
+    let mut out = String::new();
+    for i in start..=end_inclusive {
+        out.push_str(&format!("{{\"id\":{i}}}\n"));
+    }
+    out
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_bounded_memory() {
+    let Some((_container, port)) = start_sftp().await else {
+        return;
+    };
+    let conn = connection(port);
+
+    // Seed a 5,000-record JSONL file into the writable upload directory.
+    let sftp = faucet_common_sftp::connect(&conn)
+        .await
+        .expect("seed connect");
+    let body = jsonl_body(1, 5_000);
+    sftp.write(format!("{UPLOAD_DIR}/data.jsonl"), body.as_bytes())
+        .await
+        .expect("seed write");
+    drop(sftp);
+
+    let config = SftpSourceConfig::new(conn, UPLOAD_DIR).with_batch_size(250);
+    let source = SftpSource::new(config).expect("SftpSource::new");
+
+    assert_bounded_memory(&source, 250, 5_000).await;
+    // _container stays alive to here.
+}
+
+// ── Check 6: errors, not panics (no container) ──────────────────────────────
+
+/// Point the source at an unreachable endpoint (`127.0.0.1:1`, which refuses
+/// connections immediately). `new()` stays lazy — no container needed — and the
+/// first connect on both `fetch_all` and `stream_pages` fails with a typed
+/// `FaucetError`, never a panic.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_errors_not_panics() {
+    let conn = SftpConnectionConfig {
+        host: "127.0.0.1".to_string(),
+        port: 1,
+        username: "nobody".to_string(),
+        auth: SftpAuth::Password {
+            password: "x".to_string(),
+        },
+        known_hosts: HostKeyPolicy::Insecure,
+    };
+    let source =
+        SftpSource::new(SftpSourceConfig::new(conn, "/data")).expect("source builds lazily");
+    assert_errors_not_panics(&source).await;
+}

--- a/crates/source/sftp/tests/conformance.rs
+++ b/crates/source/sftp/tests/conformance.rs
@@ -80,13 +80,24 @@ async fn conformance_bounded_memory() {
     let conn = connection(port);
 
     // Seed a 5,000-record JSONL file into the writable upload directory.
+    // `SftpSession::write` opens with WRITE only (no CREATE), so it cannot
+    // create a new file — open explicitly with CREATE|WRITE|TRUNCATE.
+    use faucet_common_sftp::OpenFlags;
+    use tokio::io::AsyncWriteExt;
     let sftp = faucet_common_sftp::connect(&conn)
         .await
         .expect("seed connect");
     let body = jsonl_body(1, 5_000);
-    sftp.write(format!("{UPLOAD_DIR}/data.jsonl"), body.as_bytes())
+    let mut file = sftp
+        .open_with_flags(
+            format!("{UPLOAD_DIR}/data.jsonl"),
+            OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::TRUNCATE,
+        )
         .await
-        .expect("seed write");
+        .expect("seed open");
+    file.write_all(body.as_bytes()).await.expect("seed write");
+    file.shutdown().await.expect("seed close");
+    drop(file);
     drop(sftp);
 
     let config = SftpSourceConfig::new(conn, UPLOAD_DIR).with_batch_size(250);

--- a/crates/source/sqs/CHANGELOG.md
+++ b/crates/source/sqs/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+
+## [1.0.0] - 2026-07-28
+
+### Features
+
+- Initial release: AWS SQS source — long-polls `ReceiveMessage`, buffers to
+  `batch_size` and streams pages with bounded memory, deletes each page's
+  receipt handles before yielding (at-least-once), and terminates on
+  `idle_timeout_secs` / `max_messages`. Conformance battery wired
+  ([#412](https://github.com/PawanSikawat/faucet-stream/issues/412)).

--- a/crates/source/sqs/Cargo.toml
+++ b/crates/source/sqs/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "faucet-source-sqs"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "AWS SQS source connector for faucet-stream (long-poll receive, at-least-once drain, delete-on-emit)"
+readme = "README.md"
+keywords = ["sqs", "aws", "queue", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-sqs.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+aws-sdk-sqs.workspace = true
+async-trait.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tracing.workspace = true
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+schemars.workspace = true
+futures = { workspace = true }
+serde_yaml = "0.9"
+# LocalStack-backed integration tests (Docker), mirroring the kinesis pair.
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["localstack"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/sqs/README.md
+++ b/crates/source/sqs/README.md
@@ -1,0 +1,67 @@
+# faucet-source-sqs
+
+AWS SQS **source** connector for
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream): long-polls
+`ReceiveMessage`, buffers up to `batch_size` messages, and emits them page by
+page with bounded memory. It terminates on `idle_timeout_secs` and/or
+`max_messages`.
+
+```yaml
+source:
+  type: sqs
+  config:
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/events
+    region: us-east-1
+    idle_timeout_secs: 30      # at least one termination knob is required
+    wait_time_seconds: 10
+    batch_size: 1000
+```
+
+## Configuration
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `queue_url` | — | Required. Full SQS queue URL. |
+| `region` | SDK default chain | |
+| `endpoint_url` | — | LocalStack / VPC endpoint override. |
+| `credentials` | `{ type: default }` | `default` \| `profile` \| `access_key` \| `assume_role` \| `web_identity` — see `faucet-common-sqs`. |
+| `idle_timeout_secs` / `max_messages` | — | **At least one is required** so a batch run terminates. |
+| `wait_time_seconds` | `10` | Long-poll wait per `ReceiveMessage` (0–20). |
+| `batch_size` | `1000` | Records per emitted page. `0` = one page for the whole drain. |
+
+Each `ReceiveMessage` call requests up to 10 messages (the SQS API cap),
+capped further so it never over-reads past `max_messages`.
+
+## Record shape
+
+Each message body is emitted as its **parsed JSON value** when the body is
+valid JSON, otherwise as a JSON **string** of the raw body:
+
+```json
+{ "order_id": 42, "status": "shipped" }
+```
+```json
+"a plain, non-JSON body"
+```
+
+## Delivery semantics
+
+Each page's receipt handles are deleted (via `DeleteMessageBatch`) right before
+the page is yielded. Delivery is **at-least-once**: any message whose delete
+does not land — or whose visibility window elapses before a downstream commit —
+is redelivered on a later run. There is no resumable bookmark (`bookmark: None`
+on every page); the queue itself is the cursor. Key downstream consumers on a
+message field (e.g. an upsert sink) when replays must converge.
+
+## LocalStack
+
+```yaml
+config:
+  endpoint_url: http://localhost:4566
+  region: us-east-1
+  credentials: { type: access_key, config: { access_key_id: test, secret_access_key: test } }
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/source/sqs/src/config.rs
+++ b/crates/source/sqs/src/config.rs
@@ -1,0 +1,175 @@
+//! Configuration for the SQS source. No I/O here.
+
+use faucet_common_sqs::SqsCredentials;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// SQS long-poll ceiling: `ReceiveMessage` accepts at most a 20-second wait.
+pub const MAX_WAIT_TIME_SECONDS: i32 = 20;
+/// SQS hard limit: at most 10 messages per `ReceiveMessage` call.
+pub const MAX_RECEIVE_BATCH: i32 = 10;
+
+/// Configuration for [`SqsSource`](crate::SqsSource).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SqsSourceConfig {
+    /// SQS queue URL (e.g. `https://sqs.us-east-1.amazonaws.com/1234/my-q`).
+    pub queue_url: String,
+    /// AWS region. `None` uses the SDK default chain (env, profile, IMDS).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Custom endpoint URL for LocalStack / VPC endpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_url: Option<String>,
+    /// AWS credentials. Defaults to the SDK default provider chain.
+    #[serde(default)]
+    pub credentials: SqsCredentials,
+
+    /// Stop after this many seconds without a new message. At least one of
+    /// `idle_timeout_secs` and `max_messages` must be set (mirrors the Kafka /
+    /// Kinesis sources) — a batch run must terminate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
+    /// Stop after this many messages in total.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_messages: Option<usize>,
+
+    /// Long-poll wait per `ReceiveMessage` call, in seconds (0–20). Default 10.
+    #[serde(default = "default_wait_time_seconds")]
+    pub wait_time_seconds: i32,
+
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` is the
+    /// "no batching" sentinel: one page per assembled drain buffer. Default
+    /// 1000.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_wait_time_seconds() -> i32 {
+    10
+}
+fn default_batch_size() -> usize {
+    faucet_core::DEFAULT_BATCH_SIZE
+}
+
+impl SqsSourceConfig {
+    /// Minimal config with defaults for everything but the queue URL.
+    pub fn new(queue_url: impl Into<String>) -> Self {
+        Self {
+            queue_url: queue_url.into(),
+            region: None,
+            endpoint_url: None,
+            credentials: SqsCredentials::default(),
+            idle_timeout_secs: None,
+            max_messages: None,
+            wait_time_seconds: default_wait_time_seconds(),
+            batch_size: default_batch_size(),
+        }
+    }
+
+    /// Fail-fast validation, called from `SqsSource::new`.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        use faucet_core::FaucetError;
+        if self.queue_url.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "sqs source: queue_url must not be empty".into(),
+            ));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        if self.wait_time_seconds < 0 || self.wait_time_seconds > MAX_WAIT_TIME_SECONDS {
+            return Err(FaucetError::Config(format!(
+                "sqs source: wait_time_seconds must be 0..={MAX_WAIT_TIME_SECONDS} (got {})",
+                self.wait_time_seconds
+            )));
+        }
+        if self.idle_timeout_secs.is_none() && self.max_messages.is_none() {
+            return Err(FaucetError::Config(
+                "sqs source: set at least one of idle_timeout_secs / max_messages so a run can \
+                 terminate (mirrors the kafka/kinesis sources)"
+                    .into(),
+            ));
+        }
+        if self.idle_timeout_secs == Some(0) {
+            return Err(FaucetError::Config(
+                "sqs source: idle_timeout_secs must be at least 1".into(),
+            ));
+        }
+        if self.max_messages == Some(0) {
+            return Err(FaucetError::Config(
+                "sqs source: max_messages must be at least 1".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> SqsSourceConfig {
+        let mut c = SqsSourceConfig::new("https://sqs.us-east-1.amazonaws.com/1/events");
+        c.max_messages = Some(100);
+        c
+    }
+
+    #[test]
+    fn defaults_are_sensible() {
+        let c = SqsSourceConfig::new("https://q");
+        assert_eq!(c.wait_time_seconds, 10);
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert!(c.idle_timeout_secs.is_none());
+        assert!(c.max_messages.is_none());
+    }
+
+    #[test]
+    fn validation_bounds() {
+        valid().validate().unwrap();
+
+        let mut c = valid();
+        c.queue_url = "  ".into();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.wait_time_seconds = 21;
+        assert!(c.validate().is_err());
+        c.wait_time_seconds = -1;
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.max_messages = None;
+        c.idle_timeout_secs = None;
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("idle_timeout_secs"), "{err}");
+
+        let mut c = valid();
+        c.idle_timeout_secs = Some(0);
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.max_messages = Some(0);
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn full_config_parses_from_yaml() {
+        let yaml = r#"
+queue_url: https://sqs.us-east-1.amazonaws.com/1/events
+region: us-east-1
+endpoint_url: http://127.0.0.1:4566
+credentials: { type: access_key, config: { access_key_id: a, secret_access_key: b } }
+idle_timeout_secs: 5
+max_messages: 250
+wait_time_seconds: 5
+batch_size: 100
+"#;
+        let c: SqsSourceConfig = serde_yaml::from_str(yaml).unwrap();
+        c.validate().unwrap();
+        assert_eq!(c.wait_time_seconds, 5);
+        assert_eq!(c.batch_size, 100);
+        assert_eq!(c.idle_timeout_secs, Some(5));
+        assert_eq!(c.max_messages, Some(250));
+    }
+}

--- a/crates/source/sqs/src/lib.rs
+++ b/crates/source/sqs/src/lib.rs
@@ -1,0 +1,25 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-sqs
+//!
+//! AWS SQS source connector for
+//! [faucet-stream](https://github.com/PawanSikawat/faucet-stream): long-polls
+//! `ReceiveMessage`, buffers up to `batch_size` messages, and emits them as
+//! pages with bounded memory. Each page's receipt handles are deleted right
+//! before the page is yielded, and a run terminates on `idle_timeout_secs`
+//! and/or `max_messages`.
+//!
+//! Delivery is **at-least-once**: a crash after a page is emitted but before
+//! the downstream sink durably commits it re-reads any message whose delete did
+//! not land (or whose visibility window elapsed). Pair with an idempotent /
+//! upsert sink when replays must converge. The queue is drained top-to-bottom
+//! with no resumable bookmark — every page carries `bookmark: None`.
+
+mod config;
+mod stream;
+
+pub use config::{MAX_RECEIVE_BATCH, MAX_WAIT_TIME_SECONDS, SqsSourceConfig};
+pub use stream::SqsSource;
+
+// Shared connection types, re-exported so users need only this crate.
+pub use faucet_common_sqs::{SqsCredentials, build_client};

--- a/crates/source/sqs/src/stream.rs
+++ b/crates/source/sqs/src/stream.rs
@@ -1,0 +1,343 @@
+//! The SQS `Source` implementation: long-poll `ReceiveMessage`, buffer to
+//! `batch_size`, delete each page's receipt handles right before yielding it,
+//! and terminate on `idle_timeout_secs` / `max_messages`.
+
+use crate::config::{MAX_RECEIVE_BATCH, SqsSourceConfig};
+use aws_sdk_sqs::Client;
+use aws_sdk_sqs::types::DeleteMessageBatchRequestEntry;
+use faucet_core::{FaucetError, Stream, StreamPage};
+use serde_json::Value;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+
+/// AWS SQS source. See the crate README for semantics.
+pub struct SqsSource {
+    config: SqsSourceConfig,
+    client: Client,
+}
+
+/// Decode one SQS message body: the parsed JSON value if the body is valid
+/// JSON, otherwise the raw body wrapped as a JSON string. Pure.
+pub(crate) fn decode_body(body: &str) -> Value {
+    serde_json::from_str::<Value>(body).unwrap_or_else(|_| Value::String(body.to_string()))
+}
+
+impl SqsSource {
+    /// Create a new SQS source. Validates the config and builds the AWS client;
+    /// no queue I/O happens until the first `ReceiveMessage` at stream time
+    /// (construction is offline).
+    pub async fn new(config: SqsSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = faucet_common_sqs::build_client(
+            config.region.as_deref(),
+            config.endpoint_url.as_deref(),
+            &config.credentials,
+        )
+        .await?;
+        Ok(Self { config, client })
+    }
+
+    /// Delete a page's receipt handles, chunked to the 10-entry API cap. A
+    /// whole-request failure propagates as a typed error; per-entry failures
+    /// are logged and left for SQS to redeliver (at-least-once).
+    async fn delete_handles(&self, handles: &[String]) -> Result<(), FaucetError> {
+        for chunk in handles.chunks(MAX_RECEIVE_BATCH as usize) {
+            let entries: Vec<DeleteMessageBatchRequestEntry> = chunk
+                .iter()
+                .enumerate()
+                .map(|(i, rh)| {
+                    DeleteMessageBatchRequestEntry::builder()
+                        .id(i.to_string())
+                        .receipt_handle(rh)
+                        .build()
+                        .map_err(|e| {
+                            FaucetError::Source(format!("sqs: delete entry build failed: {e}"))
+                        })
+                })
+                .collect::<Result<_, _>>()?;
+            let out = self
+                .client
+                .delete_message_batch()
+                .queue_url(&self.config.queue_url)
+                .set_entries(Some(entries))
+                .send()
+                .await
+                .map_err(|e| {
+                    FaucetError::Source(format!(
+                        "sqs: DeleteMessageBatch on '{}' failed: {}",
+                        self.config.queue_url,
+                        e.into_service_error()
+                    ))
+                })?;
+            for f in out.failed() {
+                tracing::warn!(
+                    queue = %self.config.queue_url,
+                    id = f.id(),
+                    code = f.code(),
+                    "sqs: message delete failed; message will be redelivered"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[faucet_core::async_trait]
+impl faucet_core::Source for SqsSource {
+    /// Drain the queue to termination (`idle_timeout_secs` / `max_messages` —
+    /// at least one is enforced at construction) and return every message.
+    async fn fetch_with_context(
+        &self,
+        context: &std::collections::HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut pages = self.stream_pages(context, self.config.batch_size);
+        let mut all = Vec::new();
+        while let Some(page) = pages.next().await {
+            all.extend(page?.records);
+        }
+        Ok(all)
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        _context: &'a std::collections::HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+        let chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
+
+        Box::pin(async_stream::try_stream! {
+            let idle = self.config.idle_timeout_secs.map(Duration::from_secs);
+            let max = self.config.max_messages;
+            // `buffer` and `handles` stay index-aligned: one handle slot per
+            // buffered record (None if a message somehow lacked a receipt
+            // handle — such a record is emitted but not deleted, so SQS
+            // redelivers it, preserving at-least-once).
+            let mut buffer: Vec<Value> = Vec::new();
+            let mut handles: Vec<Option<String>> = Vec::new();
+            let mut total = 0usize;
+            let mut last_activity = Instant::now();
+
+            loop {
+                // Reached the message cap → stop.
+                let remaining = match max {
+                    Some(m) if total >= m => break,
+                    Some(m) => Some(m - total),
+                    None => None,
+                };
+                let want = remaining
+                    .map_or(MAX_RECEIVE_BATCH, |r| r.min(MAX_RECEIVE_BATCH as usize) as i32);
+
+                let resp = self
+                    .client
+                    .receive_message()
+                    .queue_url(&self.config.queue_url)
+                    .max_number_of_messages(want)
+                    .wait_time_seconds(self.config.wait_time_seconds)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        FaucetError::Source(format!(
+                            "sqs: ReceiveMessage on '{}' failed: {}",
+                            self.config.queue_url,
+                            e.into_service_error()
+                        ))
+                    })?;
+
+                let messages = resp.messages();
+                if messages.is_empty() {
+                    if let Some(window) = idle
+                        && last_activity.elapsed() >= window
+                    {
+                        tracing::info!(
+                            queue = %self.config.queue_url,
+                            idle_secs = window.as_secs(),
+                            "sqs: idle termination reached"
+                        );
+                        break;
+                    }
+                    continue;
+                }
+                last_activity = Instant::now();
+
+                for msg in messages {
+                    buffer.push(decode_body(msg.body().unwrap_or("")));
+                    handles.push(msg.receipt_handle().map(str::to_string));
+                    total += 1;
+                }
+
+                // Emit every full page, deleting its handles right before yield.
+                while buffer.len() >= chunk {
+                    let page: Vec<Value> = buffer.drain(..chunk).collect();
+                    let to_delete: Vec<String> =
+                        handles.drain(..chunk).flatten().collect();
+                    self.delete_handles(&to_delete).await?;
+                    yield StreamPage { records: page, bookmark: None };
+                }
+
+                if let Some(m) = max
+                    && total >= m
+                {
+                    tracing::info!(
+                        queue = %self.config.queue_url,
+                        max = m,
+                        "sqs: max_messages reached"
+                    );
+                    break;
+                }
+            }
+
+            // Flush whatever is left as a final (short) page.
+            if !buffer.is_empty() {
+                let to_delete: Vec<String> = handles.into_iter().flatten().collect();
+                self.delete_handles(&to_delete).await?;
+                yield StreamPage { records: buffer, bookmark: None };
+            }
+            tracing::info!(
+                queue = %self.config.queue_url,
+                records = total,
+                "sqs source stream complete"
+            );
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SqsSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "sqs"
+    }
+
+    fn dataset_uri(&self) -> String {
+        let name = self
+            .config
+            .queue_url
+            .rsplit('/')
+            .find(|s| !s.is_empty())
+            .unwrap_or(self.config.queue_url.as_str());
+        format!(
+            "sqs://{}/{}",
+            self.config.region.as_deref().unwrap_or("default"),
+            name
+        )
+    }
+
+    /// Side-effect-free probe: `GetQueueAttributes` (no messages consumed). The
+    /// default first-page probe could block for the full long-poll window on a
+    /// quiet queue.
+    async fn check(
+        &self,
+        ctx: &faucet_core::CheckContext,
+    ) -> Result<faucet_core::CheckReport, FaucetError> {
+        use faucet_core::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let fut = self
+            .client
+            .get_queue_attributes()
+            .queue_url(&self.config.queue_url)
+            .send();
+        let probe = match tokio::time::timeout(ctx.timeout, fut).await {
+            Err(_) => Probe::fail("get_queue_attributes", start.elapsed(), "timed out"),
+            Ok(Ok(_)) => Probe::pass("get_queue_attributes", start.elapsed()),
+            Ok(Err(e)) => Probe::fail(
+                "get_queue_attributes",
+                start.elapsed(),
+                e.into_service_error().to_string(),
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::Source as _;
+
+    fn decode(s: &str) -> Value {
+        decode_body(s)
+    }
+
+    #[test]
+    fn decode_body_parses_json_else_string() {
+        assert_eq!(decode(r#"{"a":1}"#), serde_json::json!({"a": 1}));
+        assert_eq!(decode("[1,2,3]"), serde_json::json!([1, 2, 3]));
+        assert_eq!(decode("not json"), Value::String("not json".into()));
+        assert_eq!(decode(""), Value::String(String::new()));
+    }
+
+    async fn offline_source(mut config: SqsSourceConfig) -> SqsSource {
+        config.endpoint_url = Some("http://127.0.0.1:1".into()); // unroutable
+        config.region = Some("us-east-1".into());
+        config.credentials = faucet_common_sqs::SqsCredentials::AccessKey {
+            access_key_id: "test".into(),
+            secret_access_key: "test".into(),
+            session_token: None,
+        };
+        SqsSource::new(config).await.expect("source builds")
+    }
+
+    #[tokio::test]
+    async fn new_validates_config() {
+        let err = match SqsSource::new(SqsSourceConfig::new("https://q")).await {
+            Err(e) => e,
+            Ok(_) => panic!("config without a termination knob must be rejected"),
+        };
+        assert!(err.to_string().contains("idle_timeout_secs"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn identity_overrides() {
+        let mut cfg = SqsSourceConfig::new("https://sqs.us-east-1.amazonaws.com/1/events");
+        cfg.max_messages = Some(10);
+        let source = offline_source(cfg).await;
+        assert_eq!(source.connector_name(), "sqs");
+        assert_eq!(source.dataset_uri(), "sqs://us-east-1/events");
+        assert_eq!(source.state_key(), None);
+        assert!(!source.supports_exactly_once());
+        let schema = source.config_schema();
+        assert!(
+            schema["properties"]["queue_url"].is_object(),
+            "schema exposes config fields"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_pages_surfaces_receive_errors() {
+        use futures::StreamExt;
+        let mut cfg = SqsSourceConfig::new("https://q");
+        cfg.max_messages = Some(10);
+        cfg.wait_time_seconds = 0;
+        let source = offline_source(cfg).await;
+        let ctx = std::collections::HashMap::new();
+        let mut pages = source.stream_pages(&ctx, 10);
+        let first = pages.next().await.expect("one item");
+        let err = first.unwrap_err();
+        assert!(err.to_string().contains("ReceiveMessage"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn check_probe_fails_cleanly_offline() {
+        let mut cfg = SqsSourceConfig::new("https://q");
+        cfg.max_messages = Some(10);
+        let source = offline_source(cfg).await;
+        let report = source
+            .check(&faucet_core::CheckContext {
+                timeout: Duration::from_millis(500),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            report.failed_count(),
+            1,
+            "unreachable endpoint → fail probe"
+        );
+    }
+}

--- a/crates/source/sqs/tests/conformance.rs
+++ b/crates/source/sqs/tests/conformance.rs
@@ -1,0 +1,136 @@
+//! `faucet-conformance` battery for the SQS source.
+//!
+//! Check 1 (config-schema validity) and check 6 (errors, not panics) are pure /
+//! offline and always run. Check 2 (bounded-memory streaming) boots LocalStack
+//! via testcontainers and so requires Docker — it runs in CI alongside the
+//! other integration tests.
+//!
+//! Check 3 (bookmark round-trip) does not apply: the SQS source drains the
+//! queue with no resumable bookmark (`bookmark: None` on every page).
+
+use faucet_conformance::{assert_config_schema_valid_value, assert_errors_not_panics};
+use faucet_source_sqs::{SqsCredentials, SqsSource, SqsSourceConfig};
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::localstack::LocalStack;
+
+// ── Check 1: config schema ──────────────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(SqsSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-sqs");
+}
+
+// ── Check 6: errors, not panics (offline) ───────────────────────────────────
+
+/// Point the source at an unreachable endpoint (`http://127.0.0.1:1`, which
+/// refuses connections immediately). `new()` stays lazy — no container needed —
+/// and the first `ReceiveMessage` fails with a typed `FaucetError` on both the
+/// `fetch_all` and `stream_pages` paths, never a panic.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_errors_not_panics() {
+    let mut cfg = SqsSourceConfig::new("https://sqs.us-east-1.amazonaws.com/1/does-not-exist");
+    cfg.region = Some("us-east-1".into());
+    cfg.endpoint_url = Some("http://127.0.0.1:1".into());
+    cfg.credentials = test_credentials();
+    cfg.wait_time_seconds = 0;
+    // A terminating run is required by config validation.
+    cfg.idle_timeout_secs = Some(1);
+    cfg.max_messages = Some(10);
+
+    let source = SqsSource::new(cfg).await.expect("source builds lazily");
+    assert_errors_not_panics(&source).await;
+}
+
+// ── Check 2: bounded-memory streaming (Docker) ──────────────────────────────
+
+async fn start_localstack() -> (ContainerAsync<LocalStack>, String) {
+    use testcontainers::ImageExt;
+    let image = LocalStack::default().with_env_var("SERVICES", "sqs");
+    let container = image.start().await.expect("localstack start");
+    let port = container
+        .get_host_port_ipv4(4566)
+        .await
+        .expect("localstack port");
+    (container, format!("http://127.0.0.1:{port}"))
+}
+
+fn test_credentials() -> SqsCredentials {
+    SqsCredentials::AccessKey {
+        access_key_id: "test".into(),
+        secret_access_key: "test".into(),
+        session_token: None,
+    }
+}
+
+async fn raw_client(endpoint: &str) -> aws_sdk_sqs::Client {
+    faucet_source_sqs::build_client(Some("us-east-1"), Some(endpoint), &test_credentials())
+        .await
+        .expect("client")
+}
+
+/// Create a queue (large visibility timeout so nothing is redelivered mid-run)
+/// and return its URL. Retries until LocalStack's SQS endpoint is ready.
+async fn create_queue(client: &aws_sdk_sqs::Client, name: &str) -> String {
+    use aws_sdk_sqs::types::QueueAttributeName;
+    for _ in 0..120 {
+        match client
+            .create_queue()
+            .queue_name(name)
+            .attributes(QueueAttributeName::VisibilityTimeout, "300")
+            .send()
+            .await
+        {
+            Ok(out) => return out.queue_url().expect("queue url").to_string(),
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+        }
+    }
+    panic!("localstack sqs never became ready");
+}
+
+/// Send `n` JSON messages in batches of 10.
+async fn seed(client: &aws_sdk_sqs::Client, queue_url: &str, n: usize) {
+    use aws_sdk_sqs::types::SendMessageBatchRequestEntry;
+    let mut i = 0usize;
+    while i < n {
+        let end = (i + 10).min(n);
+        let entries: Vec<SendMessageBatchRequestEntry> = (i..end)
+            .map(|j| {
+                SendMessageBatchRequestEntry::builder()
+                    .id(format!("m{j}"))
+                    .message_body(format!("{{\"i\":{j}}}"))
+                    .build()
+                    .expect("entry")
+            })
+            .collect();
+        let out = client
+            .send_message_batch()
+            .queue_url(queue_url)
+            .set_entries(Some(entries))
+            .send()
+            .await
+            .expect("send_message_batch");
+        assert!(out.failed().is_empty(), "seeding must not fail");
+        i = end;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_bounded_memory() {
+    let (_container, endpoint) = start_localstack().await;
+    let client = raw_client(&endpoint).await;
+    let queue_url = create_queue(&client, "conformance").await;
+    seed(&client, &queue_url, 5_000).await;
+
+    let mut cfg = SqsSourceConfig::new(&queue_url);
+    cfg.region = Some("us-east-1".into());
+    cfg.endpoint_url = Some(endpoint.clone());
+    cfg.credentials = test_credentials();
+    cfg.wait_time_seconds = 1;
+    cfg.idle_timeout_secs = Some(15);
+    cfg.batch_size = 250;
+
+    let source = SqsSource::new(cfg).await.expect("source");
+    faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
+    // _container stays alive to here
+}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -52,7 +52,7 @@ the loop itself in [pipeline](./pipeline.md); the streaming model in
 
 ## Crate topology
 
-The workspace is a Cargo workspace of 67 crates (66 libraries + the `faucet` CLI
+The workspace is a Cargo workspace of <!--COUNT:crates-->91<!--/COUNT--> crates (<!--COUNT:libraries-->90<!--/COUNT--> libraries + the `faucet` CLI
 binary). The topology encodes a hard rule: **connectors depend only on
 `faucet-core`.**
 

--- a/docs/blog/exactly-once-without-a-broker.md
+++ b/docs/blog/exactly-once-without-a-broker.md
@@ -137,5 +137,5 @@ Kill it mid-run. Restart it. Count the rows. They'll be right.
 ---
 
 *faucet-stream is an MIT/Apache-2.0 Rust library + CLI for moving data between
-33 sources and 25 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
+<!--COUNT:sources-->37<!--/COUNT--> sources and <!--COUNT:sinks-->29<!--/COUNT--> sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
 [GitHub](https://github.com/PawanSikawat/faucet-stream).*

--- a/docs/blog/migrating-from-meltano.md
+++ b/docs/blog/migrating-from-meltano.md
@@ -180,5 +180,5 @@ faucet run cli/examples/csv_to_jsonl.yaml   # no infra needed
 ---
 
 *faucet-stream is an MIT/Apache-2.0 Rust library + CLI for moving data between
-33 sources and 25 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
+<!--COUNT:sources-->37<!--/COUNT--> sources and <!--COUNT:sinks-->29<!--/COUNT--> sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
 [GitHub](https://github.com/PawanSikawat/faucet-stream).*

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
 # Cookbook
 
 - [Pagination styles](./cookbook/pagination.md)
+- [Airtable (via REST source)](./cookbook/airtable.md)
 - [Authentication](./cookbook/auth.md)
 - [Incremental replication & state](./cookbook/state.md)
 - [Upsert / mirror tables](./cookbook/upsert.md)

--- a/docs/book/src/comparison/meltano.md
+++ b/docs/book/src/comparison/meltano.md
@@ -34,7 +34,7 @@ Straight with you, because it's what makes the rest credible:
 |---|---|---|
 | Runtime | Rust, single native binary | Python |
 | Install | one binary / `brew` / `cargo` | Python env + plugins |
-| Connectors | 58 (33 sources, 25 sinks), growing | 600+ taps |
+| Connectors | <!--COUNT:connectors-->66<!--/COUNT--> (<!--COUNT:sources-->37<!--/COUNT--> sources, <!--COUNT:sinks-->29<!--/COUNT--> sinks), growing | 600+ taps |
 | Throughput (1M-row CSV→JSONL) | **712k rows/s, 11.8 MiB** | 7.4k rows/s, 724 MiB |
 | In-flight transforms | ✓ 11 record transforms + filter/explode/CDC-unwrap + embedded-DuckDB `sql` | mappers; dbt post-load |
 | Data quality / contracts / masking | ✓ native, in-path | assemble (mappers, dbt tests) |

--- a/docs/book/src/comparison/redpanda-connect.md
+++ b/docs/book/src/comparison/redpanda-connect.md
@@ -37,7 +37,7 @@ Straight with you — for its core job it's excellent:
 |---|---|---|
 | Language / runtime | Rust, single binary | Go, single binary |
 | Orientation | discrete runs to completion | continuous stream processing |
-| Connectors | 58 source/sink, ETL/CDC/warehouse | hundreds of components/processors |
+| Connectors | <!--COUNT:connectors-->66<!--/COUNT--> source/sink, ETL/CDC/warehouse | hundreds of components/processors |
 | Change data capture | ✓ engine-level | some CDC inputs (several enterprise-gated) |
 | Warehouse / ELT sinks | ✓ BigQuery, Snowflake, Iceberg, Delta, … | more messaging/stream-oriented |
 | Governance in-path (quality / contracts / masking / lineage / SLA) | ✓ native | ✗ |

--- a/docs/book/src/cookbook/airtable.md
+++ b/docs/book/src/cookbook/airtable.md
@@ -1,0 +1,78 @@
+# Airtable (via the REST source)
+
+Airtable's REST API is a plain bearer-authenticated, offset-token-paginated
+JSON API, so faucet's generic [`rest` source](../reference/connectors.md) covers
+it end-to-end — **no dedicated connector crate is required** (issue
+[#414](https://github.com/PawanSikawat/faucet-stream/issues/414)).
+
+## How it maps onto the `rest` source
+
+| Airtable concept | `rest` config |
+|---|---|
+| Personal access token (PAT) | `auth: { type: bearer, config: { token: ${env:AIRTABLE_TOKEN} } }` |
+| Base + table URL | `base_url: https://api.airtable.com`, `path: /v0/<base_id>/<table>` |
+| Records array | `records_path: "$.records"` |
+| Offset-token pagination | `pagination: { type: Cursor, next_token_path: offset, param_name: offset }` |
+| 5 req/s rate limit (HTTP 429 + `Retry-After`) | built-in retry: `max_retries` / `retry_backoff` |
+| `view`, `filterByFormula`, `pageSize` | `query_params` |
+
+Pagination stops automatically when the response omits `offset`. Each record is
+`{ id, createdTime, fields: {…} }`; the `flatten` transform collapses `fields`
+into dotted top-level keys (`fields.Name`, …).
+
+## Runnable recipe
+
+A complete, runnable config lives at
+[`cli/examples/airtable_to_jsonl.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/airtable_to_jsonl.yaml):
+
+```yaml
+version: 1
+name: airtable_to_jsonl
+vars:
+  base_id: ${env:AIRTABLE_BASE_ID}
+  table: Contacts
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.airtable.com
+      path: /v0/${vars.base_id}/${vars.table}
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:AIRTABLE_TOKEN}
+      query_params:
+        pageSize: "100"
+      records_path: "$.records"
+      pagination:
+        type: Cursor
+        next_token_path: offset
+        param_name: offset
+      max_retries: 5
+      retry_backoff: 1
+      replication_method:
+        type: FullTable
+      primary_keys: ["id"]
+  transforms:
+    - type: flatten
+  sink:
+    type: jsonl
+    config:
+      path: ./out/airtable_contacts.jsonl
+```
+
+```bash
+export AIRTABLE_TOKEN=pat...      # data.records:read scope
+export AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
+faucet run cli/examples/airtable_to_jsonl.yaml
+```
+
+## Notes
+
+- **Field types** — attachments and linked records come back as JSON arrays;
+  they pass through as-is.
+- **Incremental** — Airtable has no server-side change cursor; use
+  `filterByFormula` on a `Last Modified` field to narrow, or run full-table.
+- **Writing back** — an Airtable *sink* is out of scope; this recipe is
+  read-only.

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-faucet-stream wires **33 source** and **25 sink** connectors together with a single
+faucet-stream wires **37 source** and **29 sink** connectors together with a single
 `faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
 code required. Or skip the binary and embed the same engine in your own service
 through the typed `Source` / `Sink` traits.

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-faucet-stream wires **37 source** and **29 sink** connectors together with a single
+faucet-stream wires **<!--COUNT:sources-->37<!--/COUNT--> source** and **<!--COUNT:sinks-->29<!--/COUNT--> sink** connectors together with a single
 `faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
 code required. Or skip the binary and embed the same engine in your own service
 through the typed `Source` / `Sink` traits.

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **37 sources** and **29 sinks**. Each is a Cargo feature
+faucet-stream ships **<!--COUNT:sources-->37<!--/COUNT--> sources** and **<!--COUNT:sinks-->29<!--/COUNT--> sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **33 sources** and **25 sinks**. Each is a Cargo feature
+faucet-stream ships **37 sources** and **29 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 
@@ -34,6 +34,10 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 | Microsoft SQL Server | T1 ✅ | `source-mssql` | ✓ | ✓⁸ | ✗ | ✗ | ✓ | SQL query (tiberius), rows as JSON |
 | Microsoft SQL Server CDC | T1 ✅ | `source-mssql-cdc` | ✓ | ✓ | **✓** | ✗ | ✗ | CDC change tables (`fn_cdc_get_all_changes`), LSN bookmarks, `__op`-normalized |
 | SQLite | T1 ✅ | `source-sqlite` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL query, rows as JSON |
+| DuckDB | T2 | `source-duckdb` | ✓ | ✗ | ✗ | ✗ | ✗ | SQL query (file or `:memory:`), rows as JSON; blocking-task + channel streaming |
+| AWS SQS | T2 | `source-sqs` | ✓ | ✗ | ✗ | ✗ | ✗ | long-poll ReceiveMessage, delete-after-emit (at-least-once), idle/max-messages termination |
+| NATS | T2 | `source-nats` | ✓ | ✗ | ✗ | ✗ | ✗ | subject subscription or JetStream durable consumer; idle/max-messages termination |
+| SFTP | T2 | `source-sftp` | ✓ | ✗ | ✗ | ✗ | ✗ | list/glob a remote dir over SSH; JSONL, JSON array, raw text |
 | AWS S3 | T1 ✅ | `source-s3` | ✓⁵ | ✗ | ✗ | ✓ | ✓ | object reader: JSONL, JSON array, raw text |
 | Google Cloud Storage | T2 | `source-gcs` | ✓⁵ | ✗ | ✗ | ✓ | ✓ | object reader: JSONL, JSON array, raw text |
 | Azure Blob / ADLS Gen2 | T1 ✅ | `source-azure-blob` | ✓⁵ | ✗ | ✗ | ✓ | ✗ | object reader (object_store): JSONL, JSON array, raw text |
@@ -162,6 +166,10 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | MySQL | T1 ✅ | `sink-mysql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` |
 | Microsoft SQL Server | T1 ✅ | `sink-mssql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
 | SQLite | T1 ✅ | `sink-sqlite` | ✓ | ✗ | **✓** | **✓** | transaction-wrapped batch |
+| DuckDB | T2 | `sink-duckdb` | ✓ | ✗ | ✗ | ✗ | transaction-wrapped multi-row `INSERT` (JSON column or auto-mapped); append-only |
+| AWS SQS | T2 | `sink-sqs` | ✓ | ✗ | ✗ | ✗ | batched SendMessageBatch (10/req), per-entry partial-failure retry; FIFO group/dedup |
+| NATS | T2 | `sink-nats` | ✓ | ✗ | ✗ | ✗ | publish to a subject (optional subject-per-record), flush per batch |
+| SFTP | T2 | `sink-sftp` | ✓ | ✗ | ✗ | ✗ | JSONL files over SSH; atomic temp-then-rename upload |
 | AWS S3 | T1 ✅ | `sink-s3` | ✓ | ✓ | ✗ | ✗ | JSONL objects, parallel uploads |
 | Google Cloud Storage | T2 | `sink-gcs` | ✓ | ✓ | ✗ | ✗ | JSONL objects |
 | Azure Blob / ADLS Gen2 | T1 ✅ᵉ | `sink-azure-blob` | ✓ | ✓ | ✗ | ✗ | JSONL blobs (object_store), batch/byte rollover |

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -9,7 +9,7 @@ see the top-level [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## Workspace shape
 
-faucet-stream is a Cargo workspace of 67 crates. They fall into four layers,
+faucet-stream is a Cargo workspace of <!--COUNT:crates-->91<!--/COUNT--> crates. They fall into four layers,
 and the dependency direction only ever flows downward:
 
 ```mermaid

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -24,7 +24,7 @@ add this line under a relevant section (e.g. *Database* → *ETL* or *Data
 processing*), and open a PR:
 
 ```markdown
-* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement platform: 58 source and sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; runs your existing Singer taps unchanged, with streaming, CDC, DLQ, and built-in metrics.
+* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement platform: <!--COUNT:connectors-->66<!--/COUNT--> source and sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; runs your existing Singer taps unchanged, with streaming, CDC, DLQ, and built-in metrics.
 ```
 
 Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesome-data-engineering).
@@ -34,7 +34,7 @@ Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesom
 Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-week-in-rust)
 (Crate of the Week nominations + project updates). Suggested blurb:
 
-> **faucet-stream** — a config-driven data-movement platform: 58 connectors, a
+> **faucet-stream** — a config-driven data-movement platform: <!--COUNT:connectors-->66<!--/COUNT--> connectors, a
 > `faucet` CLI that runs pipelines from YAML, and an embeddable library, with
 > streaming, Postgres CDC, dead-letter queues, and built-in Prometheus/tracing.
 
@@ -48,7 +48,7 @@ Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-w
 > It's a single static binary that runs pipelines from a YAML file (no platform,
 > no Python, no daemon), or an embeddable library with typed Source/Sink traits.
 >
-> 58 connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
+> <!--COUNT:connectors-->66<!--/COUNT--> connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
 > SQLite, S3/GCS/Azure, Parquet/Delta/Iceberg, MongoDB, Redis, Elasticsearch,
 > BigQuery, Snowflake, Databricks), with native streaming (bounded memory),
 > incremental/resumable replication, dead-letter queues, retries, and built-in
@@ -67,7 +67,7 @@ Post early in the US morning (Pacific) on a weekday; reply to comments quickly.
 
 ### 4. Reddit — r/rust
 
-**Title:** `faucet-stream: a config-driven data-movement platform (58 connectors, streaming, CDC) — CLI or embeddable library`
+**Title:** `faucet-stream: a config-driven data-movement platform (<!--COUNT:connectors-->66<!--/COUNT--> connectors, streaming, CDC) — CLI or embeddable library`
 
 Lead with the Rust angle: single binary, typed traits, every connector a Cargo
 feature, performance-first design (connection reuse, multi-row inserts, bounded

--- a/docs/launch/RELEASE_PUBLICITY.md
+++ b/docs/launch/RELEASE_PUBLICITY.md
@@ -8,7 +8,7 @@ A **repeatable, per-release** playbook so publicity is routine, not heroic. Wher
 account. Keep the copy consistent across channels: consistency compounds recognition.
 
 > **Single source of truth:** the canonical pitch and the connector count live in the root
-> [`README.md`](../../README.md) hero (currently **58 connectors — 33 sources / 25 sinks**).
+> [`README.md`](../../README.md) hero (currently **<!--COUNT:connectors-->66<!--/COUNT--> connectors — <!--COUNT:sources-->37<!--/COUNT--> sources / <!--COUNT:sinks-->29<!--/COUNT--> sinks**).
 > Copy from there; don't invent variants. If the count changed this release, update the
 > templates below in the same PR.
 
@@ -66,7 +66,7 @@ DB→DB move, **~96×** as the CSV→JSONL upper bound — never the ~96× alone
 ### Elevator pitch (one-liner — use everywhere)
 
 > **faucet-stream** — the fast, config-driven way to move data in Rust. A data-movement
-> platform with 58 source and sink connectors for ETL, CDC, and streaming, run from a YAML
+> platform with <!--COUNT:connectors-->66<!--/COUNT--> source and sink connectors for ETL, CDC, and streaming, run from a YAML
 > file by a single binary or embedded as a Rust library.
 
 ### Release thread (X / Bluesky / Mastodon / LinkedIn)
@@ -83,7 +83,7 @@ DB→DB move, **~96×** as the CSV→JSONL upper bound — never the ~96× alone
 
 ### This Week in Rust
 
-> **faucet-stream vX.Y.Z** — a config-driven data-movement platform for Rust: 58 connectors,
+> **faucet-stream vX.Y.Z** — a config-driven data-movement platform for Rust: <!--COUNT:connectors-->66<!--/COUNT--> connectors,
 > a `faucet` CLI that runs pipelines from YAML, and an embeddable library, with streaming,
 > Postgres CDC, dead-letter queues, and built-in Prometheus/tracing. This release:
 > <one-line highlight>.

--- a/docs/launch/blog-post.md
+++ b/docs/launch/blog-post.md
@@ -31,7 +31,7 @@ pipeline from Rust with typed `Source`/`Sink` traits.
 
 ## What's in the box
 
-- **58 connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
+- **<!--COUNT:connectors-->66<!--/COUNT--> connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
   Postgres/MySQL/Mongo/SQL-Server CDC, S3/GCS/Azure, Parquet/Delta/Iceberg,
   MongoDB, Redis, Elasticsearch, BigQuery, Snowflake, Databricks, and more.
 - **Bring your existing Singer taps.** The `singer` source runs any Singer/Meltano

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,11 @@ These run immediately after installing the CLI — great for a first smoke test:
 | `csv_to_delta.yaml` | CSV → local Apache Delta Lake table (point `table_uri` at `s3://…` + add `credentials:` for cloud) |
 | `delta_to_jsonl.yaml` | local Delta Lake table → JSONL (run `csv_to_delta.yaml` first); supports `version`/`timestamp` time travel |
 | `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |
+| `duckdb_to_jsonl.yaml` | local DuckDB (file or `:memory:`) query → JSONL |
+| `sqs_to_jsonl.yaml` | AWS SQS → JSONL; runs against LocalStack (`docker run -p 4566:4566 -e SERVICES=sqs localstack/localstack`) |
+| `nats_to_jsonl.yaml` | NATS → JSONL; runs against a local NATS (`docker run -p 4222:4222 nats:latest -js`) |
+| `sftp_to_jsonl.yaml` | SFTP directory → JSONL over SSH; point `host`/`username`/`path` at a real server (set `SFTP_PASSWORD`) |
+| `airtable_to_jsonl.yaml` | Airtable base/table → JSONL via the generic `rest` source (bearer PAT + offset-token pagination); set `AIRTABLE_TOKEN` + `AIRTABLE_BASE_ID` |
 | `rest_to_jsonl.yaml`, `rest_streaming.yaml`, `rest_to_stdout_preview.yaml` | point `base_url` at any HTTP API; preview needs no sink setup |
 | `rest_filter_explode_to_stdout.yaml` | `filter` + `explode` + `keys_case` against DummyJSON; demonstrates the v1 JSONPath subset and the merge rule |
 | `shared_auth_rest.yaml` | one OAuth2 provider in the top-level `auth:` block shared across four matrix rows via `auth: { ref }` — single token, single-flight refresh (point `base_url` / token endpoint at a real API) |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -27,6 +27,10 @@ source = [
     "source-mysql",
     "source-mssql",
     "source-sqlite",
+    "source-duckdb",
+    "source-sqs",
+    "source-nats",
+    "source-sftp",
     "source-s3",
     "source-mongodb",
     "source-mongodb-cdc",
@@ -61,6 +65,10 @@ sink = [
     "sink-mysql",
     "sink-mssql",
     "sink-sqlite",
+    "sink-duckdb",
+    "sink-sqs",
+    "sink-nats",
+    "sink-sftp",
     "sink-s3",
     "sink-mongodb",
     "sink-redis",
@@ -158,6 +166,10 @@ source-postgres-cdc = ["dep:faucet-source-postgres-cdc"]
 source-mysql = ["dep:faucet-source-mysql"]
 source-mssql = ["dep:faucet-source-mssql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
+source-duckdb = ["dep:faucet-source-duckdb"]
+source-sqs = ["dep:faucet-source-sqs", "dep:faucet-common-sqs"]
+source-nats = ["dep:faucet-source-nats", "dep:faucet-common-nats"]
+source-sftp = ["dep:faucet-source-sftp", "dep:faucet-common-sftp"]
 source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
 source-mongodb-cdc = ["dep:faucet-source-mongodb-cdc"]
@@ -196,6 +208,10 @@ sink-snowflake = ["dep:faucet-sink-snowflake"]
 sink-mysql = ["dep:faucet-sink-mysql"]
 sink-mssql = ["dep:faucet-sink-mssql"]
 sink-sqlite = ["dep:faucet-sink-sqlite"]
+sink-duckdb = ["dep:faucet-sink-duckdb"]
+sink-sqs = ["dep:faucet-sink-sqs", "dep:faucet-common-sqs"]
+sink-nats = ["dep:faucet-sink-nats", "dep:faucet-common-nats"]
+sink-sftp = ["dep:faucet-sink-sftp", "dep:faucet-common-sftp"]
 
 sink-s3 = ["dep:faucet-sink-s3"]
 sink-mongodb = ["dep:faucet-sink-mongodb"]
@@ -274,6 +290,13 @@ faucet-source-postgres-cdc = { workspace = true, optional = true }
 faucet-source-mysql = { workspace = true, optional = true }
 faucet-source-mssql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
+faucet-source-duckdb = { workspace = true, optional = true }
+faucet-source-sqs = { workspace = true, optional = true }
+faucet-common-sqs = { workspace = true, optional = true }
+faucet-source-nats = { workspace = true, optional = true }
+faucet-common-nats = { workspace = true, optional = true }
+faucet-source-sftp = { workspace = true, optional = true }
+faucet-common-sftp = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
 faucet-source-mongodb-cdc = { workspace = true, optional = true }
@@ -306,6 +329,10 @@ faucet-sink-spanner = { workspace = true, optional = true }
 faucet-sink-mysql = { workspace = true, optional = true }
 faucet-sink-mssql = { workspace = true, optional = true }
 faucet-sink-sqlite = { workspace = true, optional = true }
+faucet-sink-duckdb = { workspace = true, optional = true }
+faucet-sink-sqs = { workspace = true, optional = true }
+faucet-sink-nats = { workspace = true, optional = true }
+faucet-sink-sftp = { workspace = true, optional = true }
 
 faucet-sink-s3 = { workspace = true, optional = true }
 faucet-sink-mongodb = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -20,6 +20,10 @@
 //! | `source-mysql` | MySQL query source |
 //! | `source-mssql` | Microsoft SQL Server query source |
 //! | `source-sqlite` | SQLite query source |
+//! | `source-duckdb` | DuckDB query source |
+//! | `source-sqs` | AWS SQS source |
+//! | `source-nats` | NATS source |
+//! | `source-sftp` | SFTP source |
 
 //! | `source-s3` | AWS S3 file source |
 //! | `source-mongodb` | MongoDB query source |
@@ -44,6 +48,10 @@
 //! | `sink-mysql` | MySQL sink |
 //! | `sink-mssql` | Microsoft SQL Server sink |
 //! | `sink-sqlite` | SQLite sink |
+//! | `sink-duckdb` | DuckDB sink |
+//! | `sink-sqs` | AWS SQS sink |
+//! | `sink-nats` | NATS sink |
+//! | `sink-sftp` | SFTP sink |
 
 //! | `sink-s3` | AWS S3 file sink |
 //! | `sink-mongodb` | MongoDB insert sink |
@@ -125,6 +133,26 @@ pub mod source {
     #[cfg(feature = "source-sqlite")]
     pub mod sqlite {
         pub use faucet_source_sqlite::*;
+    }
+
+    #[cfg(feature = "source-duckdb")]
+    pub mod duckdb {
+        pub use faucet_source_duckdb::*;
+    }
+
+    #[cfg(feature = "source-sqs")]
+    pub mod sqs {
+        pub use faucet_source_sqs::*;
+    }
+
+    #[cfg(feature = "source-nats")]
+    pub mod nats {
+        pub use faucet_source_nats::*;
+    }
+
+    #[cfg(feature = "source-sftp")]
+    pub mod sftp {
+        pub use faucet_source_sftp::*;
     }
 
     #[cfg(feature = "source-s3")]
@@ -289,6 +317,26 @@ pub mod source {
     #[cfg(feature = "source-sqlite")]
     pub mod sqlite {
         pub use faucet_source_sqlite::*;
+    }
+
+    #[cfg(feature = "source-duckdb")]
+    pub mod duckdb {
+        pub use faucet_source_duckdb::*;
+    }
+
+    #[cfg(feature = "source-sqs")]
+    pub mod sqs {
+        pub use faucet_source_sqs::*;
+    }
+
+    #[cfg(feature = "source-nats")]
+    pub mod nats {
+        pub use faucet_source_nats::*;
+    }
+
+    #[cfg(feature = "source-sftp")]
+    pub mod sftp {
+        pub use faucet_source_sftp::*;
     }
 
     #[cfg(feature = "source-s3")]
@@ -461,6 +509,26 @@ pub mod sink {
     #[cfg(feature = "sink-sqlite")]
     pub mod sqlite {
         pub use faucet_sink_sqlite::*;
+    }
+
+    #[cfg(feature = "sink-duckdb")]
+    pub mod duckdb {
+        pub use faucet_sink_duckdb::*;
+    }
+
+    #[cfg(feature = "sink-sqs")]
+    pub mod sqs {
+        pub use faucet_sink_sqs::*;
+    }
+
+    #[cfg(feature = "sink-nats")]
+    pub mod nats {
+        pub use faucet_sink_nats::*;
+    }
+
+    #[cfg(feature = "sink-sftp")]
+    pub mod sftp {
+        pub use faucet_sink_sftp::*;
     }
 
     #[cfg(feature = "sink-s3")]

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -3892,6 +3892,271 @@
         }
       }
     },
+    "source_sqs__SqsCredentials": {
+      "description": "How to authenticate with AWS SQS.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector.",
+      "oneOf": [
+        {
+          "description": "The AWS SDK default provider chain: environment variables, shared\nconfig/credentials files, ECS/EKS container credentials, web-identity\ntokens (`AWS_WEB_IDENTITY_TOKEN_FILE` / EKS IRSA), and EC2 instance\nprofiles — with automatic refresh/rotation.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "default"
+            }
+          }
+        },
+        {
+          "description": "A named profile from the shared AWS config/credentials files.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "profile"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Profile name (as in `~/.aws/credentials`).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Static access keys. Prefer `${env:…}` / secrets-manager interpolation\nover literals in config files.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "access_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "access_key_id": {
+                  "description": "AWS access key id.",
+                  "type": "string"
+                },
+                "secret_access_key": {
+                  "description": "AWS secret access key.",
+                  "type": "string"
+                },
+                "session_token": {
+                  "description": "Optional session token (for temporary credentials).",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Assume an IAM role via STS on top of the default provider chain.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "assume_role"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "role_arn": {
+                  "description": "ARN of the role to assume.",
+                  "type": "string"
+                },
+                "session_name": {
+                  "description": "Session name recorded in CloudTrail. Defaults to `faucet-stream`.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "external_id": {
+                  "description": "Optional external id for cross-account trust policies.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Web-identity federation (e.g. EKS IRSA). Equivalent to the `default`\nchain, which honors `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` —\nkept as an explicit variant so intent is visible in configs.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "web_identity"
+            }
+          }
+        }
+      ]
+    },
+    "source_nats__NatsAuth": {
+      "description": "NATS client authentication configuration.\n\nSerializes with an adjacent `{ \"type\": <method>, \"config\": { … } }` tag in\nsnake_case, matching every other faucet connector's auth shape.\n\nThe [`std::fmt::Debug`] implementation is hand-written so secret material\n(`token`, `password`, `nkey` seed) is never printed — only the variant name\nand non-secret fields appear.",
+      "oneOf": [
+        {
+          "description": "No authentication (anonymous connection).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "none"
+            }
+          }
+        },
+        {
+          "description": "Bearer/token authentication.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "token"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "description": "The authentication token.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Username + password authentication.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "user_password"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "username": {
+                  "description": "The username.",
+                  "type": "string"
+                },
+                "password": {
+                  "description": "The password.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "NKey (Ed25519 seed) authentication.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "n_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "nkey": {
+                  "description": "The NKey seed (starts with `S`).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Credentials-file (`.creds`) authentication — a decentralized JWT +\nNKey seed bundle as produced by `nsc`.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "creds_file"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Path to the `.creds` file.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source_sftp__HostKeyPolicy": {
+      "description": "How the server's host key is verified during the SSH handshake.\n\nDefaults to [`AcceptNew`](Self::AcceptNew). The insecure, verification-off\nmode is a distinct explicit variant so it can never be selected by\naccident.",
+      "oneOf": [
+        {
+          "description": "Reject any host key that is not already recorded in `known_hosts`.\nThe most secure policy; requires the key to be pre-provisioned.",
+          "type": "object",
+          "properties": {
+            "known_hosts_path": {
+              "description": "Path to the `known_hosts` file. `None` uses the standard\n`~/.ssh/known_hosts` location.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "mode": {
+              "type": "string",
+              "const": "strict"
+            }
+          }
+        },
+        {
+          "description": "Trust-on-first-use: accept and record a host key the first time it is\nseen (in `~/.ssh/known_hosts`), but reject a key that has *changed*\nfrom a previously recorded one. This is the default.",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "accept_new"
+            }
+          }
+        },
+        {
+          "description": "Disable host-key verification entirely. **Insecure** — vulnerable to\nman-in-the-middle attacks. Use only against trusted networks / test\nservers.",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "insecure"
+            }
+          }
+        }
+      ]
+    },
+    "source_sftp__SftpFormat": {
+      "description": "Format of the remote files read by the SFTP source.",
+      "oneOf": [
+        {
+          "description": "Each line in the file is a separate JSON record (the default).\nStreamed line-by-line with bounded memory.",
+          "type": "string",
+          "const": "jsonl"
+        },
+        {
+          "description": "The entire file is a JSON array of records. Buffered fully per file\n(the closing `]` is required to validate the structure), then chunked.",
+          "type": "string",
+          "const": "json_array"
+        },
+        {
+          "description": "Each file becomes a single record with `\"path\"` and `\"content\"` fields.",
+          "type": "string",
+          "const": "raw_text"
+        }
+      ]
+    },
     "source_s3__S3FileFormat": {
       "description": "Format of files stored in S3.",
       "oneOf": [
@@ -6955,6 +7220,276 @@
         }
       }
     },
+    "sink_duckdb__DuckdbColumnMapping": {
+      "description": "How to map JSON records to table columns.",
+      "oneOf": [
+        {
+          "description": "Insert each record as a single JSON text column.",
+          "type": "object",
+          "properties": {
+            "json": {
+              "type": "object",
+              "properties": {
+                "column": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "description": "Map top-level JSON keys directly to table columns. Only keys that match\nexisting columns are inserted; extra keys are ignored.",
+          "type": "string",
+          "const": "auto_map"
+        }
+      ]
+    },
+    "sink_sqs__SqsCredentials": {
+      "description": "How to authenticate with AWS SQS.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector.",
+      "oneOf": [
+        {
+          "description": "The AWS SDK default provider chain: environment variables, shared\nconfig/credentials files, ECS/EKS container credentials, web-identity\ntokens (`AWS_WEB_IDENTITY_TOKEN_FILE` / EKS IRSA), and EC2 instance\nprofiles — with automatic refresh/rotation.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "default"
+            }
+          }
+        },
+        {
+          "description": "A named profile from the shared AWS config/credentials files.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "profile"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Profile name (as in `~/.aws/credentials`).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Static access keys. Prefer `${env:…}` / secrets-manager interpolation\nover literals in config files.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "access_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "access_key_id": {
+                  "description": "AWS access key id.",
+                  "type": "string"
+                },
+                "secret_access_key": {
+                  "description": "AWS secret access key.",
+                  "type": "string"
+                },
+                "session_token": {
+                  "description": "Optional session token (for temporary credentials).",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Assume an IAM role via STS on top of the default provider chain.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "assume_role"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "role_arn": {
+                  "description": "ARN of the role to assume.",
+                  "type": "string"
+                },
+                "session_name": {
+                  "description": "Session name recorded in CloudTrail. Defaults to `faucet-stream`.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "external_id": {
+                  "description": "Optional external id for cross-account trust policies.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Web-identity federation (e.g. EKS IRSA). Equivalent to the `default`\nchain, which honors `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` —\nkept as an explicit variant so intent is visible in configs.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "web_identity"
+            }
+          }
+        }
+      ]
+    },
+    "sink_nats__NatsAuth": {
+      "description": "NATS client authentication configuration.\n\nSerializes with an adjacent `{ \"type\": <method>, \"config\": { … } }` tag in\nsnake_case, matching every other faucet connector's auth shape.\n\nThe [`std::fmt::Debug`] implementation is hand-written so secret material\n(`token`, `password`, `nkey` seed) is never printed — only the variant name\nand non-secret fields appear.",
+      "oneOf": [
+        {
+          "description": "No authentication (anonymous connection).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "none"
+            }
+          }
+        },
+        {
+          "description": "Bearer/token authentication.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "token"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "description": "The authentication token.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Username + password authentication.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "user_password"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "username": {
+                  "description": "The username.",
+                  "type": "string"
+                },
+                "password": {
+                  "description": "The password.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "NKey (Ed25519 seed) authentication.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "n_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "nkey": {
+                  "description": "The NKey seed (starts with `S`).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Credentials-file (`.creds`) authentication — a decentralized JWT +\nNKey seed bundle as produced by `nsc`.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "creds_file"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Path to the `.creds` file.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "sink_sftp__HostKeyPolicy": {
+      "description": "How the server's host key is verified during the SSH handshake.\n\nDefaults to [`AcceptNew`](Self::AcceptNew). The insecure, verification-off\nmode is a distinct explicit variant so it can never be selected by\naccident.",
+      "oneOf": [
+        {
+          "description": "Reject any host key that is not already recorded in `known_hosts`.\nThe most secure policy; requires the key to be pre-provisioned.",
+          "type": "object",
+          "properties": {
+            "known_hosts_path": {
+              "description": "Path to the `known_hosts` file. `None` uses the standard\n`~/.ssh/known_hosts` location.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "mode": {
+              "type": "string",
+              "const": "strict"
+            }
+          }
+        },
+        {
+          "description": "Trust-on-first-use: accept and record a host key the first time it is\nseen (in `~/.ssh/known_hosts`), but reject a key that has *changed*\nfrom a previously recorded one. This is the default.",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "accept_new"
+            }
+          }
+        },
+        {
+          "description": "Disable host-key verification entirely. **Insecure** — vulnerable to\nman-in-the-middle attacks. Use only against trusted networks / test\nservers.",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "insecure"
+            }
+          }
+        }
+      ]
+    },
     "sink_s3__S3SinkFormat": {
       "description": "On-the-wire format of objects written by the S3 sink.",
       "oneOf": [
@@ -9851,6 +10386,420 @@
                   "title": "SqliteSourceConfig",
                   "description": "Configuration for the SQLite query source.",
                   "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "duckdb",
+          "properties": {
+            "type": {
+              "const": "duckdb"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "database": {
+                      "description": "Path to the DuckDB database file, or `:memory:` for an in-memory\ndatabase. A `duckdb://` / `duckdb:` scheme prefix is accepted and\nstripped.",
+                      "type": "string"
+                    },
+                    "query": {
+                      "description": "SQL query to execute.",
+                      "type": "string"
+                    },
+                    "read_only": {
+                      "description": "Open the database read-only. Defaults to `false` (read-write).\n\nSet `true` to attach to a database file another process holds open —\nDuckDB permits multiple read-only connections to one file but only a\nsingle read-write connection.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). Rows are\ndrained from the DuckDB result and yielded whenever the buffer reaches\nthis size. Defaults to [`DEFAULT_BATCH_SIZE`].\n\n`batch_size = 0` is the \"no batching\" sentinel: the entire result set is\nemitted in a single page. Useful for small lookup tables.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "DuckdbSourceConfig",
+                  "description": "Configuration for the DuckDB query source.",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "sqs",
+          "properties": {
+            "type": {
+              "const": "sqs"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "queue_url": {
+                      "description": "SQS queue URL (e.g. `https://sqs.us-east-1.amazonaws.com/1234/my-q`).",
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "AWS region. `None` uses the SDK default chain (env, profile, IMDS).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "endpoint_url": {
+                      "description": "Custom endpoint URL for LocalStack / VPC endpoints.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "credentials": {
+                      "description": "AWS credentials. Defaults to the SDK default provider chain.",
+                      "$ref": "#/$defs/source_sqs__SqsCredentials",
+                      "default": {
+                        "type": "default"
+                      }
+                    },
+                    "idle_timeout_secs": {
+                      "description": "Stop after this many seconds without a new message. At least one of\n`idle_timeout_secs` and `max_messages` must be set (mirrors the Kafka /\nKinesis sources) — a batch run must terminate.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0
+                    },
+                    "max_messages": {
+                      "description": "Stop after this many messages in total.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0
+                    },
+                    "wait_time_seconds": {
+                      "description": "Long-poll wait per `ReceiveMessage` call, in seconds (0–20). Default 10.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "int32",
+                      "default": 10
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` is the\n\"no batching\" sentinel: one page per assembled drain buffer. Default\n1000.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "SqsSourceConfig",
+                  "description": "Configuration for [`SqsSource`](crate::SqsSource).",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "nats",
+          "properties": {
+            "type": {
+              "const": "nats"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "servers": {
+                      "description": "One or more NATS server URLs, e.g. `[\"nats://127.0.0.1:4222\"]`. The\nclient connects to the first reachable server and uses the rest for\nfailover.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": [
+                        "nats://127.0.0.1:4222"
+                      ]
+                    },
+                    "auth": {
+                      "description": "Authentication mode. Defaults to [`NatsAuth::None`] (anonymous).",
+                      "$ref": "#/$defs/source_nats__NatsAuth",
+                      "default": {
+                        "type": "none"
+                      }
+                    },
+                    "tls": {
+                      "description": "Require a TLS connection to the server. Defaults to `false`.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "name": {
+                      "description": "Optional client connection name (surfaced in NATS server monitoring).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "subject": {
+                      "description": "Subject to subscribe to. Supports NATS wildcards (`*` for one token,\n`>` for the remaining tokens). In JetStream mode the durable consumer's\nown filter subject governs delivery and this field is informational.",
+                      "type": "string"
+                    },
+                    "queue_group": {
+                      "description": "Optional queue group for core-NATS load-balanced subscriptions — all\nsubscribers sharing a group split the subject's messages. Ignored in\nJetStream mode.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "jetstream_stream": {
+                      "description": "JetStream stream name. When set together with\n[`jetstream_consumer`](Self::jetstream_consumer) the source pulls from a\ndurable JetStream consumer instead of a core-NATS subscription.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "jetstream_consumer": {
+                      "description": "Name of the durable JetStream (pull) consumer to bind to. Required when\n[`jetstream_stream`](Self::jetstream_stream) is set; the consumer must\nalready exist on the server.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "max_messages": {
+                      "description": "Stop after this many messages have been drained. At least one of\n`max_messages` / `idle_timeout_secs` must be set so a run terminates.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0
+                    },
+                    "idle_timeout_secs": {
+                      "description": "Stop after this many seconds elapse with no new message. At least one of\n`max_messages` / `idle_timeout_secs` must be set so a run terminates.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0
+                    },
+                    "batch_size": {
+                      "description": "Messages per emitted [`StreamPage`](faucet_core::StreamPage). Drained\nmessages accumulate in an in-memory buffer and a page is yielded when\nthe buffer reaches this size (or when the run terminates with a partial\nbuffer). Defaults to [`DEFAULT_BATCH_SIZE`].\n\n`batch_size = 0` is the \"drain-entire-run-window\" sentinel: every\nmessage produced before the terminator fires goes into a single page.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "NatsSourceConfig",
+                  "description": "Configuration for [`NatsSource`](crate::NatsSource).\n\nThe [`NatsConnectionConfig`] surface (`servers` / `auth` / `tls` / `name`)\nis flattened in, so a config looks like:\n\n```yaml\nservers: [\"nats://127.0.0.1:4222\"]\nsubject: \"events.>\"\nidle_timeout_secs: 5\nbatch_size: 500\n```",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "sftp",
+          "properties": {
+            "type": {
+              "const": "sftp"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "description": "Password authentication.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "password"
+                        },
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "password": {
+                              "description": "The account password.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "description": "Public-key authentication with an OpenSSH/PEM private key on disk.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "private_key"
+                        },
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "description": "Path to the private-key file.",
+                              "type": "string"
+                            },
+                            "passphrase": {
+                              "description": "Optional passphrase used to decrypt an encrypted private key.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "default": null
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "title": "SftpSourceConfig",
+                  "description": "Configuration for the SFTP source connector.",
+                  "type": "object",
+                  "properties": {
+                    "host": {
+                      "description": "Server hostname or IP address.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Server port (default: 22).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint16",
+                      "minimum": 0,
+                      "maximum": 65535,
+                      "default": 22
+                    },
+                    "username": {
+                      "description": "SSH username.",
+                      "type": "string"
+                    },
+                    "known_hosts": {
+                      "description": "Host-key verification policy (default: `accept_new`).",
+                      "$ref": "#/$defs/source_sftp__HostKeyPolicy",
+                      "default": {
+                        "mode": "accept_new"
+                      }
+                    },
+                    "path": {
+                      "description": "Remote path to read: a directory whose files are listed and streamed,\nor a single file.",
+                      "type": "string"
+                    },
+                    "glob": {
+                      "description": "Optional filename glob (`*` / `?`) applied to the basenames of files in\na directory listing. Ignored when `path` points at a single file.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "default": null
+                    },
+                    "format": {
+                      "description": "Format of the files to read (default: `jsonl`).",
+                      "$ref": "#/$defs/source_sftp__SftpFormat",
+                      "default": "jsonl"
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). For\n`jsonl` / `raw_text`, files are decoded incrementally and a page is\nyielded whenever the buffer reaches this size (bounded memory). For\n`json_array`, each file is buffered fully, then its records are chunked\ninto pages of this size. Defaults to [`DEFAULT_BATCH_SIZE`].\n\n`batch_size = 0` is the \"no batching\" sentinel: one page is emitted per\nfile.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  }
                 },
                 true
               ]
@@ -13281,6 +14230,368 @@
                   "title": "SqliteSinkConfig",
                   "description": "Configuration for the SQLite sink.",
                   "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "duckdb",
+          "properties": {
+            "type": {
+              "const": "duckdb"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "database": {
+                      "description": "Path to the DuckDB database file, or `:memory:`. A `duckdb://` /\n`duckdb:` scheme prefix is accepted and stripped. The target table must\nalready exist.",
+                      "type": "string"
+                    },
+                    "table_name": {
+                      "description": "Target table name.",
+                      "type": "string"
+                    },
+                    "column_mapping": {
+                      "description": "How to map JSON records to columns.",
+                      "$ref": "#/$defs/sink_duckdb__DuckdbColumnMapping",
+                      "default": {
+                        "json": {
+                          "column": "data"
+                        }
+                      }
+                    },
+                    "batch_size": {
+                      "description": "Maximum number of rows per multi-row INSERT. Defaults to\n[`DEFAULT_BATCH_SIZE`] (1000). `batch_size = 0` writes the entire\nupstream slice as a single multi-row INSERT (no re-chunking).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "DuckdbSinkConfig",
+                  "description": "Configuration for the DuckDB sink.",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "sqs",
+          "properties": {
+            "type": {
+              "const": "sqs"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "queue_url": {
+                      "description": "SQS queue URL (e.g. `https://sqs.us-east-1.amazonaws.com/1234/my-q`).",
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "AWS region. `None` uses the SDK default chain.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "endpoint_url": {
+                      "description": "Custom endpoint URL for LocalStack / VPC endpoints.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "credentials": {
+                      "description": "AWS credentials. Defaults to the SDK default provider chain.",
+                      "$ref": "#/$defs/sink_sqs__SqsCredentials",
+                      "default": {
+                        "type": "default"
+                      }
+                    },
+                    "message_group_id": {
+                      "description": "FIFO message group id, applied to every message. Required by FIFO\nqueues; omit for standard queues. Default: none.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "message_deduplication_id_field": {
+                      "description": "Record field whose (stringified) value becomes each message's\n`MessageDeduplicationId` on a FIFO queue. A record missing the field\n(or with a non-scalar value) fails per-record (DLQ-routable). Only used\nwhen set. Default: none.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "batch_size": {
+                      "description": "Max entries per `SendMessageBatch` request (1–10). Default 10.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 10
+                    },
+                    "concurrency": {
+                      "description": "Bounded concurrent in-flight `SendMessageBatch` requests. Default 4.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 4
+                    },
+                    "retry_max_attempts": {
+                      "description": "Per-record retry budget for partial failures. Default 5.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 5
+                    },
+                    "retry_initial_backoff_ms": {
+                      "description": "Initial retry backoff (milliseconds). Default 100.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 100
+                    },
+                    "retry_max_backoff_ms": {
+                      "description": "Backoff ceiling (milliseconds). Default 30000.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 30000
+                    }
+                  },
+                  "title": "SqsSinkConfig",
+                  "description": "Configuration for [`SqsSink`](crate::SqsSink).",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "nats",
+          "properties": {
+            "type": {
+              "const": "nats"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "servers": {
+                      "description": "One or more NATS server URLs, e.g. `[\"nats://127.0.0.1:4222\"]`. The\nclient connects to the first reachable server and uses the rest for\nfailover.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": [
+                        "nats://127.0.0.1:4222"
+                      ]
+                    },
+                    "auth": {
+                      "description": "Authentication mode. Defaults to [`NatsAuth::None`] (anonymous).",
+                      "$ref": "#/$defs/sink_nats__NatsAuth",
+                      "default": {
+                        "type": "none"
+                      }
+                    },
+                    "tls": {
+                      "description": "Require a TLS connection to the server. Defaults to `false`.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "name": {
+                      "description": "Optional client connection name (surfaced in NATS server monitoring).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "subject": {
+                      "description": "Default subject every record is published to.",
+                      "type": "string"
+                    },
+                    "subject_field": {
+                      "description": "Optional top-level record field whose (string) value overrides\n[`subject`](Self::subject) on a per-record basis — the subject-per-record\npattern. When the field is missing or is not a string the sink errors.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "batch_size": {
+                      "description": "Records per publish batch. Records are published one NATS message each;\nafter every `batch_size` records the client is flushed so nothing is\nlost. Defaults to [`DEFAULT_BATCH_SIZE`]. `0` publishes the whole batch\nhanded by the pipeline, flushing once at the end.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "NatsSinkConfig",
+                  "description": "Configuration for [`NatsSink`](crate::NatsSink).\n\nThe [`NatsConnectionConfig`] surface (`servers` / `auth` / `tls` / `name`)\nis flattened in.",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "sftp",
+          "properties": {
+            "type": {
+              "const": "sftp"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "description": "Password authentication.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "password"
+                        },
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "password": {
+                              "description": "The account password.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "description": "Public-key authentication with an OpenSSH/PEM private key on disk.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "private_key"
+                        },
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "description": "Path to the private-key file.",
+                              "type": "string"
+                            },
+                            "passphrase": {
+                              "description": "Optional passphrase used to decrypt an encrypted private key.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "default": null
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "title": "SftpSinkConfig",
+                  "description": "Configuration for the SFTP sink connector.",
+                  "type": "object",
+                  "properties": {
+                    "host": {
+                      "description": "Server hostname or IP address.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Server port (default: 22).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint16",
+                      "minimum": 0,
+                      "maximum": 65535,
+                      "default": 22
+                    },
+                    "username": {
+                      "description": "SSH username.",
+                      "type": "string"
+                    },
+                    "known_hosts": {
+                      "description": "Host-key verification policy (default: `accept_new`).",
+                      "$ref": "#/$defs/sink_sftp__HostKeyPolicy",
+                      "default": {
+                        "mode": "accept_new"
+                      }
+                    },
+                    "path": {
+                      "description": "Remote directory prefix under which JSON Lines objects are written.",
+                      "type": "string"
+                    },
+                    "file_extension": {
+                      "description": "File extension for written objects (default: `.jsonl`).",
+                      "type": "string",
+                      "default": ".jsonl"
+                    },
+                    "batch_size": {
+                      "description": "Records per written object. When a `write_batch` call hands the sink\n`N` records with `batch_size = M > 0`, the sink writes `ceil(N / M)`\nobjects. `batch_size = 0` writes whatever upstream hands it as a single\nobject. Defaults to [`DEFAULT_BATCH_SIZE`].",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  }
                 },
                 true
               ]

--- a/scripts/check-doc-counts.sh
+++ b/scripts/check-doc-counts.sh
@@ -1,38 +1,11 @@
 #!/usr/bin/env bash
-# Guard against connector-count drift across user-facing docs.
+# Guard against connector-/crate-count drift across the user-facing docs.
 #
-# The number of source/sink connectors is stated in several places (README hero,
-# the docs-site connector catalog, the docs intro). They have silently diverged
-# before (issue #335). This asserts every one of them matches the actual number
-# of connector crates on disk, so a connector added without updating the docs
-# fails CI.
+# Counts are a SINGLE SOURCE OF TRUTH derived from the crate directories on disk
+# and rendered into `<!--COUNT:*-->N<!--/COUNT-->` sentinel spans throughout the
+# docs by scripts/sync-doc-counts.py. This wrapper just runs its --check mode
+# (kept for the CI `doc-counts` job and anyone with the old entrypoint in muscle
+# memory). To fix drift, run: python3 scripts/sync-doc-counts.py
 set -euo pipefail
 cd "$(dirname "$0")/.."
-
-S=$(find crates/source -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-K=$(find crates/sink -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-T=$((S + K))
-echo "Connector crates on disk: ${S} sources, ${K} sinks, ${T} total"
-
-fail=0
-check() { # <file> <literal-substring>
-  if ! grep -qF -- "$2" "$1"; then
-    echo "  ✗ ${1}: expected to contain '${2}'"
-    fail=1
-  fi
-}
-
-check README.md "**${S} source**"
-check README.md "**${K} sink**"
-check README.md "**${T} in total**"
-check docs/book/src/reference/connectors.md "**${S} sources**"
-check docs/book/src/reference/connectors.md "**${K} sinks**"
-check docs/book/src/introduction.md "**${S} source**"
-check docs/book/src/introduction.md "**${K} sink**"
-
-if [ "${fail}" -ne 0 ]; then
-  echo ""
-  echo "Connector-count drift detected. Update the file(s) above to ${S} sources / ${K} sinks / ${T} total."
-  exit 1
-fi
-echo "OK: connector counts are consistent across docs."
+exec python3 scripts/sync-doc-counts.py --check

--- a/scripts/sync-doc-counts.py
+++ b/scripts/sync-doc-counts.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Single source of truth for connector/crate counts across the docs.
+
+The counts (sources, sinks, connectors, common libraries, total crates) are
+*derived from the crate directories on disk* — there is no number to hand-edit.
+Every doc that states a count wraps it in a sentinel span:
+
+    <!--COUNT:sources-->37<!--/COUNT-->
+
+The HTML comments are invisible in rendered Markdown (GitHub, docs.rs, mdBook),
+so the visible text is just "37". This script re-renders the value inside every
+span from the live crate count.
+
+Usage:
+    python3 scripts/sync-doc-counts.py            # render (rewrite files in place)
+    python3 scripts/sync-doc-counts.py --check     # verify, non-zero exit on drift (CI)
+
+Valid keys: sources, sinks, connectors, common, crates, libraries.
+Add a new count site by wrapping its number in a `<!--COUNT:<key>-->…<!--/COUNT-->`
+span — this script (and the CI `doc-counts` job) then keep it in sync forever.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SENTINEL = re.compile(r"(<!--COUNT:(?P<key>[a-z]+)-->)(?P<val>.*?)(<!--/COUNT-->)", re.DOTALL)
+# Pruned by directory name anywhere in the tree.
+SKIP_DIRS = {".git", "target", "node_modules"}
+# Pruned by exact repo-relative path (the mdBook *rendered output* — its `src/`
+# sibling holds the sources we DO want to process).
+SKIP_PATHS = {os.path.join("docs", "book", "book")}
+
+
+def counts() -> dict[str, int]:
+    def dirs(rel: str) -> int:
+        p = os.path.join(ROOT, rel)
+        return sum(
+            1
+            for e in os.listdir(p)
+            if os.path.isdir(os.path.join(p, e))
+        ) if os.path.isdir(p) else 0
+
+    sources = dirs("crates/source")
+    sinks = dirs("crates/sink")
+    common = dirs("crates/common")
+    # Every crate in the workspace = one Cargo.toml under crates/** plus the
+    # umbrella (faucet-stream) and the CLI (cli).
+    crate_manifests = 0
+    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, "crates")):
+        if "Cargo.toml" in filenames:
+            crate_manifests += 1
+    crates = crate_manifests + 2  # + faucet-stream + cli
+    return {
+        "sources": sources,
+        "sinks": sinks,
+        "connectors": sources + sinks,
+        "common": common,
+        "crates": crates,
+        "libraries": crates - 1,  # all crates except the `faucet` CLI binary
+    }
+
+
+def iter_doc_files():
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if d not in SKIP_DIRS
+            and os.path.relpath(os.path.join(dirpath, d), ROOT) not in SKIP_PATHS
+        ]
+        for fn in filenames:
+            if fn.endswith(".md"):
+                yield os.path.join(dirpath, fn)
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    vals = counts()
+    drift: list[str] = []
+    unknown: list[str] = []
+    changed = 0
+
+    for path in iter_doc_files():
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        if "<!--COUNT:" not in text:
+            continue
+
+        def repl(m: re.Match) -> str:
+            key = m.group("key")
+            if key not in vals:
+                unknown.append(f"{os.path.relpath(path, ROOT)}: unknown count key '{key}'")
+                return m.group(0)
+            want = str(vals[key])
+            if m.group("val") != want:
+                drift.append(
+                    f"{os.path.relpath(path, ROOT)}: {key} = '{m.group('val')}' → '{want}'"
+                )
+            return f"{m.group(1)}{want}{m.group(4)}"
+
+        new = SENTINEL.sub(repl, text)
+        if new != text:
+            changed += 1
+            if not check:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(new)
+
+    if unknown:
+        print("Unknown count keys (valid: %s):" % ", ".join(sorted(vals)))
+        for u in unknown:
+            print("  ✗ " + u)
+        return 1
+
+    label = "  ".join(f"{k}={v}" for k, v in vals.items())
+    print(f"Counts: {label}")
+
+    if check:
+        if drift:
+            print("\nConnector-count drift — run `python3 scripts/sync-doc-counts.py` to fix:")
+            for d in drift:
+                print("  ✗ " + d)
+            return 1
+        print("OK: every <!--COUNT:*--> span is in sync with the crate directories.")
+        return 0
+
+    print(f"Rendered {changed} file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #413, #412, #411, #410, #414 — four new source/sink connector pairs plus a documented Airtable recipe, all upholding the Faucet Connector Protocol and fully integrated into the CLI, umbrella crate, CI feature matrix, connector registry, docs site, and README.

## What's added

| Issue | Connector | Crates | Pattern |
|---|---|---|---|
| #413 | **DuckDB** | `faucet-source-duckdb`, `faucet-sink-duckdb` | SQLite pair; reuses existing workspace `duckdb` dep |
| #412 | **AWS SQS** | `faucet-common-sqs`, `faucet-source-sqs`, `faucet-sink-sqs` | Kinesis pair (`aws-sdk-sqs`) |
| #411 | **NATS** | `faucet-common-nats`, `faucet-source-nats`, `faucet-sink-nats` | Kafka pair (`async-nats`, JetStream-capable) |
| #410 | **SFTP** | `faucet-common-sftp`, `faucet-source-sftp`, `faucet-sink-sftp` | S3 pair (`russh` + `russh-sftp`) |
| #414 | **Airtable** | *(recipe — no crate)* | generic `rest` source |

### Behaviour highlights
- **DuckDB source** streams with genuinely bounded memory (a blocking task holds the connection and hands finished pages over a small channel); **sink** is append-only, transaction-wrapped multi-row `INSERT` (JSON column or auto-mapped). Arrow columnar + keyed upsert are noted as follow-ups.
- **SQS source** long-polls `ReceiveMessage` and deletes after a page is emitted (at-least-once) with idle/max-messages termination; **sink** batches `SendMessageBatch` (10/req) with per-entry partial-failure retry and FIFO group/dedup.
- **NATS source** subscribes to a subject or a JetStream durable consumer with idle/max termination; **sink** publishes to a subject (optional subject-per-record) and flushes per batch.
- **SFTP source** lists/globs a remote directory and streams JSONL / JSON-array / raw-text over SSH with a configurable host-key policy (`strict` / `accept_new` / `insecure`); **sink** writes JSONL with atomic temp-then-rename uploads.
- **Airtable** is covered end-to-end by the generic `rest` source (bearer PAT auth, offset-token `Cursor` pagination on `$.offset`, 429/`Retry-After` retry) — shipped as `cli/examples/airtable_to_jsonl.yaml` + a cookbook page, the smallest correct outcome the issue asked for.

## Conformance & integration
- Each connector wires the reusable `faucet-conformance` battery in `tests/conformance.rs`. Offline checks (config-schema validity, errors-not-panics) run everywhere; bounded-memory / capabilities-truthful checks are Docker-gated (LocalStack for SQS, `nats:latest -js` for NATS, `atmoz/sftp` for SFTP) and run in CI.
- All connectors register in `cli/connectors/registry.json` (tier **stable**, matching the `builtin_tiers_match_conformance` scorer), the registry dispatch/schema/description tables, umbrella + CLI features (SQS/NATS/SFTP pull their `-common` crate), the CI `feature-check` matrix, per-crate crates.io keywords + docs.rs metadata + `doc_cfg`.
- Docs: connector capability matrix, README connector tables, and counts updated to **37 sources / 29 sinks / 66 connectors (91 crates)** — `scripts/check-doc-counts.sh` passes. Runnable example configs added for all four.

## Verification (local)
- Integrated CLI builds green with all four connector pairs enabled together; `faucet list` / `schema` / `validate` recognise `duckdb` / `sqs` / `nats` / `sftp`; DuckDB runs end-to-end (`duckdb → jsonl`).
- `builtin_tiers_match_conformance` + `index_covers_every_compiled_builtin` pass; `check-doc-counts.sh` passes; DuckDB unit + conformance green; all 11 new crates' `--lib` tests pass; `cargo fmt --all --check` clean.
- The full `--all-features` workspace clippy/test (incl. Docker container tests) is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)