### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,7 +4767,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-sink-iceberg"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ faucet-sink-kafka = { path = "crates/sink/kafka", version = "1.3.2" }
 faucet-sink-kinesis = { path = "crates/sink/kinesis", version = "1.0.1" }
 faucet-sink-stdout = { path = "crates/sink/stdout", version = "1.2.0" }
 faucet-sink-parquet = { path = "crates/sink/parquet", version = "1.1.5" }
-faucet-sink-iceberg = { path = "crates/sink/iceberg", version = "1.2.2" }
+faucet-sink-iceberg = { path = "crates/sink/iceberg", version = "1.3.0" }
 faucet-sink-delta = { path = "crates/sink/delta", version = "1.1.0" }
 faucet-sink-spanner = { path = "crates/sink/spanner", version = "1.0.1" }
 faucet-state-redis = { path = "crates/state/redis", version = "1.0.7" }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.7.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-cli-v1.6.0...faucet-cli-v1.7.0) - 2026-07-31
+
+### Bug Fixes
+
+- Keep transform additions a minor release — pin touched crates to 1.x
+
+### Features
+
+- *(transform-wasm)* Add WebAssembly (wasmtime) per-record transform ([#124](https://github.com/PawanSikawat/faucet-stream/pull/124)) ([#426](https://github.com/PawanSikawat/faucet-stream/pull/426))
+- *(iceberg)* Additive schema evolution via iceberg-rust 0.10.0 ([#255](https://github.com/PawanSikawat/faucet-stream/pull/255)); fix(cli): run summary → stderr ([#424](https://github.com/PawanSikawat/faucet-stream/pull/424)) ([#425](https://github.com/PawanSikawat/faucet-stream/pull/425))
+- *(cli)* MCP server — agent-operable control plane ([#420](https://github.com/PawanSikawat/faucet-stream/pull/420)) ([#422](https://github.com/PawanSikawat/faucet-stream/pull/422))
+- *(cli)* Topology mode — fan-out (tee), fan-in (merge), and cross-source join (#71, #72) ([#421](https://github.com/PawanSikawat/faucet-stream/pull/421))
+- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
+- *(connectors)* Add DuckDB, SQS, NATS, SFTP connector pairs + Airtable REST recipe
+
+### Testing
+
+- *(cli)* Whitelist SFTP_PASSWORD + AIRTABLE_* env for example-validate test
+
 ## [1.6.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-cli-v1.5.0...faucet-cli-v1.6.0) - 2026-07-24
 
 ### Documentation

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.7.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-core-v1.6.0...faucet-core-v1.7.0) - 2026-07-31
+
+### Bug Fixes
+
+- Keep transform additions a minor release — pin touched crates to 1.x
+
+### Features
+
+- *(cli)* Topology mode — fan-out (tee), fan-in (merge), and cross-source join (#71, #72) ([#421](https://github.com/PawanSikawat/faucet-stream/pull/421))
+- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
+
 ## [1.6.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-core-v1.5.0...faucet-core-v1.6.0) - 2026-07-24
 
 ### Documentation

--- a/crates/sink/iceberg/CHANGELOG.md
+++ b/crates/sink/iceberg/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.3.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-sink-iceberg-v1.2.2...faucet-sink-iceberg-v1.3.0) - 2026-07-31
+
+### Features
+
+- *(iceberg)* Additive schema evolution via iceberg-rust 0.10.0 ([#255](https://github.com/PawanSikawat/faucet-stream/pull/255)); fix(cli): run summary → stderr ([#424](https://github.com/PawanSikawat/faucet-stream/pull/424)) ([#425](https://github.com/PawanSikawat/faucet-stream/pull/425))
+
 ## [1.2.2](https://github.com/PawanSikawat/faucet-stream/compare/faucet-sink-iceberg-v1.2.1...faucet-sink-iceberg-v1.2.2) - 2026-07-24
 
 ### Miscellaneous

--- a/crates/sink/iceberg/Cargo.toml
+++ b/crates/sink/iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-sink-iceberg"
-version = "1.2.2"
+version = "1.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/sink/stdout/CHANGELOG.md
+++ b/crates/sink/stdout/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.2.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-sink-stdout-v1.1.5...faucet-sink-stdout-v1.2.0) - 2026-07-31
+
+### Bug Fixes
+
+- Keep transform additions a minor release — pin touched crates to 1.x
+
+### Features
+
+- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
+
 ## [1.1.5](https://github.com/PawanSikawat/faucet-stream/compare/faucet-sink-stdout-v1.1.4...faucet-sink-stdout-v1.1.5) - 2026-07-24
 
 ### Miscellaneous

--- a/crates/source/rest/CHANGELOG.md
+++ b/crates/source/rest/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.4.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-source-rest-v1.3.1...faucet-source-rest-v1.4.0) - 2026-07-31
+
+### Bug Fixes
+
+- Keep transform additions a minor release — pin touched crates to 1.x
+
+### Features
+
+- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
+
 ## [1.3.1](https://github.com/PawanSikawat/faucet-stream/compare/faucet-source-rest-v1.3.0...faucet-source-rest-v1.3.1) - 2026-07-24
 
 ### Miscellaneous

--- a/crates/transform-wasm/CHANGELOG.md
+++ b/crates/transform-wasm/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+## [1.0.0](https://github.com/PawanSikawat/faucet-stream/releases/tag/faucet-transform-wasm-v1.0.0) - 2026-07-31
+
+### Features
+
+- *(transform-wasm)* Add WebAssembly (wasmtime) per-record transform ([#124](https://github.com/PawanSikawat/faucet-stream/pull/124)) ([#426](https://github.com/PawanSikawat/faucet-stream/pull/426))

--- a/faucet-stream/CHANGELOG.md
+++ b/faucet-stream/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.6.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-stream-v1.5.0...faucet-stream-v1.6.0) - 2026-07-31
+
+### Bug Fixes
+
+- Keep transform additions a minor release — pin touched crates to 1.x
+
+### Documentation
+
+- Single source of truth for connector/crate counts
+- *(gtm)* Elevate Singer on-ramp, fix conformance + connector-count drift
+- *(readme)* Keep downloads badge link on faucet-stream
+- *(readme)* Point downloads badge at faucet-core
+
+### Features
+
+- *(transform-wasm)* Add WebAssembly (wasmtime) per-record transform ([#124](https://github.com/PawanSikawat/faucet-stream/pull/124)) ([#426](https://github.com/PawanSikawat/faucet-stream/pull/426))
+- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
+- *(connectors)* Add DuckDB, SQS, NATS, SFTP connector pairs + Airtable REST recipe
+
+### Testing
+
+- *(conformance)* Wire the battery into delta/clickhouse/pubsub/azure-blob; fix databricks tier (#396, #397)
+
 ## [1.5.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-stream-v1.4.0...faucet-stream-v1.5.0) - 2026-07-24
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `faucet-core`: 1.6.0 -> 1.7.0
* `faucet-transform-wasm`: 1.0.0
* `faucet-source-rest`: 1.3.1 -> 1.4.0
* `faucet-sink-stdout`: 1.1.5 -> 1.2.0
* `faucet-sink-iceberg`: 1.2.2 -> 1.3.0
* `faucet-source-duckdb`: 1.0.0
* `faucet-sink-duckdb`: 1.0.0
* `faucet-common-sqs`: 1.0.0
* `faucet-source-sqs`: 1.0.0
* `faucet-sink-sqs`: 1.0.0
* `faucet-common-nats`: 1.0.0
* `faucet-source-nats`: 1.0.0
* `faucet-sink-nats`: 1.0.0
* `faucet-common-sftp`: 1.0.0
* `faucet-source-sftp`: 1.0.0
* `faucet-sink-sftp`: 1.0.0
* `faucet-stream`: 1.5.0 -> 1.6.0
* `faucet-cli`: 1.6.0 -> 1.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `faucet-core`

<blockquote>

## [1.7.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-core-v1.6.0...faucet-core-v1.7.0) - 2026-07-31

### Bug Fixes

- Keep transform additions a minor release — pin touched crates to 1.x

### Features

- *(cli)* Topology mode — fan-out (tee), fan-in (merge), and cross-source join (#71, #72) ([#421](https://github.com/PawanSikawat/faucet-stream/pull/421))
- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
</blockquote>

## `faucet-transform-wasm`

<blockquote>

## [1.0.0](https://github.com/PawanSikawat/faucet-stream/releases/tag/faucet-transform-wasm-v1.0.0) - 2026-07-31

### Features

- *(transform-wasm)* Add WebAssembly (wasmtime) per-record transform ([#124](https://github.com/PawanSikawat/faucet-stream/pull/124)) ([#426](https://github.com/PawanSikawat/faucet-stream/pull/426))
</blockquote>

## `faucet-source-rest`

<blockquote>

## [1.4.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-source-rest-v1.3.1...faucet-source-rest-v1.4.0) - 2026-07-31

### Bug Fixes

- Keep transform additions a minor release — pin touched crates to 1.x

### Features

- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
</blockquote>

## `faucet-sink-stdout`

<blockquote>

## [1.2.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-sink-stdout-v1.1.5...faucet-sink-stdout-v1.2.0) - 2026-07-31

### Bug Fixes

- Keep transform additions a minor release — pin touched crates to 1.x

### Features

- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
</blockquote>

## `faucet-sink-iceberg`

<blockquote>

## [1.3.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-sink-iceberg-v1.2.2...faucet-sink-iceberg-v1.3.0) - 2026-07-31

### Features

- *(iceberg)* Additive schema evolution via iceberg-rust 0.10.0 ([#255](https://github.com/PawanSikawat/faucet-stream/pull/255)); fix(cli): run summary → stderr ([#424](https://github.com/PawanSikawat/faucet-stream/pull/424)) ([#425](https://github.com/PawanSikawat/faucet-stream/pull/425))
</blockquote>

## `faucet-source-duckdb`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: DuckDB query source — opens a DuckDB file or in-memory
  database, runs a configured SQL query, and streams rows as JSON with
  bounded memory. Conformance battery wired ([#413](https://github.com/PawanSikawat/faucet-stream/issues/413)).
</blockquote>

## `faucet-sink-duckdb`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: DuckDB sink — writes JSON records to a DuckDB table via a
  JSON column or auto-mapped columns, each batch a transaction-wrapped
  multi-row INSERT. Conformance battery wired ([#413](https://github.com/PawanSikawat/faucet-stream/issues/413)).
</blockquote>

## `faucet-common-sqs`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: shared `SqsCredentials` auth enum + `build_client` helper for
  the AWS SQS source and sink connectors ([#412](https://github.com/PawanSikawat/faucet-stream/issues/412)).
</blockquote>

## `faucet-source-sqs`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: AWS SQS source — long-polls `ReceiveMessage`, buffers to
  `batch_size` and streams pages with bounded memory, deletes each page's
  receipt handles before yielding (at-least-once), and terminates on
  `idle_timeout_secs` / `max_messages`. Conformance battery wired
  ([#412](https://github.com/PawanSikawat/faucet-stream/issues/412)).
</blockquote>

## `faucet-sink-sqs`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: AWS SQS sink — batched `SendMessageBatch` writes (≤10 entries
  / ≤256 KiB per request), bounded request concurrency, per-entry
  partial-failure retry, optional FIFO `message_group_id` /
  `message_deduplication_id`, and DLQ-routable per-record outcomes. Conformance
  battery wired ([#412](https://github.com/PawanSikawat/faucet-stream/issues/412)).
</blockquote>

## `faucet-common-nats`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: shared NATS configuration types for the source and sink
  connectors — `NatsAuth` (secret-safe `Debug`), `NatsConnectionConfig`, and
  the `connect` client builder ([#411](https://github.com/PawanSikawat/faucet-stream/issues/411)).
</blockquote>

## `faucet-source-nats`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: NATS source — subscribes to a subject (core NATS with
  `*`/`>` wildcards and optional queue groups) or pulls from a durable
  JetStream consumer, drains with `max_messages` / `idle_timeout_secs`
  termination, and streams payloads as JSON with bounded memory. Conformance
  battery wired ([#411](https://github.com/PawanSikawat/faucet-stream/issues/411)).
</blockquote>

## `faucet-sink-nats`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: NATS sink — publishes each record as a JSON message to a
  fixed subject or a per-record subject (`subject_field`), flushing after each
  batch. Append-only. Conformance battery wired
  ([#411](https://github.com/PawanSikawat/faucet-stream/issues/411)).
</blockquote>

## `faucet-common-sftp`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: shared SFTP connection config (`SftpConnectionConfig`,
  `SftpAuth`, `HostKeyPolicy`) and the async `connect` helper used by the
  `faucet-source-sftp` and `faucet-sink-sftp` connectors. Password and
  private-key auth; host-key verification via strict / accept-new / insecure
  policies; secret-safe `Debug` ([#410](https://github.com/PawanSikawat/faucet-stream/issues/410)).
</blockquote>

## `faucet-source-sftp`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: SFTP source connector — lists a remote directory (or reads a
  single file) over SFTP and streams the files as JSON Lines, JSON arrays, or
  raw text with bounded memory. Filename glob filter, lazy connect, conformance
  battery wired ([#410](https://github.com/PawanSikawat/faucet-stream/issues/410)).
</blockquote>

## `faucet-sink-sftp`

<blockquote>

## [1.0.0] - 2026-07-28

### Features

- Initial release: SFTP sink connector — writes records to an SFTP server as
  JSON Lines objects under a remote directory. Atomic writes (upload to a
  temporary name, then rename into place), append-only, lazy connect with a
  reused session, conformance battery wired ([#410](https://github.com/PawanSikawat/faucet-stream/issues/410)).
</blockquote>

## `faucet-stream`

<blockquote>

## [1.6.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-stream-v1.5.0...faucet-stream-v1.6.0) - 2026-07-31

### Bug Fixes

- Keep transform additions a minor release — pin touched crates to 1.x

### Documentation

- Single source of truth for connector/crate counts
- *(gtm)* Elevate Singer on-ramp, fix conformance + connector-count drift
- *(readme)* Keep downloads badge link on faucet-stream
- *(readme)* Point downloads badge at faucet-core

### Features

- *(transform-wasm)* Add WebAssembly (wasmtime) per-record transform ([#124](https://github.com/PawanSikawat/faucet-stream/pull/124)) ([#426](https://github.com/PawanSikawat/faucet-stream/pull/426))
- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
- *(connectors)* Add DuckDB, SQS, NATS, SFTP connector pairs + Airtable REST recipe

### Testing

- *(conformance)* Wire the battery into delta/clickhouse/pubsub/azure-blob; fix databricks tier (#396, #397)
</blockquote>

## `faucet-cli`

<blockquote>

## [1.7.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-cli-v1.6.0...faucet-cli-v1.7.0) - 2026-07-31

### Bug Fixes

- Keep transform additions a minor release — pin touched crates to 1.x

### Features

- *(transform-wasm)* Add WebAssembly (wasmtime) per-record transform ([#124](https://github.com/PawanSikawat/faucet-stream/pull/124)) ([#426](https://github.com/PawanSikawat/faucet-stream/pull/426))
- *(iceberg)* Additive schema evolution via iceberg-rust 0.10.0 ([#255](https://github.com/PawanSikawat/faucet-stream/pull/255)); fix(cli): run summary → stderr ([#424](https://github.com/PawanSikawat/faucet-stream/pull/424)) ([#425](https://github.com/PawanSikawat/faucet-stream/pull/425))
- *(cli)* MCP server — agent-operable control plane ([#420](https://github.com/PawanSikawat/faucet-stream/pull/420)) ([#422](https://github.com/PawanSikawat/faucet-stream/pull/422))
- *(cli)* Topology mode — fan-out (tee), fan-in (merge), and cross-source join (#71, #72) ([#421](https://github.com/PawanSikawat/faucet-stream/pull/421))
- *(transforms)* [**breaking**] Hash / json_parse / coalesce / split / join, value_case title+capitalize, keys_case dot, stdout csv (#403–#409) — faucet-core 2.0.0 ([#418](https://github.com/PawanSikawat/faucet-stream/pull/418))
- *(connectors)* Add DuckDB, SQS, NATS, SFTP connector pairs + Airtable REST recipe

### Testing

- *(cli)* Whitelist SFTP_PASSWORD + AIRTABLE_* env for example-validate test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).