### PR TITLE
feat(cli): topology mode — fan-out (tee), fan-in (merge), cross-source join (#71, #72)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -882,6 +882,93 @@ metrics (`faucet_pipeline_adaptive_batch_*`).
 
 A state-key collision among siblings sharing a parent is detected upfront and errors with both offenders named.
 
+### Topology mode — fan-out (tee), fan-in (merge), and joins
+
+For pipelines that outgrow a single source → sink line, declare an explicit
+**node graph** instead of a matrix. Set `pipeline.nodes` (a map of node id →
+node) and `pipeline.edges` (producer → consumer connections). Topology mode is
+**mutually exclusive** with `matrix:` — setting both is an error.
+
+Each node is typed by `kind`:
+
+| `kind` | in | out | fields |
+|--------|----|-----|--------|
+| `source` | 0 | 1 | `ref:` (a `pipeline.sources` template) + optional `type`/`config` overrides |
+| `transform` | 1 | 1 | `transforms:` (same list syntax as elsewhere) |
+| `tee` | 1 | N | `channel_capacity` (default 4), optional `fanout` (must equal the outgoing-edge count) |
+| `merge` | N | 1 | — |
+| `join` | 2 | 1 | see below |
+| `sink` | 1 | 0 | `ref:` (a `pipeline.sinks` template) + optional `type`/`config` overrides |
+
+```yaml
+version: 1
+name: fan_out
+pipeline:
+  sources:
+    orders: { type: csv, config: { path: ./data/orders.csv } }
+  sinks:
+    warehouse: { type: jsonl, config: { path: ./out/warehouse.jsonl } }
+    archive:   { type: jsonl, config: { path: ./out/archive.jsonl } }
+  nodes:
+    src:  { kind: source, ref: orders }
+    fan:  { kind: tee, channel_capacity: 4, fanout: 2 }
+    w1:   { kind: sink, ref: warehouse }
+    w2:   { kind: sink, ref: archive }
+  edges:
+    - { from: src, to: fan }
+    - { from: fan, to: w1 }
+    - { from: fan, to: w2 }
+```
+
+**Execution.** Nodes run concurrently, connected by bounded channels — the
+slowest sink paces its producer (backpressure). A `tee` clones each page to
+every downstream edge; a `merge` forwards pages from all inputs in arrival
+order. Sink nodes reuse the normal streaming write path, so DLQ, bookmarks, and
+metrics work unchanged (`faucet_tee_records_total`, `faucet_merge_records_total`,
+`faucet_join_*`, labelled `pipeline` + `node`).
+
+**State.** Each terminal sink owns a bookmark under `{name}::{node_id}`. On
+restart the source resumes from the **minimum** across every sink's stored
+bookmark (only when all sinks have one), so a lagging sink is never skipped —
+sinks whose bookmarks have diverged must be idempotent.
+
+**`on_error`.** `execution.on_error: stop` aborts the whole topology on the
+first node failure; `continue` lets healthy branches finish and reports the
+failures at the end.
+
+#### `join:` — enrich one stream from another by key
+
+A `join` node hash-joins two upstreams: the **build** (right) side is buffered
+into an in-memory index keyed by `build.key`, then the **probe** (left) side is
+streamed and each record enriched with the `project`ed fields of its match. The
+join's two incoming edges carry `as:` labels matching `build.edge` /
+`probe.edge`.
+
+```yaml
+  nodes:
+    enrich:
+      kind: join
+      mode: left                 # `inner` drops non-matches; `left` keeps them
+      build: { edge: customers_in, key: id }
+      probe: { edge: orders_in,    key: customer_id }
+      project:
+        - { from: tier, as: customer_tier }
+      on_missing: null           # left-mode fill when no match
+      on_duplicate: first        # or `cartesian` (one row per build match)
+      on_collision: overwrite    # or `skip` / `error`
+      key_normalize: preserve    # or `stringify` ("42" == 42)
+      max_build_records: 10000000
+  edges:
+    - { from: fetch_customers, to: enrich, as: customers_in }
+    - { from: fetch_orders,    to: enrich, as: orders_in }
+    - { from: enrich,          to: write }
+```
+
+The build side is fully materialized before probing begins, so pair a large
+dimension table with a fast local source (SQLite/Parquet) rather than a slow
+remote API. Runnable examples:
+`cli/examples/topology_{tee_users,merge_files,join_orders_countries}.yaml`.
+
 ### State stores
 
 ```yaml

--- a/cli/examples/topology_join_orders_countries.yaml
+++ b/cli/examples/topology_join_orders_countries.yaml
@@ -1,0 +1,63 @@
+# Topology mode (#71) + cross-source join (#72).
+#
+# Enrich each order with its country name by joining `orders.country_code`
+# against `countries.code`. The `join` node buffers the build (right) side —
+# `countries` — into an in-memory hash index, then streams the probe (left)
+# side — `orders` — enriching each record with the projected fields.
+#
+#   faucet validate cli/examples/topology_join_orders_countries.yaml
+#   faucet run      cli/examples/topology_join_orders_countries.yaml
+#
+# The join's two incoming edges carry `as:` labels that match its
+# `build.edge` / `probe.edge` names.
+version: 1
+name: topology_join_orders_countries
+
+pipeline:
+  sources:
+    orders:
+      type: csv
+      config:
+        path: ./data/orders.csv
+    countries:
+      type: csv
+      config:
+        path: ./data/countries.csv
+  sinks:
+    enriched:
+      type: jsonl
+      config:
+        path: ./out/orders_enriched.jsonl
+
+  nodes:
+    read_orders:
+      kind: source
+      ref: orders
+    read_countries:
+      kind: source
+      ref: countries
+
+    enrich:
+      kind: join
+      mode: left                 # keep orders even when no country matches
+      build:
+        edge: countries_in       # right side — buffered as the lookup index
+        key: code
+      probe:
+        edge: orders_in          # left side — streamed
+        key: country_code
+      project:
+        - { from: country, as: country_name }
+      on_missing: "UNKNOWN"       # left-mode fill when no match
+      on_duplicate: first
+      on_collision: overwrite
+      key_normalize: preserve
+
+    write_enriched:
+      kind: sink
+      ref: enriched
+
+  edges:
+    - { from: read_countries, to: enrich, as: countries_in }
+    - { from: read_orders,    to: enrich, as: orders_in }
+    - { from: enrich,         to: write_enriched }

--- a/cli/examples/topology_merge_files.yaml
+++ b/cli/examples/topology_merge_files.yaml
@@ -1,0 +1,46 @@
+# Topology mode (#71): fan-in (merge).
+#
+# Two CSV sources are concatenated into one logical stream and written to a
+# single JSONL sink. A `merge` node forwards pages from all of its inputs in
+# arrival order (N in, 1 out).
+#
+#   faucet validate cli/examples/topology_merge_files.yaml
+#   faucet run      cli/examples/topology_merge_files.yaml
+version: 1
+name: topology_merge_files
+
+pipeline:
+  sources:
+    orders:
+      type: csv
+      config:
+        path: ./data/orders.csv
+    countries:
+      type: csv
+      config:
+        path: ./data/countries.csv
+  sinks:
+    combined:
+      type: jsonl
+      config:
+        path: ./out/combined.jsonl
+
+  nodes:
+    read_orders:
+      kind: source
+      ref: orders
+    read_countries:
+      kind: source
+      ref: countries
+
+    merge_all:
+      kind: merge
+
+    write_combined:
+      kind: sink
+      ref: combined
+
+  edges:
+    - { from: read_orders,    to: merge_all }
+    - { from: read_countries, to: merge_all }
+    - { from: merge_all,      to: write_combined }

--- a/cli/examples/topology_tee_users.yaml
+++ b/cli/examples/topology_tee_users.yaml
@@ -1,0 +1,67 @@
+# Topology mode (#71): fan-out (tee).
+#
+# One CSV source is fetched ONCE, keys are snake-cased, and the same records
+# are routed to three sinks in the same process — no refetch, no divergence.
+#
+#   faucet validate cli/examples/topology_tee_users.yaml
+#   faucet run      cli/examples/topology_tee_users.yaml
+#
+# `pipeline.nodes` + `edges` replace the matrix: each node is typed by `kind`
+# and edges connect producers to consumers. A `tee` node clones every page to
+# each of its outgoing edges; the slowest sink paces the source (backpressure).
+version: 1
+name: topology_tee_users
+
+pipeline:
+  # Named templates the nodes reference via `ref:`.
+  sources:
+    orders:
+      type: csv
+      config:
+        path: ./data/orders.csv
+  sinks:
+    archive:
+      type: jsonl
+      config:
+        path: ./out/orders_archive.jsonl
+    warehouse:
+      type: jsonl
+      config:
+        path: ./out/orders_warehouse.jsonl
+    audit:
+      type: stdout
+      config:
+        format: json_lines
+
+  nodes:
+    fetch_orders:
+      kind: source
+      ref: orders
+
+    normalize:
+      kind: transform
+      transforms:
+        - type: keys_case
+          config: { mode: snake }
+
+    tee_orders:
+      kind: tee
+      channel_capacity: 4
+      fanout: 3
+
+    write_archive:
+      kind: sink
+      ref: archive
+    write_warehouse:
+      kind: sink
+      ref: warehouse
+    write_audit:
+      kind: sink
+      ref: audit
+
+  edges:
+    - { from: fetch_orders, to: normalize }
+    - { from: normalize,    to: tee_orders }
+    - { from: tee_orders,   to: write_archive }
+    - { from: tee_orders,   to: write_warehouse }
+    - { from: tee_orders,   to: write_audit }

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -30,6 +30,12 @@ pub async fn run(args: PreviewArgs) -> CliResult<()> {
     };
     let cfg = PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
     let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
+
+    // Topology mode (#71/#72): preview the source side of each source node.
+    if crate::topology::is_topology(&cfg) {
+        return crate::topology::preview(&cfg, &auth, args.limit).await;
+    }
+
     let nodes = expand(&cfg)?;
     // Apply runtime row selection so `preview` previews the first root of the
     // selected run set (#370/#371/#376/#377).

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -145,6 +145,23 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     });
 
     let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
+
+    // Topology mode (#71/#72): an explicit `pipeline.nodes` graph replaces the
+    // matrix entirely. Run it directly and report through the same summary
+    // surfaces (`--output text|json|ndjson`), then return.
+    if crate::topology::is_topology(&cfg) {
+        let started_at = Utc::now();
+        let summary = crate::topology::run_topology(&cfg, &auth, None).await?;
+        let finished_at = Utc::now();
+        return finish_topology_run(
+            &pipeline_name,
+            started_at,
+            finished_at,
+            &summary,
+            args.output,
+        );
+    }
+
     #[cfg(feature = "lineage")]
     let lineage = crate::lineage_glue::build_emitter(cfg.lineage.as_ref())
         .map_err(|e| CliError::Config(format!("lineage: {e}")))?;
@@ -405,6 +422,64 @@ pub(crate) fn summary_document(
         totals,
         rows,
     }
+}
+
+/// Report a topology-mode run through the same `--output` surfaces as a matrix
+/// run, then map any node failures to the process exit code (#71/#72).
+fn finish_topology_run(
+    pipeline_name: &str,
+    started_at: DateTime<Utc>,
+    finished_at: DateTime<Utc>,
+    summary: &RunSummary,
+    output: RunOutput,
+) -> CliResult<()> {
+    let total_written: usize = summary.invocations.iter().map(|i| i.records_written).sum();
+    let failed = summary.failure_count();
+    let success = summary.invocations.len() - failed;
+
+    tracing::info!(
+        pipeline = %pipeline_name,
+        nodes = summary.invocations.len(),
+        succeeded = success,
+        failed,
+        records_written = total_written,
+        "topology completed"
+    );
+
+    match output {
+        RunOutput::Text => println!(
+            "{}: {} sink node{}, {} ok, {} failed, wrote {} record{}",
+            pipeline_name,
+            summary.invocations.len(),
+            if summary.invocations.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
+            success,
+            failed,
+            total_written,
+            if total_written == 1 { "" } else { "s" }
+        ),
+        RunOutput::Json => {
+            let doc = summary_document(pipeline_name, started_at, finished_at, summary);
+            let rendered = serde_json::to_string_pretty(&doc).unwrap_or_else(|_| "{}".to_string());
+            println!("{}", crate::secrets::registry::redact(&rendered));
+        }
+        RunOutput::Ndjson => {
+            for row in summary_rows(summary) {
+                let line = serde_json::to_string(&row).unwrap_or_else(|_| "{}".to_string());
+                println!("{}", crate::secrets::registry::redact(&line));
+            }
+        }
+    }
+
+    faucet_core::shutdown_otel();
+
+    if summary.had_failures() {
+        return Err(CliError::TopologyHadFailures { count: failed });
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -47,6 +47,24 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         }
         cfg
     };
+    // Topology mode (#71/#72): build + validate the node graph instead of the
+    // matrix. `build_topology` runs the core structural validator (arity,
+    // fan-out, join edges, cycle, reachability).
+    if crate::topology::is_topology(&cfg) {
+        let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
+        let topo = crate::topology::build_topology(&cfg, &auth).await?;
+        println!(
+            "topology '{}': {} node(s), {} edge(s) — valid",
+            cfg.name.as_deref().unwrap_or("unnamed"),
+            topo.nodes().len(),
+            topo.edges().len()
+        );
+        for n in topo.nodes() {
+            println!("  - {} ({})", n.id, n.kind.kind_str());
+        }
+        return Ok(());
+    }
+
     let nodes = expand(&cfg)?;
 
     // Validate the replication block (snapshot source / CDC source / state) so

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -209,6 +209,137 @@ pub struct PipelineSpec {
     /// Schema-drift handling policy (pipeline-level; no matrix-row override in v1).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema: Option<faucet_core::SchemaDriftSpec>,
+
+    /// Topology-mode nodes (issue #71): an explicit graph of typed nodes
+    /// (`source` / `transform` / `tee` / `merge` / `join` / `sink`) keyed by
+    /// node id. When non-empty this pipeline runs in **topology mode** and the
+    /// top-level `matrix:` block must be empty (they are mutually exclusive).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub nodes: HashMap<String, NodeSpec>,
+
+    /// Topology-mode edges connecting `nodes` (issue #71). Each edge names a
+    /// producer (`from`) and consumer (`to`); a join's incoming edges also
+    /// carry an `as:` label matching the join's `build`/`probe` edge names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edges: Vec<EdgeSpec>,
+}
+
+/// A single topology node (issue #71). The `kind` discriminator selects the
+/// node type; the remaining fields are kind-specific.
+///
+/// `source` / `sink` nodes pick a template with `ref:` (defaulting to
+/// `default`) and may override `type` / `config` inline — the same shape as a
+/// matrix row's [`PartialConnector`]. `transform` carries a `transforms:`
+/// list. `tee` carries `channel_capacity` + optional `fanout`. `merge` has no
+/// extra fields. `join` carries the hash-join configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum NodeSpec {
+    /// A data source (0 in, 1 out).
+    Source {
+        /// Template name in `pipeline.sources` (defaults to `default`).
+        #[serde(rename = "ref", default, skip_serializing_if = "Option::is_none")]
+        template: Option<String>,
+        /// Inline connector-type override.
+        #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+        kind: Option<String>,
+        /// Inline config override (deep-merged onto the resolved template).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        config: Option<Value>,
+    },
+    /// A data sink (1 in, 0 out).
+    Sink {
+        /// Template name in `pipeline.sinks` (defaults to `default`).
+        #[serde(rename = "ref", default, skip_serializing_if = "Option::is_none")]
+        template: Option<String>,
+        /// Inline connector-type override.
+        #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+        kind: Option<String>,
+        /// Inline config override (deep-merged onto the resolved template).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        config: Option<Value>,
+    },
+    /// Transform stages applied per page (1 in, 1 out).
+    Transform {
+        /// Transform stages, in order.
+        #[serde(default)]
+        transforms: Vec<TransformSpec>,
+    },
+    /// Fan-out: clone each page to every downstream edge (1 in, N out).
+    Tee {
+        /// Bounded-channel capacity for each outgoing edge.
+        #[serde(default = "default_channel_capacity")]
+        channel_capacity: usize,
+        /// Optional expected fan-out (outgoing edge count) sanity check.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fanout: Option<usize>,
+    },
+    /// Fan-in: forward pages from all inputs in arrival order (N in, 1 out).
+    Merge,
+    /// Hash-join two upstreams by key (2 in, 1 out).
+    Join(JoinSpec),
+}
+
+/// The `join:` node configuration (issue #72).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct JoinSpec {
+    /// `inner` (drop non-matches) or `left` (keep non-matches).
+    #[serde(default)]
+    pub mode: faucet_core::JoinMode,
+    /// The build (right) side — fully buffered as a lookup index.
+    pub build: JoinSide,
+    /// The probe (left) side — streamed and enriched.
+    pub probe: JoinSide,
+    /// Fields to copy from the matched build record onto the probe record.
+    #[serde(default)]
+    pub project: Vec<faucet_core::Projection>,
+    /// Value used to fill projected fields on a `left`-mode non-match.
+    #[serde(default)]
+    pub on_missing: Value,
+    /// Multi-match policy: `first` or `cartesian`.
+    #[serde(default)]
+    pub on_duplicate: faucet_core::OnDuplicate,
+    /// Projection-collision policy: `overwrite` / `skip` / `error`.
+    #[serde(default)]
+    pub on_collision: faucet_core::OnCollision,
+    /// Key normalization: `preserve` (no coercion) or `stringify`.
+    #[serde(default)]
+    pub key_normalize: faucet_core::KeyNormalize,
+    /// Safety cap on build-side records.
+    #[serde(default = "default_max_build_records")]
+    pub max_build_records: usize,
+}
+
+/// One side of a [`JoinSpec`]: the incoming edge label plus the dotted key path.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct JoinSide {
+    /// Name of the incoming edge (matches an `edges[].as` label).
+    pub edge: String,
+    /// Dotted path to the join key inside each record on this side.
+    pub key: String,
+}
+
+/// A topology edge (issue #71).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EdgeSpec {
+    /// Producer node id.
+    pub from: String,
+    /// Consumer node id.
+    pub to: String,
+    /// Optional edge label (required on a join's two incoming edges).
+    #[serde(rename = "as", default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+fn default_channel_capacity() -> usize {
+    faucet_core::topology::DEFAULT_CHANNEL_CAPACITY
+}
+
+fn default_max_build_records() -> usize {
+    faucet_core::join::DEFAULT_MAX_BUILD_RECORDS
 }
 
 /// A `{ type, config }` block, the universal shape for both sources and sinks.

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -328,6 +328,9 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
             #[cfg(feature = "masking")]
             masking: None,
             schema: None,
+            // Pure-env mode does not assemble a topology graph.
+            nodes: std::collections::HashMap::new(),
+            edges: Vec::new(),
         },
         matrix: Vec::new(),
         execution: None,

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -174,6 +174,26 @@ pub enum CliError {
     #[error("{count} pipeline invocation(s) failed (see logs above for details)")]
     PipelineHadFailures { count: usize },
 
+    /// Both `pipeline.nodes` (topology mode) and `matrix:` are non-empty.
+    /// They are mutually exclusive: topology mode replaces the matrix.
+    #[error(
+        "`pipeline.nodes` (topology mode) and `matrix:` are mutually exclusive — set one or the other, not both"
+    )]
+    MatrixAndNodesBothPresent,
+
+    /// A topology edge references a node id that doesn't exist in `nodes:`.
+    #[error("topology edge references unknown node '{name}' (known nodes: {})", known.join(", "))]
+    EdgeEndpointMissing { name: String, known: Vec<String> },
+
+    /// A topology graph-structure violation (arity, fan-out, join edges,
+    /// cycle, reachability) reported by the core validator.
+    #[error("invalid topology: {message}")]
+    InvalidTopology { message: String },
+
+    /// One or more topology sink nodes failed under `on_error: continue`.
+    #[error("{count} topology node(s) failed (see logs above for details)")]
+    TopologyHadFailures { count: usize },
+
     /// DLQ sink kind is not registered (not compiled in or feature disabled).
     #[error("DLQ sink kind `{kind}` is not registered (in {context})")]
     UnknownDlqSinkKind { kind: String, context: String },

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1939,6 +1939,8 @@ mod tests {
                 #[cfg(feature = "masking")]
                 masking: None,
                 schema: None,
+                nodes: std::collections::HashMap::new(),
+                edges: Vec::new(),
             },
             matrix: Vec::new(),
             execution: None,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -54,6 +54,7 @@ pub mod select;
 pub mod serve;
 pub mod sla;
 pub mod state;
+pub mod topology;
 pub mod transforms;
 #[cfg(feature = "cli-tui")]
 pub mod tui;

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -1,0 +1,293 @@
+//! Topology mode (issues #71 / #72): build and run a
+//! [`faucet_core::Topology`] from a config's `pipeline.nodes` / `edges` block.
+//!
+//! When `pipeline.nodes` is non-empty the pipeline runs as an explicit node
+//! graph rather than a matrix. This module resolves each node's connector
+//! templates, compiles its transforms, wires the edges, and drives the core
+//! topology executor — reusing [`crate::registry`] for connector construction
+//! and [`crate::state`] / [`crate::executor::build_dlq_config`] for the
+//! sink-side plumbing.
+
+use crate::auth_catalog::AuthCatalog;
+use crate::config::{ConnectorSpec, NodeSpec, PipelineConfig};
+use crate::error::{CliError, CliResult};
+use crate::executor::{InvocationOutcome, RunSummary};
+use crate::merge::merge_value;
+use crate::registry::{build_sink, build_source};
+use crate::transforms::compile_transforms;
+use faucet_core::stage::compile_stage;
+use faucet_core::topology::{
+    JoinConfig, JoinNode, NodeKind, Topology, TopologyOnError, TopologyOptions,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use tokio_util::sync::CancellationToken;
+
+/// Whether the config selects topology mode (a non-empty `pipeline.nodes`).
+pub fn is_topology(cfg: &PipelineConfig) -> bool {
+    !cfg.pipeline.nodes.is_empty()
+}
+
+/// Resolve one source/sink node's template `ref` + inline overrides into a
+/// concrete `(kind, config)` pair.
+fn resolve_connector(
+    templates: &HashMap<String, ConnectorSpec>,
+    legacy: &Option<ConnectorSpec>,
+    template_ref: Option<&str>,
+    kind_override: Option<&str>,
+    config_override: Option<&Value>,
+    node_id: &str,
+    kind_label: &'static str,
+) -> CliResult<(String, Value)> {
+    let name = template_ref.unwrap_or("default");
+    let base: ConnectorSpec = if name == "default" {
+        templates
+            .get("default")
+            .cloned()
+            .or_else(|| legacy.clone())
+            .ok_or(CliError::MissingTemplate {
+                kind: kind_label,
+                row_id: node_id.to_string(),
+            })?
+    } else {
+        templates
+            .get(name)
+            .cloned()
+            .ok_or_else(|| CliError::UnknownTemplate {
+                kind: kind_label,
+                name: name.to_string(),
+                row_id: node_id.to_string(),
+                known: {
+                    let mut k: Vec<String> = templates.keys().cloned().collect();
+                    if legacy.is_some() {
+                        k.push("default".to_string());
+                    }
+                    k.sort();
+                    k
+                },
+            })?
+    };
+    let mut kind = base.kind;
+    let mut config = base.config;
+    if let Some(k) = kind_override {
+        kind = k.to_string();
+    }
+    if let Some(c) = config_override {
+        merge_value(&mut config, c.clone());
+    }
+    Ok((kind, config))
+}
+
+/// Build a [`faucet_core::Topology`] from the config's `pipeline.nodes` /
+/// `edges` block.
+pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResult<Topology> {
+    if !cfg.matrix.is_empty() {
+        return Err(CliError::MatrixAndNodesBothPresent);
+    }
+
+    let spec = &cfg.pipeline;
+    let mut builder = Topology::builder();
+
+    // Deterministic node order (sorted by id) so errors/logs are stable.
+    let mut node_ids: Vec<&String> = spec.nodes.keys().collect();
+    node_ids.sort();
+
+    for id in &node_ids {
+        let node = &spec.nodes[*id];
+        let kind: NodeKind = match node {
+            NodeSpec::Source {
+                template,
+                kind,
+                config,
+            } => {
+                let (k, c) = resolve_connector(
+                    &spec.sources,
+                    &spec.source,
+                    template.as_deref(),
+                    kind.as_deref(),
+                    config.as_ref(),
+                    id,
+                    "source",
+                )?;
+                NodeKind::Source(build_source(&k, c, auth, None).await?)
+            }
+            NodeSpec::Sink {
+                template,
+                kind,
+                config,
+            } => {
+                let (k, c) = resolve_connector(
+                    &spec.sinks,
+                    &spec.sink,
+                    template.as_deref(),
+                    kind.as_deref(),
+                    config.as_ref(),
+                    id,
+                    "sink",
+                )?;
+                NodeKind::Sink(build_sink(&k, c, auth).await?)
+            }
+            NodeSpec::Transform { transforms } => {
+                let stages = compile_transforms(transforms)?;
+                let compiled = stages
+                    .iter()
+                    .map(compile_stage)
+                    .collect::<Result<Vec<_>, _>>()?;
+                NodeKind::Transform(compiled)
+            }
+            NodeSpec::Tee {
+                channel_capacity,
+                fanout,
+            } => NodeKind::Tee {
+                capacity: *channel_capacity,
+                fanout: *fanout,
+            },
+            NodeSpec::Merge => NodeKind::Merge,
+            NodeSpec::Join(js) => NodeKind::Join(JoinNode {
+                config: JoinConfig {
+                    mode: js.mode,
+                    build_key: js.build.key.clone(),
+                    probe_key: js.probe.key.clone(),
+                    projections: js.project.clone(),
+                    on_missing: js.on_missing.clone(),
+                    on_duplicate: js.on_duplicate,
+                    on_collision: js.on_collision,
+                    key_normalize: js.key_normalize,
+                    max_build_records: js.max_build_records,
+                },
+                build_edge: js.build.edge.clone(),
+                probe_edge: js.probe.edge.clone(),
+            }),
+        };
+        builder = builder.node((*id).clone(), kind);
+    }
+
+    // Validate edge endpoints up front for a friendly error, then wire them.
+    let known: Vec<String> = node_ids.iter().map(|s| (*s).clone()).collect();
+    for e in &spec.edges {
+        if !spec.nodes.contains_key(&e.from) {
+            return Err(CliError::EdgeEndpointMissing {
+                name: e.from.clone(),
+                known: known.clone(),
+            });
+        }
+        if !spec.nodes.contains_key(&e.to) {
+            return Err(CliError::EdgeEndpointMissing {
+                name: e.to.clone(),
+                known: known.clone(),
+            });
+        }
+        builder = match &e.label {
+            Some(label) => builder.labelled_edge(e.from.clone(), e.to.clone(), label.clone()),
+            None => builder.edge(e.from.clone(), e.to.clone()),
+        };
+    }
+
+    builder.build().map_err(|e| CliError::InvalidTopology {
+        message: e.to_string(),
+    })
+}
+
+/// Preview topology mode: build each `source` node and print the first
+/// `limit` records per source to stdout as JSON Lines (source side only —
+/// downstream nodes are not run, mirroring matrix-mode `faucet preview`).
+pub async fn preview(cfg: &PipelineConfig, auth: &AuthCatalog, limit: usize) -> CliResult<()> {
+    if !cfg.matrix.is_empty() {
+        return Err(CliError::MatrixAndNodesBothPresent);
+    }
+    let spec = &cfg.pipeline;
+    let mut ids: Vec<&String> = spec.nodes.keys().collect();
+    ids.sort();
+
+    let mut previewed = false;
+    for id in ids {
+        if let NodeSpec::Source {
+            template,
+            kind,
+            config,
+        } = &spec.nodes[id]
+        {
+            let (k, c) = resolve_connector(
+                &spec.sources,
+                &spec.source,
+                template.as_deref(),
+                kind.as_deref(),
+                config.as_ref(),
+                id,
+                "source",
+            )?;
+            let source = build_source(&k, c, auth, None).await?;
+            tracing::info!(node = %id, "previewing source node");
+            let records = source.fetch_all().await?;
+            for rec in records.into_iter().take(limit) {
+                println!("{}", serde_json::to_string(&rec).unwrap_or_default());
+            }
+            previewed = true;
+        }
+    }
+    if !previewed {
+        return Err(CliError::InvalidTopology {
+            message: "no source nodes to preview".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Build and run the topology, returning a [`RunSummary`] shaped like a matrix
+/// run (one invocation per sink node, plus one per node failure under
+/// `on_error: continue`).
+pub async fn run_topology(
+    cfg: &PipelineConfig,
+    auth: &AuthCatalog,
+    cancel: Option<CancellationToken>,
+) -> CliResult<RunSummary> {
+    let topo = build_topology(cfg, auth).await?;
+
+    let pipeline_name = cfg.name.clone().unwrap_or_else(|| "unnamed".to_string());
+    let run_id = uuid::Uuid::now_v7().to_string();
+
+    let on_error = match cfg.execution.as_ref().map(|e| e.on_error) {
+        Some(crate::config::OnError::Stop) => TopologyOnError::Propagate,
+        _ => TopologyOnError::Continue,
+    };
+
+    let mut opts = TopologyOptions::new(pipeline_name).with_on_error(on_error);
+    opts.run_id = run_id;
+
+    if let Some(state) = &cfg.pipeline.state {
+        opts = opts.with_state_store(crate::state::build_state_store(state).await?);
+    }
+    if let Some(dlq) = &cfg.pipeline.dlq {
+        opts = opts.with_dlq(crate::executor::build_dlq_config(dlq).await?);
+    }
+    if let Some(c) = cancel {
+        opts = opts.with_cancel(c);
+    }
+
+    let result = topo.run(opts).await?;
+
+    let mut invocations: Vec<InvocationOutcome> = result
+        .per_sink
+        .into_iter()
+        .map(|(node_id, records)| InvocationOutcome {
+            row_id: node_id,
+            parent_record_key: None,
+            records_written: records,
+            error: None,
+            metrics: None,
+        })
+        .collect();
+    invocations.sort_by(|a, b| a.row_id.cmp(&b.row_id));
+
+    for msg in result.errors {
+        invocations.push(InvocationOutcome {
+            row_id: "topology".to_string(),
+            parent_record_key: None,
+            records_written: 0,
+            error: Some(msg),
+            metrics: None,
+        });
+    }
+
+    Ok(RunSummary { invocations })
+}

--- a/cli/tests/examples_roundtrip.rs
+++ b/cli/tests/examples_roundtrip.rs
@@ -88,6 +88,13 @@ fn every_example_loads_and_expands() {
                 continue;
             }
         };
+        // Topology-mode examples (`pipeline.nodes`) are not matrix rows, so
+        // `expand` (matrix-only) does not apply. The parse above already
+        // validated their structure; graph validation is covered by
+        // `topology_end_to_end.rs`.
+        if !cfg.pipeline.nodes.is_empty() {
+            continue;
+        }
         if let Err(e) = expand(&cfg) {
             failures.push(format!("expand {}: {e}", path.display()));
         }

--- a/cli/tests/topology_end_to_end.rs
+++ b/cli/tests/topology_end_to_end.rs
@@ -1,0 +1,669 @@
+//! Topology mode (#71 / #72) end-to-end tests: fan-out (tee), fan-in (merge),
+//! and cross-source join, plus the config-validation error paths.
+//!
+//! Binary-driven tests exercise the `run` / `validate` / `preview` command
+//! wiring via `assert_cmd`; the error-path tests call
+//! `faucet_cli::topology::build_topology` directly to assert the typed
+//! `CliError` variants.
+#![cfg(all(
+    feature = "source-csv",
+    feature = "sink-jsonl",
+    feature = "sink-stdout",
+    feature = "transforms"
+))]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+}
+
+fn orders_csv(dir: &Path) -> std::path::PathBuf {
+    let p = dir.join("orders.csv");
+    write(
+        &p,
+        "order_id,country_code,amount\n1,US,10\n2,US,5\n3,IN,7\n4,DE,3\n",
+    );
+    p
+}
+
+fn countries_csv(dir: &Path) -> std::path::PathBuf {
+    let p = dir.join("countries.csv");
+    write(&p, "code,country\nUS,United States\nIN,India\nDE,Germany\n");
+    p
+}
+
+// ── tee (fan-out) ─────────────────────────────────────────────────────────────
+
+#[test]
+fn tee_fans_out_to_two_sinks() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let a = dir.path().join("a.jsonl");
+    let b = dir.path().join("b.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: tee_test
+pipeline:
+  sources:
+    orders: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    a: {{ type: jsonl, config: {{ path: {a} }} }}
+    b: {{ type: jsonl, config: {{ path: {b} }} }}
+  nodes:
+    # `config` inline override (deep-merged onto the template) + a transform node.
+    src: {{ kind: source, ref: orders, config: {{ batch_size: 2 }} }}
+    norm: {{ kind: transform, transforms: [ {{ type: keys_case, config: {{ mode: snake }} }} ] }}
+    fan: {{ kind: tee, channel_capacity: 2, fanout: 2 }}
+    # `type` inline override (same kind as the template — exercises the override path).
+    wa: {{ kind: sink, ref: a, type: jsonl }}
+    wb: {{ kind: sink, ref: b }}
+  edges:
+    - {{ from: src, to: norm }}
+    - {{ from: norm, to: fan }}
+    - {{ from: fan, to: wa }}
+    - {{ from: fan, to: wb }}
+"#,
+            csv = csv.display(),
+            a = a.display(),
+            b = b.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("2 sink node"));
+
+    assert_eq!(fs::read_to_string(&a).unwrap().lines().count(), 4);
+    assert_eq!(fs::read_to_string(&b).unwrap().lines().count(), 4);
+}
+
+// ── merge (fan-in) ────────────────────────────────────────────────────────────
+
+#[test]
+fn merge_fans_in_two_sources() {
+    let dir = TempDir::new().unwrap();
+    let orders = orders_csv(dir.path());
+    let countries = countries_csv(dir.path());
+    let out = dir.path().join("combined.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: merge_test
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {orders} }} }}
+    c: {{ type: csv, config: {{ path: {countries} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    ro: {{ kind: source, ref: o }}
+    rc: {{ kind: source, ref: c }}
+    m: {{ kind: merge }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: ro, to: m }}
+    - {{ from: rc, to: m }}
+    - {{ from: m, to: w }}
+"#,
+            orders = orders.display(),
+            countries = countries.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success();
+
+    // 4 orders + 3 countries.
+    assert_eq!(fs::read_to_string(&out).unwrap().lines().count(), 7);
+}
+
+// ── join ───────────────────────────────────────────────────────────────────────
+
+#[test]
+fn join_enriches_orders_with_country() {
+    let dir = TempDir::new().unwrap();
+    let orders = orders_csv(dir.path());
+    let countries = countries_csv(dir.path());
+    let out = dir.path().join("enriched.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: join_test
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {orders} }} }}
+    c: {{ type: csv, config: {{ path: {countries} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    ro: {{ kind: source, ref: o }}
+    rc: {{ kind: source, ref: c }}
+    j:
+      kind: join
+      mode: left
+      build: {{ edge: c_in, key: code }}
+      probe: {{ edge: o_in, key: country_code }}
+      project:
+        - {{ from: country, as: country_name }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: rc, to: j, as: c_in }}
+    - {{ from: ro, to: j, as: o_in }}
+    - {{ from: j, to: w }}
+"#,
+            orders = orders.display(),
+            countries = countries.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success();
+
+    let body = fs::read_to_string(&out).unwrap();
+    assert_eq!(body.lines().count(), 4);
+    assert!(body.contains("\"country_name\":\"United States\""));
+    assert!(body.contains("\"country_name\":\"India\""));
+    assert!(body.contains("\"country_name\":\"Germany\""));
+}
+
+// ── validate + preview ──────────────────────────────────────────────────────────
+
+#[test]
+fn validate_reports_topology_summary() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("o.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: validate_test
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("2 node(s), 1 edge(s) — valid"));
+}
+
+#[test]
+fn preview_prints_source_records() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("o.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: preview_test
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["preview", "--limit", "2"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("order_id"));
+}
+
+// ── error paths (direct calls) ───────────────────────────────────────────────────
+
+use faucet_cli::auth_catalog::build_auth_catalog;
+use faucet_cli::config::PipelineConfig;
+use faucet_cli::error::CliError;
+use faucet_cli::topology::build_topology;
+
+fn parse(yaml: &str) -> PipelineConfig {
+    PipelineConfig::from_text(yaml, Path::new("test.yaml")).expect("parses")
+}
+
+#[tokio::test]
+async fn rejects_matrix_and_nodes_together() {
+    let cfg = parse(
+        r#"version: 1
+name: both
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+matrix:
+  - id: extra
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    assert!(matches!(err, CliError::MatrixAndNodesBothPresent));
+}
+
+#[tokio::test]
+async fn rejects_edge_to_unknown_node() {
+    let cfg = parse(
+        r#"version: 1
+name: badedge
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: ghost }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    assert!(
+        matches!(err, CliError::EdgeEndpointMissing { ref name, .. } if name == "ghost"),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_unknown_template_ref() {
+    let cfg = parse(
+        r#"version: 1
+name: badref
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: nonexistent }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    assert!(matches!(err, CliError::UnknownTemplate { .. }), "{err:?}");
+}
+
+#[tokio::test]
+async fn rejects_edge_from_unknown_node() {
+    let cfg = parse(
+        r#"version: 1
+name: badfrom
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: ghost, to: w }
+    - { from: s, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    assert!(
+        matches!(err, CliError::EdgeEndpointMissing { ref name, .. } if name == "ghost"),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn preview_rejects_matrix_and_nodes() {
+    let cfg = parse(
+        r#"version: 1
+name: pv_both
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+matrix:
+  - id: extra
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = faucet_cli::topology::preview(&cfg, &auth, 5)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CliError::MatrixAndNodesBothPresent));
+}
+
+#[tokio::test]
+async fn preview_errors_when_no_source_node() {
+    // A nodes map with no `source` kind: preview finds nothing to emit.
+    let cfg = parse(
+        r#"version: 1
+name: pv_nosrc
+pipeline:
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    w: { kind: sink, ref: out }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = faucet_cli::topology::preview(&cfg, &auth, 5)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CliError::InvalidTopology { .. }), "{err:?}");
+}
+
+#[tokio::test]
+async fn run_topology_direct_with_uncancelled_token() {
+    // Exercises `run_topology` directly (records-written mapping + the cancel
+    // branch) with a non-cancelled token.
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("o.jsonl");
+    let cfg = parse(&format!(
+        r#"version: 1
+name: direct_run
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+        csv = csv.display(),
+        out = out.display()
+    ));
+    let auth = build_auth_catalog(None).unwrap();
+    let cancel = faucet_core::CancellationToken::new();
+    let summary = faucet_cli::topology::run_topology(&cfg, &auth, Some(cancel))
+        .await
+        .unwrap();
+    assert_eq!(summary.invocations.len(), 1);
+    assert_eq!(summary.invocations[0].records_written, 4);
+    assert_eq!(summary.invocations[0].row_id, "w");
+}
+
+#[tokio::test]
+async fn rejects_missing_default_template() {
+    // A source node with no `ref` defaults to the `default` template; with only
+    // a named template and no legacy `pipeline.source`, that is a MissingTemplate.
+    let cfg = parse(
+        r#"version: 1
+name: nodefault
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    assert!(matches!(err, CliError::MissingTemplate { .. }), "{err:?}");
+}
+
+// ── run-command coverage: state, on_error, output formats, failures ──────────────
+
+#[test]
+fn run_with_state_and_stop_on_error() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("o.jsonl");
+    let state = dir.path().join("state");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: state_stop
+execution:
+  on_error: stop
+pipeline:
+  state: {{ type: file, config: {{ path: {state} }} }}
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            state = state.display(),
+            csv = csv.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success();
+    assert_eq!(fs::read_to_string(&out).unwrap().lines().count(), 4);
+}
+
+#[test]
+fn run_output_json_and_ndjson() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("o.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: outfmt
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--output", "json"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("totals"));
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--output", "ndjson"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("\"row_id\""));
+}
+
+#[test]
+fn run_with_dlq_block() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("o.jsonl");
+    let dlq = dir.path().join("dlq.jsonl");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: dlq_topo
+pipeline:
+  dlq:
+    sink: {{ type: jsonl, config: {{ path: {dlq} }} }}
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            dlq = dlq.display(),
+            csv = csv.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success();
+    // Happy path: everything written to the main sink, nothing to the DLQ.
+    assert_eq!(fs::read_to_string(&out).unwrap().lines().count(), 4);
+}
+
+#[test]
+fn run_reports_node_failure_under_continue() {
+    // A source pointed at a missing file fails; under the default `continue`
+    // policy the run exits non-zero with a TopologyHadFailures error.
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("o.jsonl");
+    let missing = dir.path().join("does_not_exist.csv");
+    let cfg = dir.path().join("faucet.yaml");
+    write(
+        &cfg,
+        &format!(
+            r#"version: 1
+name: failrun
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {missing} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            missing = missing.display(),
+            out = out.display()
+        ),
+    );
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .failure();
+}
+
+#[tokio::test]
+async fn rejects_invalid_graph_arity() {
+    // A source with an incoming edge is an arity violation caught by the core
+    // validator and surfaced as InvalidTopology.
+    let cfg = parse(
+        r#"version: 1
+name: badarity
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+    - { from: w, to: s }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    assert!(matches!(err, CliError::InvalidTopology { .. }), "{err:?}");
+}

--- a/crates/core/src/join.rs
+++ b/crates/core/src/join.rs
@@ -1,0 +1,799 @@
+//! Pure hash-join logic for the topology `join` node (issue #72).
+//!
+//! A [`HashJoin`] buffers one upstream (the **build** side) into an in-memory
+//! index keyed by a configurable dotted path, then enriches records streamed
+//! from the other upstream (the **probe** side) with projected fields looked
+//! up from the matching build record. This is the classic *hash-join* shape:
+//! the build side is fully materialized before the probe side starts emitting.
+//!
+//! This module is **pure data logic** — no I/O, no channels, no `async`. The
+//! topology executor ([`crate::topology`]) owns the streaming/channel plumbing
+//! and calls [`HashJoin::add_build_page`] / [`HashJoin::probe_page`] as pages
+//! arrive. Keeping it pure makes every join semantic unit-testable in
+//! isolation (see the extensive tests at the bottom of this file).
+//!
+//! ## Semantics
+//!
+//! - **`inner`** drops probe records with no build-side match.
+//! - **`left`** passes probe records through for non-matches, filling the
+//!   projected fields with [`JoinConfig::on_missing`].
+//! - **`on_duplicate`** decides what happens when one probe key matches more
+//!   than one build record: [`OnDuplicate::First`] keeps the first, and
+//!   [`OnDuplicate::Cartesian`] emits one enriched record per match.
+//! - **`on_collision`** decides what happens when a projected `as` name
+//!   already exists on the probe record.
+//! - **`key_normalize`** controls whether `"42"` (string) and `42` (number)
+//!   are treated as the same key ([`KeyNormalize::Stringify`]) or as distinct
+//!   keys ([`KeyNormalize::Preserve`], the default — no coercion).
+
+use crate::error::FaucetError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Default safety cap on build-side records (10M).
+pub const DEFAULT_MAX_BUILD_RECORDS: usize = 10_000_000;
+
+/// Join mode — how probe records with no build match are handled.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum JoinMode {
+    /// Drop probe records that have no matching build record.
+    #[default]
+    Inner,
+    /// Pass probe records through even without a match, filling projected
+    /// fields from [`JoinConfig::on_missing`].
+    Left,
+}
+
+impl std::fmt::Display for JoinMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            JoinMode::Inner => "inner",
+            JoinMode::Left => "left",
+        })
+    }
+}
+
+/// What to do when one probe key matches more than one build record.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OnDuplicate {
+    /// Keep only the first build-side match (deterministic given build order).
+    #[default]
+    First,
+    /// Emit one enriched record per build-side match (may duplicate the probe
+    /// record).
+    Cartesian,
+}
+
+/// What to do when a projected `as` name collides with an existing field on
+/// the probe record.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OnCollision {
+    /// Overwrite the probe record's field with the projected value.
+    #[default]
+    Overwrite,
+    /// Leave the probe record's field untouched; skip the projection.
+    Skip,
+    /// Fail the record with a typed error.
+    Error,
+}
+
+/// How to normalize keys before comparison.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyNormalize {
+    /// Compare keys as their JSON value (no coercion): `"42"` != `42`.
+    #[default]
+    Preserve,
+    /// Coerce scalar keys to their string form before comparison so `"42"`
+    /// and `42` match.
+    Stringify,
+}
+
+/// A single field projection: copy `from` (a dotted path into the build
+/// record) onto the probe record under the name `as_`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Projection {
+    /// Dotted path inside each build (right) record.
+    pub from: String,
+    /// Output field name written onto the probe (left) record.
+    #[serde(rename = "as")]
+    pub as_: String,
+}
+
+/// Compiled join configuration. Dotted key paths are pre-split at construction.
+#[derive(Debug, Clone)]
+pub struct JoinConfig {
+    /// Inner vs left.
+    pub mode: JoinMode,
+    /// Dotted path to the build-side (right) key.
+    pub build_key: String,
+    /// Dotted path to the probe-side (left) key.
+    pub probe_key: String,
+    /// Fields to copy from the build record onto the probe record.
+    pub projections: Vec<Projection>,
+    /// Value used to fill projected fields on a `left`-mode non-match.
+    pub on_missing: Value,
+    /// Multi-match policy.
+    pub on_duplicate: OnDuplicate,
+    /// Projection-collision policy.
+    pub on_collision: OnCollision,
+    /// Key-normalization policy.
+    pub key_normalize: KeyNormalize,
+    /// Safety cap on build-side records.
+    pub max_build_records: usize,
+}
+
+impl Default for JoinConfig {
+    fn default() -> Self {
+        Self {
+            mode: JoinMode::default(),
+            build_key: String::new(),
+            probe_key: String::new(),
+            projections: Vec::new(),
+            on_missing: Value::Null,
+            on_duplicate: OnDuplicate::default(),
+            on_collision: OnCollision::default(),
+            key_normalize: KeyNormalize::default(),
+            max_build_records: DEFAULT_MAX_BUILD_RECORDS,
+        }
+    }
+}
+
+/// Running counters for a join, mirroring the `faucet_join_*` metrics.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JoinStats {
+    /// Records ingested by the build side (before null-key skipping).
+    pub build_records: u64,
+    /// Build records skipped because their key resolved to null/absent.
+    pub build_nulls: u64,
+    /// Distinct build keys that appeared more than once (duplicate keys).
+    pub duplicates: u64,
+    /// Records ingested by the probe side.
+    pub probe_records: u64,
+    /// Probe records that matched at least one build record.
+    pub matches: u64,
+    /// Probe records with no build-side match.
+    pub misses: u64,
+    /// Projections skipped because the `from` path was absent on the build
+    /// record.
+    pub project_misses: u64,
+}
+
+/// A hash join: build the index, then probe it.
+#[derive(Debug)]
+pub struct HashJoin {
+    config: JoinConfig,
+    /// Build index: canonical key → build records (in build order).
+    index: HashMap<String, Vec<Value>>,
+    stats: JoinStats,
+}
+
+impl HashJoin {
+    /// Create an empty join ready to receive build-side pages.
+    pub fn new(config: JoinConfig) -> Self {
+        Self {
+            config,
+            index: HashMap::new(),
+            stats: JoinStats::default(),
+        }
+    }
+
+    /// Access the running counters.
+    pub fn stats(&self) -> &JoinStats {
+        &self.stats
+    }
+
+    /// The compiled config.
+    pub fn config(&self) -> &JoinConfig {
+        &self.config
+    }
+
+    /// Ingest a page of build-side records into the index.
+    ///
+    /// Records whose build key resolves to null/absent are skipped (counted in
+    /// [`JoinStats::build_nulls`]). Returns [`FaucetError::Transform`] with a
+    /// `JoinBuildOverflow`-style message once the cumulative build count
+    /// exceeds [`JoinConfig::max_build_records`].
+    pub fn add_build_page(&mut self, records: Vec<Value>) -> Result<(), FaucetError> {
+        for rec in records {
+            self.stats.build_records += 1;
+            if self.stats.build_records as usize > self.config.max_build_records {
+                return Err(FaucetError::Transform(format!(
+                    "join build side exceeded max_build_records ({}); raise the limit or partition the join",
+                    self.config.max_build_records
+                )));
+            }
+            let key = match get_path(&rec, &self.config.build_key) {
+                Some(v) if !v.is_null() => v,
+                _ => {
+                    self.stats.build_nulls += 1;
+                    continue;
+                }
+            };
+            let ckey = match canonical_key(key, self.config.key_normalize) {
+                Some(k) => k,
+                None => {
+                    // Non-scalar key under stringify, or otherwise unrepresentable.
+                    self.stats.build_nulls += 1;
+                    continue;
+                }
+            };
+            let bucket = self.index.entry(ckey).or_default();
+            if !bucket.is_empty() {
+                self.stats.duplicates += 1;
+            }
+            bucket.push(rec);
+        }
+        Ok(())
+    }
+
+    /// Number of distinct keys indexed so far.
+    pub fn indexed_keys(&self) -> usize {
+        self.index.len()
+    }
+
+    /// Enrich a page of probe-side records against the built index.
+    ///
+    /// Must be called only after every build page has been ingested. Returns
+    /// the enriched output records (0..N per input record depending on mode
+    /// and duplicate policy).
+    pub fn probe_page(&mut self, records: Vec<Value>) -> Result<Vec<Value>, FaucetError> {
+        let mut out = Vec::with_capacity(records.len());
+        for left in records {
+            self.stats.probe_records += 1;
+            let key = get_path(&left, &self.config.probe_key).filter(|v| !v.is_null());
+            let ckey = key.and_then(|k| canonical_key(k, self.config.key_normalize));
+
+            let matches: Option<&Vec<Value>> = ckey.as_ref().and_then(|k| self.index.get(k));
+
+            match matches {
+                Some(bucket) if !bucket.is_empty() => {
+                    self.stats.matches += 1;
+                    let take = match self.config.on_duplicate {
+                        OnDuplicate::First => &bucket[..1],
+                        OnDuplicate::Cartesian => &bucket[..],
+                    };
+                    // Clone the build records we need up front so we no longer
+                    // borrow `self.index` while mutating `self.stats`.
+                    let rights: Vec<Value> = take.to_vec();
+                    for right in &rights {
+                        let mut enriched = left.clone();
+                        self.apply_projection(&mut enriched, Some(right))?;
+                        out.push(enriched);
+                    }
+                }
+                _ => {
+                    self.stats.misses += 1;
+                    if self.config.mode == JoinMode::Left {
+                        let mut enriched = left;
+                        self.apply_projection(&mut enriched, None)?;
+                        out.push(enriched);
+                    }
+                    // inner mode: drop.
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Apply the configured projections onto `left`. `right = None` fills every
+    /// projected field with `on_missing` (the `left`-mode non-match path).
+    fn apply_projection(
+        &mut self,
+        left: &mut Value,
+        right: Option<&Value>,
+    ) -> Result<(), FaucetError> {
+        for proj in &self.config.projections {
+            let value = match right {
+                Some(r) => match get_path(r, &proj.from) {
+                    Some(v) => v.clone(),
+                    None => {
+                        // Field absent on the matched build record — skip it.
+                        self.stats.project_misses += 1;
+                        continue;
+                    }
+                },
+                None => self.config.on_missing.clone(),
+            };
+            set_field(left, &proj.as_, value, self.config.on_collision)?;
+        }
+        Ok(())
+    }
+}
+
+/// Resolve a dotted path against a JSON value, traversing objects only.
+///
+/// `"a.b.c"` descends three object levels. A missing key or a non-object
+/// intermediate yields `None`. An empty path yields the value itself.
+fn get_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    if path.is_empty() {
+        return Some(value);
+    }
+    let mut cur = value;
+    for seg in path.split('.') {
+        match cur {
+            Value::Object(map) => cur = map.get(seg)?,
+            _ => return None,
+        }
+    }
+    Some(cur)
+}
+
+/// Set `left[name] = value` at the top level, applying the collision policy.
+fn set_field(
+    left: &mut Value,
+    name: &str,
+    value: Value,
+    on_collision: OnCollision,
+) -> Result<(), FaucetError> {
+    let obj = match left {
+        Value::Object(map) => map,
+        _ => {
+            return Err(FaucetError::Transform(
+                "join can only enrich object-shaped records".into(),
+            ));
+        }
+    };
+    if obj.contains_key(name) {
+        match on_collision {
+            OnCollision::Overwrite => {
+                obj.insert(name.to_string(), value);
+            }
+            OnCollision::Skip => {}
+            OnCollision::Error => {
+                return Err(FaucetError::Transform(format!(
+                    "join projection '{name}' collides with an existing field (on_collision: error)"
+                )));
+            }
+        }
+    } else {
+        obj.insert(name.to_string(), value);
+    }
+    Ok(())
+}
+
+/// Turn a JSON scalar into a canonical hash-map key string.
+///
+/// `Preserve` prefixes a type tag so `"42"` and `42` never collide. `Stringify`
+/// coerces scalars to their plain string form so they do. Non-scalar keys
+/// (objects/arrays) return `None` — they are not valid join keys.
+fn canonical_key(value: &Value, mode: KeyNormalize) -> Option<String> {
+    match mode {
+        KeyNormalize::Preserve => match value {
+            Value::String(s) => Some(format!("s:{s}")),
+            Value::Number(n) => Some(format!("n:{n}")),
+            Value::Bool(b) => Some(format!("b:{b}")),
+            Value::Null => None,
+            _ => None,
+        },
+        KeyNormalize::Stringify => match value {
+            Value::String(s) => Some(s.clone()),
+            Value::Number(n) => Some(n.to_string()),
+            Value::Bool(b) => Some(b.to_string()),
+            Value::Null => None,
+            _ => None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cfg() -> JoinConfig {
+        JoinConfig {
+            build_key: "id".into(),
+            probe_key: "customer_id".into(),
+            projections: vec![
+                Projection {
+                    from: "tier".into(),
+                    as_: "customer_tier".into(),
+                },
+                Projection {
+                    from: "signup_date".into(),
+                    as_: "customer_signup_date".into(),
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn build_customers(join: &mut HashJoin) {
+        join.add_build_page(vec![
+            json!({"id": 1, "tier": "gold", "signup_date": "2020-01-01"}),
+            json!({"id": 2, "tier": "silver", "signup_date": "2021-06-15"}),
+        ])
+        .unwrap();
+    }
+
+    // ── get_path ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn get_path_top_level() {
+        let v = json!({"a": 1});
+        assert_eq!(get_path(&v, "a"), Some(&json!(1)));
+    }
+
+    #[test]
+    fn get_path_nested() {
+        let v = json!({"a": {"b": {"c": 42}}});
+        assert_eq!(get_path(&v, "a.b.c"), Some(&json!(42)));
+    }
+
+    #[test]
+    fn get_path_missing() {
+        let v = json!({"a": 1});
+        assert_eq!(get_path(&v, "b"), None);
+        assert_eq!(get_path(&v, "a.b"), None);
+    }
+
+    #[test]
+    fn get_path_empty_returns_self() {
+        let v = json!({"a": 1});
+        assert_eq!(get_path(&v, ""), Some(&v));
+    }
+
+    // ── inner join ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn inner_match_enriches() {
+        let mut j = HashJoin::new(cfg());
+        build_customers(&mut j);
+        let out = j
+            .probe_page(vec![json!({"order": "A", "customer_id": 1})])
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["customer_tier"], json!("gold"));
+        assert_eq!(out[0]["customer_signup_date"], json!("2020-01-01"));
+        assert_eq!(out[0]["order"], json!("A"));
+        assert_eq!(j.stats().matches, 1);
+        assert_eq!(j.stats().misses, 0);
+    }
+
+    #[test]
+    fn inner_no_match_drops() {
+        let mut j = HashJoin::new(cfg());
+        build_customers(&mut j);
+        let out = j
+            .probe_page(vec![json!({"order": "A", "customer_id": 999})])
+            .unwrap();
+        assert!(out.is_empty());
+        assert_eq!(j.stats().matches, 0);
+        assert_eq!(j.stats().misses, 1);
+    }
+
+    // ── left join ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn left_match_enriches() {
+        let mut c = cfg();
+        c.mode = JoinMode::Left;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let out = j
+            .probe_page(vec![json!({"order": "A", "customer_id": 2})])
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["customer_tier"], json!("silver"));
+    }
+
+    #[test]
+    fn left_no_match_passes_through_with_on_missing() {
+        let mut c = cfg();
+        c.mode = JoinMode::Left;
+        c.on_missing = json!("UNKNOWN");
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let out = j
+            .probe_page(vec![json!({"order": "A", "customer_id": 999})])
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["order"], json!("A"));
+        assert_eq!(out[0]["customer_tier"], json!("UNKNOWN"));
+        assert_eq!(out[0]["customer_signup_date"], json!("UNKNOWN"));
+        assert_eq!(j.stats().misses, 1);
+    }
+
+    #[test]
+    fn left_no_match_default_on_missing_is_null() {
+        let mut c = cfg();
+        c.mode = JoinMode::Left;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let out = j.probe_page(vec![json!({"customer_id": 999})]).unwrap();
+        assert_eq!(out[0]["customer_tier"], Value::Null);
+    }
+
+    // ── duplicate build keys ────────────────────────────────────────────────────
+
+    #[test]
+    fn duplicate_first_wins() {
+        let mut c = cfg();
+        c.on_duplicate = OnDuplicate::First;
+        let mut j = HashJoin::new(c);
+        j.add_build_page(vec![
+            json!({"id": 1, "tier": "gold", "signup_date": "d1"}),
+            json!({"id": 1, "tier": "platinum", "signup_date": "d2"}),
+        ])
+        .unwrap();
+        let out = j.probe_page(vec![json!({"customer_id": 1})]).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["customer_tier"], json!("gold"));
+        assert_eq!(j.stats().duplicates, 1);
+    }
+
+    #[test]
+    fn duplicate_cartesian_emits_all() {
+        let mut c = cfg();
+        c.on_duplicate = OnDuplicate::Cartesian;
+        let mut j = HashJoin::new(c);
+        j.add_build_page(vec![
+            json!({"id": 1, "tier": "gold", "signup_date": "d1"}),
+            json!({"id": 1, "tier": "platinum", "signup_date": "d2"}),
+        ])
+        .unwrap();
+        let out = j.probe_page(vec![json!({"customer_id": 1})]).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["customer_tier"], json!("gold"));
+        assert_eq!(out[1]["customer_tier"], json!("platinum"));
+        assert_eq!(j.stats().matches, 1);
+    }
+
+    // ── null keys ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn null_build_key_is_skipped() {
+        let mut j = HashJoin::new(cfg());
+        j.add_build_page(vec![
+            json!({"id": null, "tier": "gold"}),
+            json!({"tier": "silver"}), // missing id
+            json!({"id": 3, "tier": "bronze", "signup_date": "d"}),
+        ])
+        .unwrap();
+        assert_eq!(j.stats().build_nulls, 2);
+        assert_eq!(j.indexed_keys(), 1);
+    }
+
+    #[test]
+    fn null_probe_key_inner_drops() {
+        let mut j = HashJoin::new(cfg());
+        build_customers(&mut j);
+        let out = j.probe_page(vec![json!({"order": "A"})]).unwrap();
+        assert!(out.is_empty());
+        assert_eq!(j.stats().misses, 1);
+    }
+
+    #[test]
+    fn null_probe_key_left_emits_on_missing() {
+        let mut c = cfg();
+        c.mode = JoinMode::Left;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let out = j.probe_page(vec![json!({"order": "A"})]).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["customer_tier"], Value::Null);
+    }
+
+    // ── key normalization ────────────────────────────────────────────────────────
+
+    #[test]
+    fn preserve_does_not_coerce_types() {
+        let mut c = cfg();
+        c.key_normalize = KeyNormalize::Preserve;
+        let mut j = HashJoin::new(c);
+        j.add_build_page(vec![json!({"id": "42", "tier": "str", "signup_date": "d"})])
+            .unwrap();
+        // Probe with numeric 42 must NOT match the string "42".
+        let out = j.probe_page(vec![json!({"customer_id": 42})]).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn stringify_coerces_types() {
+        let mut c = cfg();
+        c.key_normalize = KeyNormalize::Stringify;
+        let mut j = HashJoin::new(c);
+        j.add_build_page(vec![json!({"id": "42", "tier": "str", "signup_date": "d"})])
+            .unwrap();
+        let out = j.probe_page(vec![json!({"customer_id": 42})]).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["customer_tier"], json!("str"));
+    }
+
+    // ── projection edge cases ─────────────────────────────────────────────────────
+
+    #[test]
+    fn projection_missing_source_field_is_skipped() {
+        let mut j = HashJoin::new(cfg());
+        // Build record lacks `signup_date`.
+        j.add_build_page(vec![json!({"id": 1, "tier": "gold"})])
+            .unwrap();
+        let out = j.probe_page(vec![json!({"customer_id": 1})]).unwrap();
+        assert_eq!(out[0]["customer_tier"], json!("gold"));
+        assert!(out[0].get("customer_signup_date").is_none());
+        assert_eq!(j.stats().project_misses, 1);
+    }
+
+    #[test]
+    fn projection_collision_overwrite() {
+        let mut c = cfg();
+        c.on_collision = OnCollision::Overwrite;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let out = j
+            .probe_page(vec![json!({"customer_id": 1, "customer_tier": "OLD"})])
+            .unwrap();
+        assert_eq!(out[0]["customer_tier"], json!("gold"));
+    }
+
+    #[test]
+    fn projection_collision_skip() {
+        let mut c = cfg();
+        c.on_collision = OnCollision::Skip;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let out = j
+            .probe_page(vec![json!({"customer_id": 1, "customer_tier": "OLD"})])
+            .unwrap();
+        assert_eq!(out[0]["customer_tier"], json!("OLD"));
+    }
+
+    #[test]
+    fn projection_collision_error() {
+        let mut c = cfg();
+        c.on_collision = OnCollision::Error;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let err = j
+            .probe_page(vec![json!({"customer_id": 1, "customer_tier": "OLD"})])
+            .unwrap_err();
+        assert!(matches!(err, FaucetError::Transform(_)));
+        assert!(err.to_string().contains("collides"));
+    }
+
+    #[test]
+    fn nested_projection_path() {
+        let mut c = cfg();
+        c.projections = vec![Projection {
+            from: "profile.tier".into(),
+            as_: "tier".into(),
+        }];
+        let mut j = HashJoin::new(c);
+        j.add_build_page(vec![json!({"id": 1, "profile": {"tier": "gold"}})])
+            .unwrap();
+        let out = j.probe_page(vec![json!({"customer_id": 1})]).unwrap();
+        assert_eq!(out[0]["tier"], json!("gold"));
+    }
+
+    // ── overflow ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn build_overflow_errors() {
+        let mut c = cfg();
+        c.max_build_records = 2;
+        let mut j = HashJoin::new(c);
+        let err = j
+            .add_build_page(vec![
+                json!({"id": 1, "tier": "a", "signup_date": "d"}),
+                json!({"id": 2, "tier": "b", "signup_date": "d"}),
+                json!({"id": 3, "tier": "c", "signup_date": "d"}),
+            ])
+            .unwrap_err();
+        assert!(matches!(err, FaucetError::Transform(_)));
+        assert!(err.to_string().contains("max_build_records"));
+    }
+
+    #[test]
+    fn build_at_exactly_limit_ok() {
+        let mut c = cfg();
+        c.max_build_records = 2;
+        let mut j = HashJoin::new(c);
+        assert!(
+            j.add_build_page(vec![
+                json!({"id": 1, "tier": "a", "signup_date": "d"}),
+                json!({"id": 2, "tier": "b", "signup_date": "d"}),
+            ])
+            .is_ok()
+        );
+    }
+
+    // ── multi-page build ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn build_across_multiple_pages() {
+        let mut j = HashJoin::new(cfg());
+        j.add_build_page(vec![json!({"id": 1, "tier": "gold", "signup_date": "d1"})])
+            .unwrap();
+        j.add_build_page(vec![
+            json!({"id": 2, "tier": "silver", "signup_date": "d2"}),
+        ])
+        .unwrap();
+        assert_eq!(j.indexed_keys(), 2);
+        let out = j
+            .probe_page(vec![json!({"customer_id": 1}), json!({"customer_id": 2})])
+            .unwrap();
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn non_object_record_errors() {
+        // A non-object probe record resolves to a null key (miss). Under inner
+        // mode it is simply dropped; under left mode we attempt to project onto
+        // it, which is where the "object-shaped records only" guard fires.
+        let mut c = cfg();
+        c.mode = JoinMode::Left;
+        let mut j = HashJoin::new(c);
+        build_customers(&mut j);
+        let err = j.probe_page(vec![json!(42)]).unwrap_err();
+        assert!(matches!(err, FaucetError::Transform(_)));
+    }
+
+    #[test]
+    fn non_object_probe_inner_is_dropped_not_errored() {
+        let mut j = HashJoin::new(cfg());
+        build_customers(&mut j);
+        // inner mode: non-object → null key → miss → dropped, no error.
+        let out = j.probe_page(vec![json!(42)]).unwrap();
+        assert!(out.is_empty());
+        assert_eq!(j.stats().misses, 1);
+    }
+
+    #[test]
+    fn bool_key_matches() {
+        let mut c = cfg();
+        c.build_key = "active".into();
+        c.probe_key = "is_active".into();
+        c.projections = vec![Projection {
+            from: "label".into(),
+            as_: "label".into(),
+        }];
+        let mut j = HashJoin::new(c);
+        j.add_build_page(vec![json!({"active": true, "label": "yes"})])
+            .unwrap();
+        let out = j.probe_page(vec![json!({"is_active": true})]).unwrap();
+        assert_eq!(out[0]["label"], json!("yes"));
+    }
+
+    #[test]
+    fn enums_serde_roundtrip() {
+        assert_eq!(serde_json::to_value(JoinMode::Left).unwrap(), json!("left"));
+        assert_eq!(
+            serde_json::from_value::<OnDuplicate>(json!("cartesian")).unwrap(),
+            OnDuplicate::Cartesian
+        );
+        assert_eq!(
+            serde_json::from_value::<OnCollision>(json!("skip")).unwrap(),
+            OnCollision::Skip
+        );
+        assert_eq!(
+            serde_json::from_value::<KeyNormalize>(json!("stringify")).unwrap(),
+            KeyNormalize::Stringify
+        );
+    }
+
+    #[test]
+    fn join_mode_display() {
+        assert_eq!(JoinMode::Inner.to_string(), "inner");
+        assert_eq!(JoinMode::Left.to_string(), "left");
+    }
+
+    #[test]
+    fn projection_serde_uses_as_rename() {
+        let p: Projection = serde_json::from_value(json!({"from": "a", "as": "b"})).unwrap();
+        assert_eq!(p.from, "a");
+        assert_eq!(p.as_, "b");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod drift;
 pub mod encryption;
 pub mod error;
 pub mod idempotency;
+pub mod join;
 #[cfg(feature = "masking")]
 pub mod masking;
 pub mod observability;
@@ -41,6 +42,7 @@ pub mod schema;
 pub mod shard;
 pub mod stage;
 pub mod state;
+pub mod topology;
 pub mod traits;
 pub mod transform;
 pub mod transforming_source;
@@ -78,6 +80,9 @@ pub use idempotency::{
     SinkGuarantee, derive_delivery_guarantee, format_token, format_token_with_bookmark,
     parse_token, parse_token_parts, unwrap_state, wrap_state,
 };
+pub use join::{
+    HashJoin, JoinConfig, JoinMode, JoinStats, KeyNormalize, OnCollision, OnDuplicate, Projection,
+};
 #[cfg(feature = "contract")]
 pub use observability::instrumented_apply_contract;
 #[cfg(feature = "masking")]
@@ -111,6 +116,10 @@ pub use stage::{ExplodeSpec, OnMissing};
 pub use stage::{FilterOp, FilterSpec};
 pub use stage::{TransformStage, compile_stage};
 pub use state::{FileStateStore, MemoryStateStore, StateStore};
+pub use topology::{
+    Edge, JoinNode, Node, NodeKind, Topology, TopologyBuilder, TopologyOnError, TopologyOptions,
+    TopologyResult,
+};
 pub use traits::{RowOutcome, Sink, Source};
 #[cfg(feature = "transform-json-parse")]
 pub use transform::JsonParseOnError;

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -1,0 +1,1648 @@
+//! Multi-edge pipeline topology — fan-out (tee), fan-in (merge), and
+//! hash-join over an explicit node graph (issues #71 and #72).
+//!
+//! The single-source→single-sink [`Pipeline`](crate::Pipeline) covers the
+//! common case. A [`Topology`] generalizes it to a directed acyclic graph of
+//! typed nodes connected by edges, so one run can *tee* a source's records to
+//! several sinks, *merge* several sources into one sink, or *join* two
+//! upstreams by key. It is the in-process primitive behind the CLI's
+//! `pipeline.nodes` / `edges` topology mode.
+//!
+//! ## Node kinds
+//!
+//! | Kind | In | Out | Semantics |
+//! |------|----|-----|-----------|
+//! | [`NodeKind::Source`] | 0 | 1 | Drives [`Source::stream_pages`]. |
+//! | [`NodeKind::Transform`] | 1 | 1 | Applies compiled transform stages per page. |
+//! | [`NodeKind::Tee`] | 1 | N | Clones each page to every downstream edge. |
+//! | [`NodeKind::Merge`] | N | 1 | Forwards pages from all inputs in arrival order. |
+//! | [`NodeKind::Join`] | 2 | 1 | Hash-join: buffer the build edge, enrich the probe edge. |
+//! | [`NodeKind::Sink`] | 1 | 0 | Drives [`run_stream`] (write → flush → persist). |
+//!
+//! ## Execution
+//!
+//! Each node runs as a cooperatively-scheduled future; edges are bounded
+//! [`tokio::sync::mpsc`] channels so the slowest consumer paces its producer
+//! (backpressure). No OS threads are spawned — the topology runs on whatever
+//! runtime drives [`Topology::run`], overlapping the nodes' I/O. Sink nodes
+//! reuse [`run_stream`], so DLQ routing, bookmark persistence, and the full
+//! observability metric set come for free.
+//!
+//! ## State
+//!
+//! Each terminal sink owns its bookmark under `{pipeline}::{node_id}`. On
+//! restart the source resumes from the **minimum** across every sink's stored
+//! bookmark (so the slowest sink catches up), applied only when *every* sink
+//! has a stored bookmark; otherwise the source replays in full. Sinks whose
+//! bookmarks have diverged must therefore be idempotent — a faster sink will
+//! re-see already-written pages.
+
+use crate::dlq::DlqConfig;
+use crate::error::FaucetError;
+use crate::join::HashJoin;
+use crate::observability::{Labels, RunStreamOptions, instrumented_apply_stages};
+use crate::pipeline::{DEFAULT_BATCH_SIZE, StreamPage, run_stream};
+use crate::replication::json_gt;
+use crate::stage::CompiledStage;
+use crate::state::StateStore;
+use crate::traits::{Sink, Source};
+use futures::StreamExt;
+use metrics::{Label, SharedString, counter, histogram};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+pub use crate::join::{JoinConfig, JoinMode, KeyNormalize, OnCollision, OnDuplicate, Projection};
+
+/// Default bounded-channel capacity for topology edges.
+pub const DEFAULT_CHANNEL_CAPACITY: usize = 4;
+
+/// A join node: the pure [`JoinConfig`] plus the labels of its two incoming
+/// edges identifying which upstream is the build (right) side and which is the
+/// probe (left) side.
+#[derive(Debug, Clone)]
+pub struct JoinNode {
+    /// Pure join logic configuration.
+    pub config: JoinConfig,
+    /// Label of the incoming edge feeding the build (right) side.
+    pub build_edge: String,
+    /// Label of the incoming edge feeding the probe (left) side.
+    pub probe_edge: String,
+}
+
+/// A typed topology node.
+pub enum NodeKind {
+    /// A data source (0 in, 1 out).
+    Source(Box<dyn Source>),
+    /// Transform stages applied per page (1 in, 1 out).
+    Transform(Vec<CompiledStage>),
+    /// Fan-out: clone each page to every downstream edge (1 in, N out).
+    Tee {
+        /// Bounded-channel capacity for each outgoing edge.
+        capacity: usize,
+        /// Optional expected fan-out (outgoing edge count) sanity check.
+        fanout: Option<usize>,
+    },
+    /// Fan-in: forward pages from all inputs in arrival order (N in, 1 out).
+    Merge,
+    /// Hash-join two upstreams by key (2 in, 1 out).
+    Join(JoinNode),
+    /// A data sink (1 in, 0 out).
+    Sink(Box<dyn Sink>),
+}
+
+impl std::fmt::Debug for NodeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.kind_str())
+    }
+}
+
+impl NodeKind {
+    /// Short name of this node kind, used in errors and metric labels.
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            NodeKind::Source(_) => "source",
+            NodeKind::Transform(_) => "transform",
+            NodeKind::Tee { .. } => "tee",
+            NodeKind::Merge => "merge",
+            NodeKind::Join(_) => "join",
+            NodeKind::Sink(_) => "sink",
+        }
+    }
+
+    fn is_source(&self) -> bool {
+        matches!(self, NodeKind::Source(_))
+    }
+
+    fn is_sink(&self) -> bool {
+        matches!(self, NodeKind::Sink(_))
+    }
+}
+
+/// A node in the topology: a stable id plus its typed kind.
+#[derive(Debug)]
+pub struct Node {
+    /// Stable node id (used as the metric `node` label and state-key suffix).
+    pub id: String,
+    /// The node's kind.
+    pub kind: NodeKind,
+}
+
+/// A directed edge from one node's output to another's input.
+#[derive(Debug, Clone)]
+pub struct Edge {
+    /// Producer node id.
+    pub from: String,
+    /// Consumer node id.
+    pub to: String,
+    /// Optional edge label, used by [`NodeKind::Join`] to distinguish its
+    /// build edge from its probe edge.
+    pub label: Option<String>,
+}
+
+/// What to do when a node fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TopologyOnError {
+    /// Abort the whole topology on the first node failure (default).
+    #[default]
+    Propagate,
+    /// Let every node run to completion; collect and report failures without
+    /// aborting healthy branches.
+    Continue,
+}
+
+/// Per-run options for [`Topology::run`].
+#[derive(Clone)]
+pub struct TopologyOptions {
+    /// Pipeline name (metric `pipeline` label).
+    pub pipeline_name: String,
+    /// Run id (span attribute).
+    pub run_id: String,
+    /// Batch-size hint passed to source nodes' `stream_pages`.
+    pub batch_size: usize,
+    /// State store shared by every sink node (each under `{pipeline}::{node_id}`).
+    pub state_store: Option<Arc<dyn StateStore>>,
+    /// DLQ applied to every sink node.
+    pub dlq: Option<DlqConfig>,
+    /// Cooperative cancellation.
+    pub cancel: Option<CancellationToken>,
+    /// Failure policy.
+    pub on_error: TopologyOnError,
+    /// Default bounded-channel capacity for edges not fed by a tee.
+    pub default_channel_capacity: usize,
+}
+
+impl Default for TopologyOptions {
+    fn default() -> Self {
+        Self {
+            pipeline_name: "unnamed".into(),
+            run_id: String::new(),
+            batch_size: DEFAULT_BATCH_SIZE,
+            state_store: None,
+            dlq: None,
+            cancel: None,
+            on_error: TopologyOnError::default(),
+            default_channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+        }
+    }
+}
+
+impl TopologyOptions {
+    /// New options with the given pipeline name.
+    pub fn new(pipeline_name: impl Into<String>) -> Self {
+        Self {
+            pipeline_name: pipeline_name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Attach a state store.
+    pub fn with_state_store(mut self, store: Arc<dyn StateStore>) -> Self {
+        self.state_store = Some(store);
+        self
+    }
+
+    /// Attach a DLQ applied to every sink node.
+    pub fn with_dlq(mut self, dlq: DlqConfig) -> Self {
+        self.dlq = Some(dlq);
+        self
+    }
+
+    /// Attach a cancellation token.
+    pub fn with_cancel(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = Some(cancel);
+        self
+    }
+
+    /// Set the failure policy.
+    pub fn with_on_error(mut self, on_error: TopologyOnError) -> Self {
+        self.on_error = on_error;
+        self
+    }
+
+    /// Set the batch-size hint.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+/// Outcome of a topology run.
+#[derive(Debug, Clone, Default)]
+pub struct TopologyResult {
+    /// Total records written across all sink nodes.
+    pub records_written: usize,
+    /// Per-sink-node records written, keyed by node id.
+    pub per_sink: HashMap<String, usize>,
+    /// Per-sink-node final bookmark, keyed by node id.
+    pub bookmarks: HashMap<String, Option<Value>>,
+    /// Node failures observed under [`TopologyOnError::Continue`] (empty under
+    /// `Propagate`, which returns `Err` on the first failure instead).
+    pub errors: Vec<String>,
+}
+
+/// One incoming edge of a node: its optional label plus the receiving end of
+/// the channel.
+struct InEdge {
+    label: Option<String>,
+    rx: mpsc::Receiver<StreamPage>,
+}
+
+/// Pop the single input receiver from a one-input node's edge list.
+fn take_single(mut ins: Vec<InEdge>) -> Option<mpsc::Receiver<StreamPage>> {
+    ins.drain(..).next().map(|ie| ie.rx)
+}
+
+/// Remove and return the input receiver whose edge carries `label`.
+fn take_by_label(ins: &mut Vec<InEdge>, label: &str) -> Option<mpsc::Receiver<StreamPage>> {
+    ins.iter()
+        .position(|ie| ie.label.as_deref() == Some(label))
+        .map(|pos| ins.remove(pos).rx)
+}
+
+/// What a completed node future reports back.
+enum NodeOutcome {
+    Sink {
+        node_id: String,
+        records: usize,
+        bookmark: Option<Value>,
+    },
+    Other,
+}
+
+/// A directed acyclic graph of typed nodes.
+///
+/// Build one with [`Topology::builder`], then drive it with [`Topology::run`].
+#[derive(Debug)]
+pub struct Topology {
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+}
+
+impl Topology {
+    /// Start building a topology.
+    pub fn builder() -> TopologyBuilder {
+        TopologyBuilder::default()
+    }
+
+    /// The nodes, in insertion order.
+    pub fn nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+
+    /// The edges, in insertion order.
+    pub fn edges(&self) -> &[Edge] {
+        &self.edges
+    }
+
+    /// Validate the graph: unique ids, existing endpoints, per-kind arity,
+    /// tee fan-out, join edge labels, acyclicity, and source→sink
+    /// reachability. Returns [`FaucetError::Config`] with a descriptive
+    /// message on the first violation.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.nodes.is_empty() {
+            return Err(cfg("topology has no nodes"));
+        }
+
+        // Unique ids.
+        let mut seen = HashSet::new();
+        for n in &self.nodes {
+            if !seen.insert(n.id.as_str()) {
+                return Err(cfg(format!("duplicate node id '{}'", n.id)));
+            }
+        }
+        let ids: HashSet<&str> = seen;
+
+        // Edge endpoints exist.
+        for e in &self.edges {
+            if !ids.contains(e.from.as_str()) {
+                return Err(cfg(format!(
+                    "edge references unknown 'from' node '{}'",
+                    e.from
+                )));
+            }
+            if !ids.contains(e.to.as_str()) {
+                return Err(cfg(format!("edge references unknown 'to' node '{}'", e.to)));
+            }
+        }
+
+        // In/out degrees.
+        let mut in_deg: HashMap<&str, usize> = HashMap::new();
+        let mut out_deg: HashMap<&str, usize> = HashMap::new();
+        for e in &self.edges {
+            *out_deg.entry(e.from.as_str()).or_default() += 1;
+            *in_deg.entry(e.to.as_str()).or_default() += 1;
+        }
+
+        let mut has_source = false;
+        let mut has_sink = false;
+        for n in &self.nodes {
+            let i = in_deg.get(n.id.as_str()).copied().unwrap_or(0);
+            let o = out_deg.get(n.id.as_str()).copied().unwrap_or(0);
+            match &n.kind {
+                NodeKind::Source(_) => {
+                    has_source = true;
+                    arity(&n.id, "source", i == 0, o == 1, "0 in, exactly 1 out")?;
+                }
+                NodeKind::Transform(_) => {
+                    arity(&n.id, "transform", i == 1, o == 1, "exactly 1 in, 1 out")?;
+                }
+                NodeKind::Tee { fanout, .. } => {
+                    arity(&n.id, "tee", i == 1, o >= 2, "exactly 1 in, 2+ out")?;
+                    if let Some(f) = fanout
+                        && *f != o
+                    {
+                        return Err(cfg(format!(
+                            "tee '{}' declares fanout {f} but has {o} outgoing edges",
+                            n.id
+                        )));
+                    }
+                }
+                NodeKind::Merge => {
+                    arity(&n.id, "merge", i >= 2, o == 1, "2+ in, exactly 1 out")?;
+                }
+                NodeKind::Join(j) => {
+                    arity(&n.id, "join", i == 2, o == 1, "exactly 2 in, 1 out")?;
+                    self.validate_join_edges(&n.id, j)?;
+                }
+                NodeKind::Sink(_) => {
+                    has_sink = true;
+                    arity(&n.id, "sink", i == 1, o == 0, "exactly 1 in, 0 out")?;
+                }
+            }
+        }
+
+        if !has_source {
+            return Err(cfg("topology has no source node"));
+        }
+        if !has_sink {
+            return Err(cfg("topology has no sink node"));
+        }
+
+        self.detect_cycle()?;
+        self.check_reachability()?;
+        Ok(())
+    }
+
+    fn validate_join_edges(&self, node_id: &str, j: &JoinNode) -> Result<(), FaucetError> {
+        let labels: Vec<&str> = self
+            .edges
+            .iter()
+            .filter(|e| e.to == node_id)
+            .filter_map(|e| e.label.as_deref())
+            .collect();
+        for want in [j.build_edge.as_str(), j.probe_edge.as_str()] {
+            if !labels.contains(&want) {
+                return Err(cfg(format!(
+                    "join '{node_id}' has no incoming edge labelled '{want}' (known labels: {labels:?})"
+                )));
+            }
+        }
+        if j.build_edge == j.probe_edge {
+            return Err(cfg(format!(
+                "join '{node_id}' build_edge and probe_edge must differ"
+            )));
+        }
+        Ok(())
+    }
+
+    /// DFS cycle detection (three-color).
+    fn detect_cycle(&self) -> Result<(), FaucetError> {
+        let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+        for e in &self.edges {
+            adj.entry(e.from.as_str()).or_default().push(e.to.as_str());
+        }
+        #[derive(Clone, Copy, PartialEq)]
+        enum Color {
+            White,
+            Gray,
+            Black,
+        }
+        let mut color: HashMap<&str, Color> = self
+            .nodes
+            .iter()
+            .map(|n| (n.id.as_str(), Color::White))
+            .collect();
+
+        // Iterative DFS to avoid stack overflow on deep graphs.
+        for start in self.nodes.iter().map(|n| n.id.as_str()) {
+            if color[start] != Color::White {
+                continue;
+            }
+            let mut stack: Vec<(&str, usize)> = vec![(start, 0)];
+            *color.get_mut(start).unwrap() = Color::Gray;
+            while let Some((node, idx)) = stack.last().copied() {
+                let neighbours = adj.get(node).map(|v| v.as_slice()).unwrap_or(&[]);
+                if idx < neighbours.len() {
+                    stack.last_mut().unwrap().1 += 1;
+                    let next = neighbours[idx];
+                    match color[next] {
+                        Color::Gray => {
+                            return Err(cfg(format!("topology has a cycle through node '{next}'")));
+                        }
+                        Color::White => {
+                            *color.get_mut(next).unwrap() = Color::Gray;
+                            stack.push((next, 0));
+                        }
+                        Color::Black => {}
+                    }
+                } else {
+                    *color.get_mut(node).unwrap() = Color::Black;
+                    stack.pop();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Every source must reach at least one sink, and every sink must be
+    /// reachable from at least one source.
+    fn check_reachability(&self) -> Result<(), FaucetError> {
+        let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+        let mut radj: HashMap<&str, Vec<&str>> = HashMap::new();
+        for e in &self.edges {
+            adj.entry(e.from.as_str()).or_default().push(e.to.as_str());
+            radj.entry(e.to.as_str()).or_default().push(e.from.as_str());
+        }
+        let sink_ids: HashSet<&str> = self
+            .nodes
+            .iter()
+            .filter(|n| n.kind.is_sink())
+            .map(|n| n.id.as_str())
+            .collect();
+        let source_ids: HashSet<&str> = self
+            .nodes
+            .iter()
+            .filter(|n| n.kind.is_source())
+            .map(|n| n.id.as_str())
+            .collect();
+
+        for src in &source_ids {
+            if !reaches_any(src, &adj, &sink_ids) {
+                return Err(cfg(format!("source '{src}' does not reach any sink node")));
+            }
+        }
+        for sink in &sink_ids {
+            if !reaches_any(sink, &radj, &source_ids) {
+                return Err(cfg(format!(
+                    "sink '{sink}' is not reachable from any source node"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Run the topology to completion.
+    pub async fn run(self, opts: TopologyOptions) -> Result<TopologyResult, FaucetError> {
+        self.validate()?;
+        let Topology { nodes, edges } = self;
+
+        // Capacity per outgoing edge: a tee's edges use its configured
+        // capacity; everything else uses the default.
+        let tee_cap: HashMap<&str, usize> = nodes
+            .iter()
+            .filter_map(|n| match &n.kind {
+                NodeKind::Tee { capacity, .. } => Some((n.id.as_str(), *capacity)),
+                _ => None,
+            })
+            .collect();
+
+        // Compute the source start bookmark = min across sink bookmarks.
+        let sink_ids: Vec<String> = nodes
+            .iter()
+            .filter(|n| n.kind.is_sink())
+            .map(|n| n.id.clone())
+            .collect();
+        let start_bookmark = compute_start_bookmark(&opts, &sink_ids).await;
+
+        // Build channels.
+        let mut outs: HashMap<String, Vec<mpsc::Sender<StreamPage>>> = HashMap::new();
+        let mut ins: HashMap<String, Vec<InEdge>> = HashMap::new();
+        for e in &edges {
+            let cap = tee_cap
+                .get(e.from.as_str())
+                .copied()
+                .unwrap_or(opts.default_channel_capacity)
+                .max(1);
+            let (tx, rx) = mpsc::channel(cap);
+            outs.entry(e.from.clone()).or_default().push(tx);
+            ins.entry(e.to.clone()).or_default().push(InEdge {
+                label: e.label.clone(),
+                rx,
+            });
+        }
+
+        // Build one future per node.
+        type NodeFut = Pin<Box<dyn Future<Output = Result<NodeOutcome, FaucetError>>>>;
+        let mut futs: Vec<NodeFut> = Vec::with_capacity(nodes.len());
+
+        for node in nodes {
+            let node_outs = outs.remove(&node.id).unwrap_or_default();
+            let mut node_ins = ins.remove(&node.id).unwrap_or_default();
+            let pipeline = opts.pipeline_name.clone();
+            let cancel = opts.cancel.clone();
+            let Node { id, kind } = node;
+
+            let fut: NodeFut = match kind {
+                NodeKind::Source(source) => {
+                    let sb = start_bookmark.clone();
+                    let bs = opts.batch_size;
+                    Box::pin(run_source_node(source, sb, bs, node_outs, cancel))
+                }
+                NodeKind::Transform(stages) => {
+                    let rx = take_single(node_ins)
+                        .ok_or_else(|| cfg(format!("transform '{id}' has no input edge")))?;
+                    let labels = Labels::new(pipeline.clone(), id.clone(), opts.run_id.clone());
+                    Box::pin(run_transform_node(stages, labels, rx, node_outs, cancel))
+                }
+                NodeKind::Tee { .. } => {
+                    let rx = take_single(node_ins)
+                        .ok_or_else(|| cfg(format!("tee '{id}' has no input edge")))?;
+                    Box::pin(run_tee_node(id, pipeline, rx, node_outs, cancel))
+                }
+                NodeKind::Merge => {
+                    let rxs: Vec<mpsc::Receiver<StreamPage>> =
+                        node_ins.into_iter().map(|ie| ie.rx).collect();
+                    Box::pin(run_merge_node(id, pipeline, rxs, node_outs, cancel))
+                }
+                NodeKind::Join(j) => {
+                    let build_rx = take_by_label(&mut node_ins, &j.build_edge);
+                    let probe_rx = take_by_label(&mut node_ins, &j.probe_edge);
+                    match (build_rx, probe_rx) {
+                        (Some(b), Some(p)) => {
+                            Box::pin(run_join_node(id, pipeline, j, b, p, node_outs, cancel))
+                        }
+                        _ => {
+                            return Err(cfg(format!(
+                                "join '{id}' is missing its build/probe input edges"
+                            )));
+                        }
+                    }
+                }
+                NodeKind::Sink(sink) => {
+                    let rx = take_single(node_ins)
+                        .ok_or_else(|| cfg(format!("sink '{id}' has no input edge")))?;
+                    let sopts = SinkNodeOpts {
+                        pipeline_name: pipeline,
+                        run_id: opts.run_id.clone(),
+                        state_store: opts.state_store.clone(),
+                        dlq: opts.dlq.clone(),
+                        cancel: cancel.clone(),
+                    };
+                    Box::pin(run_sink_node(id, sink, rx, sopts))
+                }
+            };
+            futs.push(fut);
+        }
+
+        // Drop the leftover maps so no dangling senders keep channels open.
+        drop(outs);
+        drop(ins);
+
+        match opts.on_error {
+            TopologyOnError::Propagate => {
+                let outcomes = futures::future::try_join_all(futs).await?;
+                Ok(aggregate(outcomes))
+            }
+            TopologyOnError::Continue => {
+                let results = futures::future::join_all(futs).await;
+                let mut ok = Vec::new();
+                let mut errs = Vec::new();
+                for r in results {
+                    match r {
+                        Ok(o) => ok.push(o),
+                        Err(e) => {
+                            tracing::error!(error = %e, "topology node failed (on_error: continue)");
+                            errs.push(e.to_string());
+                        }
+                    }
+                }
+                let mut result = aggregate(ok);
+                result.errors = errs;
+                Ok(result)
+            }
+        }
+    }
+}
+
+/// Aggregate node outcomes into a [`TopologyResult`].
+fn aggregate(outcomes: Vec<NodeOutcome>) -> TopologyResult {
+    let mut result = TopologyResult::default();
+    for o in outcomes {
+        if let NodeOutcome::Sink {
+            node_id,
+            records,
+            bookmark,
+        } = o
+        {
+            result.records_written += records;
+            result.per_sink.insert(node_id.clone(), records);
+            result.bookmarks.insert(node_id, bookmark);
+        }
+    }
+    result
+}
+
+fn cfg(msg: impl Into<String>) -> FaucetError {
+    FaucetError::Config(format!("topology: {}", msg.into()))
+}
+
+fn arity(
+    node_id: &str,
+    kind: &str,
+    in_ok: bool,
+    out_ok: bool,
+    expected: &str,
+) -> Result<(), FaucetError> {
+    if in_ok && out_ok {
+        Ok(())
+    } else {
+        Err(cfg(format!(
+            "{kind} '{node_id}' has the wrong edge arity (expected {expected})"
+        )))
+    }
+}
+
+fn reaches_any(start: &str, adj: &HashMap<&str, Vec<&str>>, targets: &HashSet<&str>) -> bool {
+    let mut stack = vec![start];
+    let mut seen = HashSet::new();
+    while let Some(n) = stack.pop() {
+        if targets.contains(n) {
+            return true;
+        }
+        if !seen.insert(n) {
+            continue;
+        }
+        if let Some(ns) = adj.get(n) {
+            stack.extend(ns.iter().copied());
+        }
+    }
+    false
+}
+
+/// Read every sink node's stored bookmark; return the minimum only when every
+/// sink has one (so the slowest sink is not skipped past on restart).
+async fn compute_start_bookmark(opts: &TopologyOptions, sink_ids: &[String]) -> Option<Value> {
+    let store = opts.state_store.as_ref()?;
+    if sink_ids.is_empty() {
+        return None;
+    }
+    let mut values = Vec::with_capacity(sink_ids.len());
+    for id in sink_ids {
+        let key = format!("{}::{}", opts.pipeline_name, id);
+        match store.get(&key).await {
+            Ok(Some(v)) => values.push(v),
+            _ => return None, // a sink with no bookmark → full replay.
+        }
+    }
+    min_bookmark(&values)
+}
+
+/// The minimum of a set of bookmarks under the replication ordering.
+fn min_bookmark(vals: &[Value]) -> Option<Value> {
+    let mut min: Option<&Value> = None;
+    for v in vals {
+        match min {
+            None => min = Some(v),
+            Some(m) if json_gt(m, v) => min = Some(v),
+            _ => {}
+        }
+    }
+    min.cloned()
+}
+
+/// Send `page` to every live output, moving into the last and cloning for the
+/// rest. Closed (dropped-receiver) outputs are removed. Returns `false` once
+/// every output has closed.
+async fn broadcast(page: StreamPage, outs: &mut Vec<mpsc::Sender<StreamPage>>) -> bool {
+    if outs.is_empty() {
+        return false;
+    }
+    let last = outs.len() - 1;
+    let mut closed: Vec<usize> = Vec::new();
+    for (i, tx) in outs.iter().enumerate().take(last) {
+        if tx.send(page.clone()).await.is_err() {
+            closed.push(i);
+        }
+    }
+    if outs[last].send(page).await.is_err() {
+        closed.push(last);
+    }
+    for &i in closed.iter().rev() {
+        outs.remove(i);
+    }
+    !outs.is_empty()
+}
+
+fn cancelled(cancel: &Option<CancellationToken>) -> bool {
+    cancel.as_ref().is_some_and(|c| c.is_cancelled())
+}
+
+async fn run_source_node(
+    source: Box<dyn Source>,
+    start_bookmark: Option<Value>,
+    batch_size: usize,
+    mut outs: Vec<mpsc::Sender<StreamPage>>,
+    cancel: Option<CancellationToken>,
+) -> Result<NodeOutcome, FaucetError> {
+    if let Some(bm) = start_bookmark {
+        source.apply_start_bookmark(bm).await?;
+    }
+    let ctx = std::collections::HashMap::new();
+    let mut pages = source.stream_pages(&ctx, batch_size);
+    while let Some(item) = pages.next().await {
+        if cancelled(&cancel) {
+            break;
+        }
+        let page = item?;
+        if !broadcast(page, &mut outs).await {
+            break;
+        }
+    }
+    Ok(NodeOutcome::Other)
+}
+
+async fn run_transform_node(
+    stages: Vec<CompiledStage>,
+    labels: Labels,
+    mut rx: mpsc::Receiver<StreamPage>,
+    mut outs: Vec<mpsc::Sender<StreamPage>>,
+    cancel: Option<CancellationToken>,
+) -> Result<NodeOutcome, FaucetError> {
+    while let Some(page) = rx.recv().await {
+        if cancelled(&cancel) {
+            break;
+        }
+        let records = instrumented_apply_stages(page.records, &stages, &labels)?;
+        let out = StreamPage {
+            records,
+            bookmark: page.bookmark,
+        };
+        if !broadcast(out, &mut outs).await {
+            break;
+        }
+    }
+    Ok(NodeOutcome::Other)
+}
+
+fn node_labels(pipeline: &str, node: &str) -> Vec<Label> {
+    vec![
+        Label::new("pipeline", SharedString::from(pipeline.to_string())),
+        Label::new("node", SharedString::from(node.to_string())),
+    ]
+}
+
+async fn run_tee_node(
+    node_id: String,
+    pipeline: String,
+    mut rx: mpsc::Receiver<StreamPage>,
+    mut outs: Vec<mpsc::Sender<StreamPage>>,
+    cancel: Option<CancellationToken>,
+) -> Result<NodeOutcome, FaucetError> {
+    let labels = node_labels(&pipeline, &node_id);
+    while let Some(page) = rx.recv().await {
+        if cancelled(&cancel) {
+            break;
+        }
+        counter!("faucet_tee_records_total", labels.clone()).increment(page.records.len() as u64);
+        if !broadcast(page, &mut outs).await {
+            break;
+        }
+    }
+    Ok(NodeOutcome::Other)
+}
+
+async fn run_merge_node(
+    node_id: String,
+    pipeline: String,
+    rxs: Vec<mpsc::Receiver<StreamPage>>,
+    mut outs: Vec<mpsc::Sender<StreamPage>>,
+    cancel: Option<CancellationToken>,
+) -> Result<NodeOutcome, FaucetError> {
+    let labels = node_labels(&pipeline, &node_id);
+    let streams = rxs.into_iter().map(|mut rx| {
+        Box::pin(async_stream::stream! {
+            while let Some(p) = rx.recv().await {
+                yield p;
+            }
+        }) as Pin<Box<dyn futures::Stream<Item = StreamPage> + Send>>
+    });
+    let mut sel = futures::stream::select_all(streams);
+    while let Some(page) = sel.next().await {
+        if cancelled(&cancel) {
+            break;
+        }
+        counter!("faucet_merge_records_total", labels.clone()).increment(page.records.len() as u64);
+        if !broadcast(page, &mut outs).await {
+            break;
+        }
+    }
+    Ok(NodeOutcome::Other)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_join_node(
+    node_id: String,
+    pipeline: String,
+    j: JoinNode,
+    mut build_rx: mpsc::Receiver<StreamPage>,
+    mut probe_rx: mpsc::Receiver<StreamPage>,
+    mut outs: Vec<mpsc::Sender<StreamPage>>,
+    cancel: Option<CancellationToken>,
+) -> Result<NodeOutcome, FaucetError> {
+    let mode = j.config.mode;
+    let mut join = HashJoin::new(j.config);
+
+    // Build phase: fully drain the build side before probing.
+    let build_start = std::time::Instant::now();
+    while let Some(page) = build_rx.recv().await {
+        if cancelled(&cancel) {
+            return Ok(NodeOutcome::Other);
+        }
+        join.add_build_page(page.records)?;
+    }
+    let labels = node_labels(&pipeline, &node_id);
+    histogram!("faucet_join_build_duration_seconds", labels.clone())
+        .record(build_start.elapsed().as_secs_f64());
+
+    // Probe phase.
+    while let Some(page) = probe_rx.recv().await {
+        if cancelled(&cancel) {
+            break;
+        }
+        let enriched = join.probe_page(page.records)?;
+        let out = StreamPage {
+            records: enriched,
+            bookmark: page.bookmark,
+        };
+        if !broadcast(out, &mut outs).await {
+            break;
+        }
+    }
+
+    emit_join_metrics(&labels, mode, join.stats());
+    Ok(NodeOutcome::Other)
+}
+
+fn emit_join_metrics(labels: &[Label], mode: JoinMode, stats: &crate::join::JoinStats) {
+    counter!("faucet_join_build_records_total", labels.to_vec()).increment(stats.build_records);
+    counter!("faucet_join_build_nulls_total", labels.to_vec()).increment(stats.build_nulls);
+    counter!("faucet_join_duplicates_total", labels.to_vec()).increment(stats.duplicates);
+    counter!("faucet_join_probe_records_total", labels.to_vec()).increment(stats.probe_records);
+    counter!("faucet_join_project_misses_total", labels.to_vec()).increment(stats.project_misses);
+    let mut match_labels = labels.to_vec();
+    match_labels.push(Label::new("kind", SharedString::from(mode.to_string())));
+    counter!("faucet_join_matches_total", match_labels.clone()).increment(stats.matches);
+    counter!("faucet_join_misses_total", match_labels).increment(stats.misses);
+}
+
+struct SinkNodeOpts {
+    pipeline_name: String,
+    run_id: String,
+    state_store: Option<Arc<dyn StateStore>>,
+    dlq: Option<DlqConfig>,
+    cancel: Option<CancellationToken>,
+}
+
+async fn run_sink_node(
+    node_id: String,
+    sink: Box<dyn Sink>,
+    mut rx: mpsc::Receiver<StreamPage>,
+    opts: SinkNodeOpts,
+) -> Result<NodeOutcome, FaucetError> {
+    let pages = Box::pin(async_stream::stream! {
+        while let Some(page) = rx.recv().await {
+            yield Ok::<StreamPage, FaucetError>(page);
+        }
+    });
+
+    let mut run_opts = RunStreamOptions::new()
+        .with_name(opts.pipeline_name.clone())
+        .with_row(node_id.clone())
+        .with_run_id(opts.run_id.clone());
+    if let Some(store) = opts.state_store {
+        let key = format!("{}::{}", opts.pipeline_name, node_id);
+        run_opts = run_opts.with_state(store, key);
+    }
+    if let Some(dlq) = opts.dlq {
+        run_opts = run_opts.with_dlq(dlq);
+    }
+    if let Some(cancel) = opts.cancel {
+        run_opts = run_opts.with_cancel(cancel);
+    }
+
+    let result = run_stream(pages, sink.as_ref(), run_opts).await?;
+    Ok(NodeOutcome::Sink {
+        node_id,
+        records: result.records_written,
+        bookmark: result.bookmark,
+    })
+}
+
+// ── Builder ──────────────────────────────────────────────────────────────────
+
+/// Fluent builder for a [`Topology`].
+#[derive(Default)]
+pub struct TopologyBuilder {
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+}
+
+impl TopologyBuilder {
+    /// Add a node of any kind.
+    pub fn node(mut self, id: impl Into<String>, kind: NodeKind) -> Self {
+        self.nodes.push(Node {
+            id: id.into(),
+            kind,
+        });
+        self
+    }
+
+    /// Add a source node.
+    pub fn source(self, id: impl Into<String>, source: Box<dyn Source>) -> Self {
+        self.node(id, NodeKind::Source(source))
+    }
+
+    /// Add a transform node.
+    pub fn transform(self, id: impl Into<String>, stages: Vec<CompiledStage>) -> Self {
+        self.node(id, NodeKind::Transform(stages))
+    }
+
+    /// Add a tee (fan-out) node.
+    pub fn tee(self, id: impl Into<String>, capacity: usize, fanout: Option<usize>) -> Self {
+        self.node(id, NodeKind::Tee { capacity, fanout })
+    }
+
+    /// Add a merge (fan-in) node.
+    pub fn merge(self, id: impl Into<String>) -> Self {
+        self.node(id, NodeKind::Merge)
+    }
+
+    /// Add a join node.
+    pub fn join(self, id: impl Into<String>, join: JoinNode) -> Self {
+        self.node(id, NodeKind::Join(join))
+    }
+
+    /// Add a sink node.
+    pub fn sink(self, id: impl Into<String>, sink: Box<dyn Sink>) -> Self {
+        self.node(id, NodeKind::Sink(sink))
+    }
+
+    /// Add an unlabelled edge.
+    pub fn edge(mut self, from: impl Into<String>, to: impl Into<String>) -> Self {
+        self.edges.push(Edge {
+            from: from.into(),
+            to: to.into(),
+            label: None,
+        });
+        self
+    }
+
+    /// Add a labelled edge (used by join build/probe wiring).
+    pub fn labelled_edge(
+        mut self,
+        from: impl Into<String>,
+        to: impl Into<String>,
+        label: impl Into<String>,
+    ) -> Self {
+        self.edges.push(Edge {
+            from: from.into(),
+            to: to.into(),
+            label: Some(label.into()),
+        });
+        self
+    }
+
+    /// Finalize and validate the topology.
+    pub fn build(self) -> Result<Topology, FaucetError> {
+        let t = Topology {
+            nodes: self.nodes,
+            edges: self.edges,
+        };
+        t.validate()?;
+        Ok(t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::join::{JoinConfig, JoinMode, Projection};
+    use crate::state::MemoryStateStore;
+    use async_trait::async_trait;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    // ── Mock connectors ───────────────────────────────────────────────────────
+
+    struct VecSource {
+        records: Vec<Value>,
+        bookmark: Option<Value>,
+    }
+    impl VecSource {
+        fn boxed(records: Vec<Value>) -> Box<dyn Source> {
+            Box::new(VecSource {
+                records,
+                bookmark: None,
+            })
+        }
+        fn boxed_bm(records: Vec<Value>, bm: Value) -> Box<dyn Source> {
+            Box::new(VecSource {
+                records,
+                bookmark: Some(bm),
+            })
+        }
+    }
+    #[async_trait]
+    impl Source for VecSource {
+        async fn fetch_with_context(
+            &self,
+            _c: &std::collections::HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.records.clone())
+        }
+        async fn fetch_with_context_incremental(
+            &self,
+            _c: &std::collections::HashMap<String, Value>,
+        ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+            Ok((self.records.clone(), self.bookmark.clone()))
+        }
+    }
+
+    struct FailingSource;
+    #[async_trait]
+    impl Source for FailingSource {
+        async fn fetch_with_context(
+            &self,
+            _c: &std::collections::HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Err(FaucetError::Source("boom".into()))
+        }
+    }
+
+    /// Records the bookmark applied via `apply_start_bookmark`.
+    struct RecordingSource {
+        records: Vec<Value>,
+        applied: Arc<Mutex<Option<Value>>>,
+    }
+    #[async_trait]
+    impl Source for RecordingSource {
+        async fn fetch_with_context(
+            &self,
+            _c: &std::collections::HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.records.clone())
+        }
+        async fn apply_start_bookmark(&self, bm: Value) -> Result<(), FaucetError> {
+            *self.applied.lock().unwrap() = Some(bm);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct CollectSink {
+        store: Arc<Mutex<Vec<Value>>>,
+    }
+    impl CollectSink {
+        fn new() -> (Self, Arc<Mutex<Vec<Value>>>) {
+            let store = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    store: store.clone(),
+                },
+                store,
+            )
+        }
+    }
+    #[async_trait]
+    impl Sink for CollectSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            self.store.lock().unwrap().extend_from_slice(records);
+            Ok(records.len())
+        }
+    }
+
+    struct FailingSink;
+    #[async_trait]
+    impl Sink for FailingSink {
+        async fn write_batch(&self, _records: &[Value]) -> Result<usize, FaucetError> {
+            Err(FaucetError::Sink("sink boom".into()))
+        }
+    }
+
+    fn recs(n: usize) -> Vec<Value> {
+        (0..n).map(|i| json!({ "i": i })).collect()
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_rejects_empty() {
+        let err = Topology {
+            nodes: vec![],
+            edges: vec![],
+        }
+        .validate()
+        .unwrap_err();
+        assert!(err.to_string().contains("no nodes"));
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_id() {
+        let (sink, _) = CollectSink::new();
+        let err = Topology::builder()
+            .source("a", VecSource::boxed(recs(1)))
+            .sink("a", Box::new(sink))
+            .edge("a", "a")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate node id"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_endpoint() {
+        let err = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .edge("s", "ghost")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown 'to' node 'ghost'"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_from_endpoint() {
+        let (sink, _) = CollectSink::new();
+        let err = Topology::builder()
+            .sink("k", Box::new(sink))
+            .edge("ghost", "k")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown 'from' node 'ghost'"));
+    }
+
+    #[test]
+    fn validate_rejects_source_with_incoming_edge() {
+        let (sink, _) = CollectSink::new();
+        let err = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .edge("k", "s") // sink→source: gives source in=1 and sink out=1
+            .build()
+            .unwrap_err();
+        // Either arity or cycle is caught; both are correct rejections.
+        assert!(err.to_string().contains("arity") || err.to_string().contains("cycle"));
+    }
+
+    #[test]
+    fn validate_rejects_tee_fanout_mismatch() {
+        let (s1, _) = CollectSink::new();
+        let (s2, _) = CollectSink::new();
+        let err = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .tee("t", 4, Some(3))
+            .sink("a", Box::new(s1))
+            .sink("b", Box::new(s2))
+            .edge("s", "t")
+            .edge("t", "a")
+            .edge("t", "b")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("fanout 3 but has 2"));
+    }
+
+    #[test]
+    fn validate_rejects_tee_with_one_output() {
+        let (s1, _) = CollectSink::new();
+        let err = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .tee("t", 4, None)
+            .sink("a", Box::new(s1))
+            .edge("s", "t")
+            .edge("t", "a")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("tee 't'"));
+    }
+
+    #[test]
+    fn validate_rejects_merge_with_one_input() {
+        let (s1, _) = CollectSink::new();
+        let err = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .merge("m")
+            .sink("a", Box::new(s1))
+            .edge("s", "m")
+            .edge("m", "a")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("merge 'm'"));
+    }
+
+    #[test]
+    fn validate_rejects_join_missing_label() {
+        let (s1, _) = CollectSink::new();
+        let jn = JoinNode {
+            config: JoinConfig::default(),
+            build_edge: "build".into(),
+            probe_edge: "probe".into(),
+        };
+        let err = Topology::builder()
+            .source("b", VecSource::boxed(recs(1)))
+            .source("p", VecSource::boxed(recs(1)))
+            .join("j", jn)
+            .sink("a", Box::new(s1))
+            .labelled_edge("b", "j", "build")
+            .edge("p", "j") // unlabelled — probe label missing
+            .edge("j", "a")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("labelled 'probe'"));
+    }
+
+    #[test]
+    fn validate_rejects_join_same_labels() {
+        let (s1, _) = CollectSink::new();
+        let jn = JoinNode {
+            config: JoinConfig::default(),
+            build_edge: "x".into(),
+            probe_edge: "x".into(),
+        };
+        let err = Topology::builder()
+            .source("b", VecSource::boxed(recs(1)))
+            .source("p", VecSource::boxed(recs(1)))
+            .join("j", jn)
+            .sink("a", Box::new(s1))
+            .labelled_edge("b", "j", "x")
+            .labelled_edge("p", "j", "x")
+            .edge("j", "a")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("must differ"));
+    }
+
+    #[test]
+    fn validate_rejects_cycle() {
+        // s → m(merge) → t(tee) → {m, k}. The m→t→m loop is a valid-arity
+        // cycle (merge absorbs the back-edge, tee provides the second out).
+        let (sink, _) = CollectSink::new();
+        let err = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .merge("m")
+            .tee("t", 4, None)
+            .sink("k", Box::new(sink))
+            .edge("s", "m")
+            .edge("m", "t")
+            .edge("t", "m")
+            .edge("t", "k")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("cycle"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_no_source() {
+        // Two transforms wired in a ring: valid arity, but no source node.
+        let err = Topology::builder()
+            .transform("t1", vec![])
+            .transform("t2", vec![])
+            .edge("t1", "t2")
+            .edge("t2", "t1")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("no source"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_no_sink() {
+        // Two sources into a self-looping merge: valid arity, but no sink.
+        let err = Topology::builder()
+            .source("s1", VecSource::boxed(recs(1)))
+            .source("s2", VecSource::boxed(recs(1)))
+            .merge("m")
+            .edge("s1", "m")
+            .edge("s2", "m")
+            .edge("m", "m")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("no sink"), "{err}");
+    }
+
+    // ── Execution ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn simple_source_to_sink() {
+        let (sink, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(5)))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+        let result = topo.run(TopologyOptions::new("p")).await.unwrap();
+        assert_eq!(result.records_written, 5);
+        assert_eq!(store.lock().unwrap().len(), 5);
+        assert_eq!(result.per_sink.get("k"), Some(&5));
+    }
+
+    #[tokio::test]
+    async fn source_transform_sink() {
+        let (sink, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(3)))
+            .transform("t", vec![]) // passthrough
+            .sink("k", Box::new(sink))
+            .edge("s", "t")
+            .edge("t", "k")
+            .build()
+            .unwrap();
+        let result = topo.run(TopologyOptions::new("p")).await.unwrap();
+        assert_eq!(result.records_written, 3);
+        assert_eq!(store.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn tee_fans_out_to_three_sinks() {
+        let (s1, st1) = CollectSink::new();
+        let (s2, st2) = CollectSink::new();
+        let (s3, st3) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(10)))
+            .tee("t", 4, Some(3))
+            .sink("a", Box::new(s1))
+            .sink("b", Box::new(s2))
+            .sink("c", Box::new(s3))
+            .edge("s", "t")
+            .edge("t", "a")
+            .edge("t", "b")
+            .edge("t", "c")
+            .build()
+            .unwrap();
+        let result = topo.run(TopologyOptions::new("p")).await.unwrap();
+        assert_eq!(st1.lock().unwrap().len(), 10);
+        assert_eq!(st2.lock().unwrap().len(), 10);
+        assert_eq!(st3.lock().unwrap().len(), 10);
+        assert_eq!(result.records_written, 30);
+    }
+
+    #[tokio::test]
+    async fn merge_fans_in_two_sources() {
+        let (sink, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s1", VecSource::boxed(recs(4)))
+            .source("s2", VecSource::boxed(recs(6)))
+            .merge("m")
+            .sink("k", Box::new(sink))
+            .edge("s1", "m")
+            .edge("s2", "m")
+            .edge("m", "k")
+            .build()
+            .unwrap();
+        let result = topo.run(TopologyOptions::new("p")).await.unwrap();
+        assert_eq!(result.records_written, 10);
+        assert_eq!(store.lock().unwrap().len(), 10);
+    }
+
+    #[tokio::test]
+    async fn join_enriches_end_to_end() {
+        let (sink, store) = CollectSink::new();
+        let customers = vec![
+            json!({"id": 1, "tier": "gold"}),
+            json!({"id": 2, "tier": "silver"}),
+        ];
+        let orders = vec![
+            json!({"order": "A", "cust": 1}),
+            json!({"order": "B", "cust": 2}),
+            json!({"order": "C", "cust": 99}),
+        ];
+        let jn = JoinNode {
+            config: JoinConfig {
+                mode: JoinMode::Inner,
+                build_key: "id".into(),
+                probe_key: "cust".into(),
+                projections: vec![Projection {
+                    from: "tier".into(),
+                    as_: "tier".into(),
+                }],
+                ..Default::default()
+            },
+            build_edge: "customers".into(),
+            probe_edge: "orders".into(),
+        };
+        let topo = Topology::builder()
+            .source("c", VecSource::boxed(customers))
+            .source("o", VecSource::boxed(orders))
+            .join("j", jn)
+            .sink("k", Box::new(sink))
+            .labelled_edge("c", "j", "customers")
+            .labelled_edge("o", "j", "orders")
+            .edge("j", "k")
+            .build()
+            .unwrap();
+        let result = topo.run(TopologyOptions::new("p")).await.unwrap();
+        // inner join: C (cust 99) drops → 2 enriched records.
+        assert_eq!(result.records_written, 2);
+        let written = store.lock().unwrap();
+        assert!(
+            written
+                .iter()
+                .any(|r| r["order"] == json!("A") && r["tier"] == json!("gold"))
+        );
+    }
+
+    #[tokio::test]
+    async fn propagate_aborts_on_sink_failure() {
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(3)))
+            .sink("k", Box::new(FailingSink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+        let err = topo.run(TopologyOptions::new("p")).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Sink(_)));
+    }
+
+    #[tokio::test]
+    async fn propagate_aborts_on_source_failure() {
+        let (sink, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", Box::new(FailingSource))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+        let err = topo.run(TopologyOptions::new("p")).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Source(_)));
+    }
+
+    #[tokio::test]
+    async fn continue_lets_healthy_branch_finish() {
+        // One branch fails, the other still receives every record.
+        let (good, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(8)))
+            .tee("t", 8, Some(2))
+            .sink("bad", Box::new(FailingSink))
+            .sink("good", Box::new(good))
+            .edge("s", "t")
+            .edge("t", "bad")
+            .edge("t", "good")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_on_error(TopologyOnError::Continue);
+        let result = topo.run(opts).await.unwrap();
+        assert_eq!(store.lock().unwrap().len(), 8);
+        assert!(!result.errors.is_empty(), "failing sink should be recorded");
+    }
+
+    #[tokio::test]
+    async fn state_min_bookmark_applied_to_source() {
+        let store = Arc::new(MemoryStateStore::new());
+        // Two sinks with diverged bookmarks; source must resume from min.
+        store.put("p::a", &json!(250)).await.unwrap();
+        store.put("p::b", &json!(100)).await.unwrap();
+        let applied = Arc::new(Mutex::new(None));
+        let src = RecordingSource {
+            records: recs(1),
+            applied: applied.clone(),
+        };
+        let (s1, _) = CollectSink::new();
+        let (s2, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", Box::new(src))
+            .tee("t", 4, Some(2))
+            .sink("a", Box::new(s1))
+            .sink("b", Box::new(s2))
+            .edge("s", "t")
+            .edge("t", "a")
+            .edge("t", "b")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        topo.run(opts).await.unwrap();
+        assert_eq!(*applied.lock().unwrap(), Some(json!(100)));
+    }
+
+    #[tokio::test]
+    async fn state_no_bookmark_when_a_sink_is_missing() {
+        let store = Arc::new(MemoryStateStore::new());
+        store.put("p::a", &json!(100)).await.unwrap();
+        // sink b has no stored bookmark → full replay (no apply).
+        let applied = Arc::new(Mutex::new(None));
+        let src = RecordingSource {
+            records: recs(1),
+            applied: applied.clone(),
+        };
+        let (s1, _) = CollectSink::new();
+        let (s2, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", Box::new(src))
+            .tee("t", 4, Some(2))
+            .sink("a", Box::new(s1))
+            .sink("b", Box::new(s2))
+            .edge("s", "t")
+            .edge("t", "a")
+            .edge("t", "b")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        topo.run(opts).await.unwrap();
+        assert_eq!(*applied.lock().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn sink_persists_bookmark() {
+        let store = Arc::new(MemoryStateStore::new());
+        let (sink, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed_bm(recs(2), json!("v9")))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        let result = topo.run(opts).await.unwrap();
+        assert_eq!(result.bookmarks.get("k"), Some(&Some(json!("v9"))));
+        assert_eq!(store.get("p::k").await.unwrap(), Some(json!("v9")));
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_the_run() {
+        let cancel = CancellationToken::new();
+        cancel.cancel(); // pre-cancelled
+        let (sink, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(1000)))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_cancel(cancel);
+        let result = topo.run(opts).await.unwrap();
+        // Cancelled before/early: far fewer than 1000 records written.
+        assert!(store.lock().unwrap().len() < 1000);
+        let _ = result;
+    }
+
+    #[test]
+    fn min_bookmark_picks_smallest() {
+        assert_eq!(
+            min_bookmark(&[json!(250), json!(100), json!(300)]),
+            Some(json!(100))
+        );
+        assert_eq!(min_bookmark(&[]), None);
+    }
+
+    #[test]
+    fn kind_str_matches() {
+        assert_eq!(NodeKind::Merge.kind_str(), "merge");
+        assert_eq!(
+            NodeKind::Tee {
+                capacity: 1,
+                fanout: None
+            }
+            .kind_str(),
+            "tee"
+        );
+    }
+
+    #[test]
+    fn builder_exposes_nodes_and_edges() {
+        let (sink, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(1)))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+        assert_eq!(topo.nodes().len(), 2);
+        assert_eq!(topo.edges().len(), 1);
+    }
+
+    #[cfg(feature = "transform-keys-case")]
+    #[tokio::test]
+    async fn transform_node_applies_stage() {
+        use crate::stage::{TransformStage, compile_stage};
+        use crate::transform::{KeyCaseMode, RecordTransform};
+        let stage = compile_stage(&TransformStage::Map(RecordTransform::KeysCase {
+            mode: KeyCaseMode::Snake,
+        }))
+        .unwrap();
+        let (sink, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(vec![json!({"FooBar": 1})]))
+            .transform("t", vec![stage])
+            .sink("k", Box::new(sink))
+            .edge("s", "t")
+            .edge("t", "k")
+            .build()
+            .unwrap();
+        topo.run(TopologyOptions::new("p")).await.unwrap();
+        let w = store.lock().unwrap();
+        assert!(w[0].get("foo_bar").is_some());
+    }
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -41,6 +41,7 @@
 - [SQL transform](./cookbook/sql-transform.md)
 - [Secrets-manager interpolation](./cookbook/secrets.md)
 - [Config composition](./cookbook/composition.md)
+- [Topology mode (tee / merge / join)](./cookbook/topology.md)
 - [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Throughput tuning](./cookbook/tuning.md)
 - [Scheduling](./cookbook/scheduling.md)

--- a/docs/book/src/cookbook/topology.md
+++ b/docs/book/src/cookbook/topology.md
@@ -1,0 +1,133 @@
+# Topology mode (tee / merge / join)
+
+The default pipeline moves records from one source to one sink. **Topology
+mode** generalizes that to an explicit graph of typed nodes, so a single run
+can:
+
+- **fan-out (tee)** — fetch a source once and route the same records to several
+  sinks (no refetch, no divergence);
+- **fan-in (merge)** — concatenate several sources into one sink;
+- **join** — enrich one stream with fields looked up from another by key.
+
+Declare `pipeline.nodes` (a map of node id → node) and `pipeline.edges`
+(producer → consumer connections). Topology mode is **mutually exclusive** with
+`matrix:`.
+
+## Node kinds
+
+| `kind` | in | out | fields |
+|--------|----|-----|--------|
+| `source` | 0 | 1 | `ref:` (a `pipeline.sources` template) + optional `type` / `config` overrides |
+| `transform` | 1 | 1 | `transforms:` (the usual transform list) |
+| `tee` | 1 | N | `channel_capacity` (default 4), optional `fanout` sanity-check |
+| `merge` | N | 1 | — |
+| `join` | 2 | 1 | see [Joins](#joins) |
+| `sink` | 1 | 0 | `ref:` (a `pipeline.sinks` template) + optional `type` / `config` overrides |
+
+## Fan-out (tee)
+
+```yaml
+version: 1
+name: fan_out
+pipeline:
+  sources:
+    orders: { type: csv, config: { path: ./data/orders.csv } }
+  sinks:
+    warehouse: { type: jsonl, config: { path: ./out/warehouse.jsonl } }
+    archive:   { type: jsonl, config: { path: ./out/archive.jsonl } }
+  nodes:
+    src:  { kind: source, ref: orders }
+    norm: { kind: transform, transforms: [ { type: keys_case, config: { mode: snake } } ] }
+    fan:  { kind: tee, channel_capacity: 4, fanout: 2 }
+    w1:   { kind: sink, ref: warehouse }
+    w2:   { kind: sink, ref: archive }
+  edges:
+    - { from: src,  to: norm }
+    - { from: norm, to: fan }
+    - { from: fan,  to: w1 }
+    - { from: fan,  to: w2 }
+```
+
+Nodes run concurrently, connected by bounded channels: the slowest sink paces
+its producer (backpressure). The `tee` clones each page to every downstream
+edge.
+
+## Fan-in (merge)
+
+```yaml
+  nodes:
+    a: { kind: source, ref: orders }
+    b: { kind: source, ref: returns }
+    m: { kind: merge }
+    w: { kind: sink, ref: combined }
+  edges:
+    - { from: a, to: m }
+    - { from: b, to: m }
+    - { from: m, to: w }
+```
+
+`merge` forwards pages from all inputs in arrival order.
+
+## Joins
+
+A `join` node hash-joins two upstreams. The **build** (right) side is buffered
+into an in-memory index keyed by `build.key`; then the **probe** (left) side is
+streamed and each record enriched with the `project`ed fields of its match. The
+join's two incoming edges carry `as:` labels that match `build.edge` /
+`probe.edge`.
+
+```yaml
+  nodes:
+    fetch_customers: { kind: source, ref: customers }
+    fetch_orders:    { kind: source, ref: orders }
+    enrich:
+      kind: join
+      mode: left                 # `inner` drops non-matches; `left` keeps them
+      build: { edge: customers_in, key: id }
+      probe: { edge: orders_in,    key: customer_id }
+      project:
+        - { from: tier, as: customer_tier }
+      on_missing: null           # left-mode fill when there is no match
+      on_duplicate: first        # or `cartesian` (one output row per build match)
+      on_collision: overwrite    # or `skip` / `error`
+      key_normalize: preserve    # or `stringify` so "42" matches 42
+      max_build_records: 10000000
+    write: { kind: sink, ref: warehouse }
+  edges:
+    - { from: fetch_customers, to: enrich, as: customers_in }
+    - { from: fetch_orders,    to: enrich, as: orders_in }
+    - { from: enrich,          to: write }
+```
+
+The build side is fully materialized before probing begins, so pair a large
+dimension table with a fast local source (SQLite / Parquet) rather than a slow
+remote API, and keep `max_build_records` as a guardrail.
+
+## State and errors
+
+Each terminal sink owns a bookmark under `{name}::{node_id}`. On restart the
+source resumes from the **minimum** across every sink's stored bookmark (only
+when all sinks have one), so a lagging sink is never skipped — sinks whose
+bookmarks diverge must be idempotent.
+
+`execution.on_error: stop` aborts the whole topology on the first failure;
+`continue` lets healthy branches finish and reports the failures at the end.
+
+## Observability
+
+Topology runs emit the standard sink/transform/state metrics plus
+`faucet_tee_records_total`, `faucet_merge_records_total`, and the
+`faucet_join_*` family (`build_records`, `probe_records`, `matches`, `misses`,
+`duplicates`, `build_nulls`, `project_misses`, `build_duration_seconds`),
+labelled `pipeline` + `node`.
+
+## Runnable examples
+
+- `cli/examples/topology_tee_users.yaml` — fan-out to three sinks.
+- `cli/examples/topology_merge_files.yaml` — fan-in of two CSV sources.
+- `cli/examples/topology_join_orders_countries.yaml` — left-join enrichment.
+
+```bash
+faucet validate cli/examples/topology_join_orders_countries.yaml
+faucet run      cli/examples/topology_join_orders_countries.yaml
+```

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -264,6 +264,17 @@ Semantics:
 - Ordering works identically under `faucet run`, `schedule`, and `serve` —
   they all execute the same expanded plan.
 
+## `pipeline.nodes` / `pipeline.edges` (topology mode)
+
+An alternative to `matrix:` for pipelines that need fan-out, fan-in, or joins:
+declare an explicit graph of typed nodes (`source` / `transform` / `tee` /
+`merge` / `join` / `sink`) under `pipeline.nodes`, connected by
+`pipeline.edges` (`{ from, to, as? }`). Topology mode is **mutually exclusive**
+with `matrix:` — both non-empty is a load-time error. `faucet run` / `validate`
+/ `preview` all understand it. See
+[Topology mode](../cookbook/topology.md) for the full grammar, the `join:`
+node, state semantics, and runnable examples.
+
 ## Row selection
 
 Register many rows, run a few. Selection resolves **after** expansion and never

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -304,6 +304,20 @@
               "type": "null"
             }
           ]
+        },
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/NodeSpec"
+          },
+          "description": "Topology-mode nodes (issue #71): an explicit graph of typed nodes\n(`source` / `transform` / `tee` / `merge` / `join` / `sink`) keyed by\nnode id. When non-empty this pipeline runs in **topology mode** and the\ntop-level `matrix:` block must be empty (they are mutually exclusive).",
+          "type": "object"
+        },
+        "edges": {
+          "description": "Topology-mode edges connecting `nodes` (issue #71). Each edge names a\nproducer (`from`) and consumer (`to`); a join's incoming edges also\ncarry an `as:` label matching the join's `build`/`probe` edge names.",
+          "items": {
+            "$ref": "#/$defs/EdgeSpec"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false
@@ -16267,6 +16281,325 @@
           "additionalProperties": false
         }
       ]
+    },
+    "EdgeSpec": {
+      "additionalProperties": false,
+      "description": "A topology edge (issue #71).",
+      "properties": {
+        "as": {
+          "description": "Optional edge label (required on a join's two incoming edges).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "from": {
+          "description": "Producer node id.",
+          "type": "string"
+        },
+        "to": {
+          "description": "Consumer node id.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
+    "JoinMode": {
+      "description": "Join mode — how probe records with no build match are handled.",
+      "oneOf": [
+        {
+          "const": "inner",
+          "description": "Drop probe records that have no matching build record.",
+          "type": "string"
+        },
+        {
+          "const": "left",
+          "description": "Pass probe records through even without a match, filling projected\nfields from [`JoinConfig::on_missing`].",
+          "type": "string"
+        }
+      ]
+    },
+    "JoinSide": {
+      "additionalProperties": false,
+      "description": "One side of a [`JoinSpec`]: the incoming edge label plus the dotted key path.",
+      "properties": {
+        "edge": {
+          "description": "Name of the incoming edge (matches an `edges[].as` label).",
+          "type": "string"
+        },
+        "key": {
+          "description": "Dotted path to the join key inside each record on this side.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "edge",
+        "key"
+      ],
+      "type": "object"
+    },
+    "KeyNormalize": {
+      "description": "How to normalize keys before comparison.",
+      "oneOf": [
+        {
+          "const": "preserve",
+          "description": "Compare keys as their JSON value (no coercion): `\"42\"` != `42`.",
+          "type": "string"
+        },
+        {
+          "const": "stringify",
+          "description": "Coerce scalar keys to their string form before comparison so `\"42\"`\nand `42` match.",
+          "type": "string"
+        }
+      ]
+    },
+    "NodeSpec": {
+      "description": "A single topology node (issue #71). The `kind` discriminator selects the\nnode type; the remaining fields are kind-specific.\n\n`source` / `sink` nodes pick a template with `ref:` (defaulting to\n`default`) and may override `type` / `config` inline — the same shape as a\nmatrix row's [`PartialConnector`]. `transform` carries a `transforms:`\nlist. `tee` carries `channel_capacity` + optional `fanout`. `merge` has no\nextra fields. `join` carries the hash-join configuration.",
+      "oneOf": [
+        {
+          "description": "A data source (0 in, 1 out).",
+          "properties": {
+            "config": {
+              "description": "Inline config override (deep-merged onto the resolved template)."
+            },
+            "kind": {
+              "const": "source",
+              "type": "string"
+            },
+            "ref": {
+              "description": "Template name in `pipeline.sources` (defaults to `default`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "description": "Inline connector-type override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A data sink (1 in, 0 out).",
+          "properties": {
+            "config": {
+              "description": "Inline config override (deep-merged onto the resolved template)."
+            },
+            "kind": {
+              "const": "sink",
+              "type": "string"
+            },
+            "ref": {
+              "description": "Template name in `pipeline.sinks` (defaults to `default`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "description": "Inline connector-type override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Transform stages applied per page (1 in, 1 out).",
+          "properties": {
+            "kind": {
+              "const": "transform",
+              "type": "string"
+            },
+            "transforms": {
+              "default": [],
+              "description": "Transform stages, in order.",
+              "items": {
+                "$ref": "#/$defs/TransformSpec"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Fan-out: clone each page to every downstream edge (1 in, N out).",
+          "properties": {
+            "channel_capacity": {
+              "default": 4,
+              "description": "Bounded-channel capacity for each outgoing edge.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fanout": {
+              "description": "Optional expected fan-out (outgoing edge count) sanity check.",
+              "format": "uint",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "tee",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Fan-in: forward pages from all inputs in arrival order (N in, 1 out).",
+          "properties": {
+            "kind": {
+              "const": "merge",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Hash-join two upstreams by key (2 in, 1 out).",
+          "properties": {
+            "build": {
+              "$ref": "#/$defs/JoinSide",
+              "description": "The build (right) side — fully buffered as a lookup index."
+            },
+            "key_normalize": {
+              "$ref": "#/$defs/KeyNormalize",
+              "default": "preserve",
+              "description": "Key normalization: `preserve` (no coercion) or `stringify`."
+            },
+            "kind": {
+              "const": "join",
+              "type": "string"
+            },
+            "max_build_records": {
+              "default": 10000000,
+              "description": "Safety cap on build-side records.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mode": {
+              "$ref": "#/$defs/JoinMode",
+              "default": "inner",
+              "description": "`inner` (drop non-matches) or `left` (keep non-matches)."
+            },
+            "on_collision": {
+              "$ref": "#/$defs/OnCollision",
+              "default": "overwrite",
+              "description": "Projection-collision policy: `overwrite` / `skip` / `error`."
+            },
+            "on_duplicate": {
+              "$ref": "#/$defs/OnDuplicate",
+              "default": "first",
+              "description": "Multi-match policy: `first` or `cartesian`."
+            },
+            "on_missing": {
+              "default": null,
+              "description": "Value used to fill projected fields on a `left`-mode non-match."
+            },
+            "probe": {
+              "$ref": "#/$defs/JoinSide",
+              "description": "The probe (left) side — streamed and enriched."
+            },
+            "project": {
+              "default": [],
+              "description": "Fields to copy from the matched build record onto the probe record.",
+              "items": {
+                "$ref": "#/$defs/Projection"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "build",
+            "probe"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "OnCollision": {
+      "description": "What to do when a projected `as` name collides with an existing field on\nthe probe record.",
+      "oneOf": [
+        {
+          "const": "overwrite",
+          "description": "Overwrite the probe record's field with the projected value.",
+          "type": "string"
+        },
+        {
+          "const": "skip",
+          "description": "Leave the probe record's field untouched; skip the projection.",
+          "type": "string"
+        },
+        {
+          "const": "error",
+          "description": "Fail the record with a typed error.",
+          "type": "string"
+        }
+      ]
+    },
+    "OnDuplicate": {
+      "description": "What to do when one probe key matches more than one build record.",
+      "oneOf": [
+        {
+          "const": "first",
+          "description": "Keep only the first build-side match (deterministic given build order).",
+          "type": "string"
+        },
+        {
+          "const": "cartesian",
+          "description": "Emit one enriched record per build-side match (may duplicate the probe\nrecord).",
+          "type": "string"
+        }
+      ]
+    },
+    "Projection": {
+      "description": "A single field projection: copy `from` (a dotted path into the build\nrecord) onto the probe record under the name `as_`.",
+      "properties": {
+        "as": {
+          "description": "Output field name written onto the probe (left) record.",
+          "type": "string"
+        },
+        "from": {
+          "description": "Dotted path inside each build (right) record.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "as"
+      ],
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds an explicit **node-graph pipeline mode** alongside the matrix, closing **#71** (multi-edge topology: fan-out / fan-in) and **#72** (cross-source join). A config with a `pipeline.nodes` / `pipeline.edges` block runs as a directed graph of typed nodes instead of a matrix (the two are mutually exclusive).

```yaml
pipeline:
  sources: { orders: { type: csv, config: { path: ./orders.csv } } }
  sinks:   { wh: { type: jsonl, config: { path: ./wh.jsonl } },
             ar: { type: jsonl, config: { path: ./ar.jsonl } } }
  nodes:
    src: { kind: source, ref: orders }
    fan: { kind: tee, fanout: 2 }
    a:   { kind: sink, ref: wh }
    b:   { kind: sink, ref: ar }
  edges:
    - { from: src, to: fan }
    - { from: fan, to: a }
    - { from: fan, to: b }
```

## What's in it

**`faucet-core`**
- `join.rs` — pure hash-join (`HashJoin`/`JoinConfig`): `inner`/`left`, `first`/`cartesian` duplicates, `overwrite`/`skip`/`error` collisions, `preserve`/`stringify` key normalization, `max_build_records` guard, `JoinStats`.
- `topology.rs` — `Topology`/`TopologyBuilder`, typed `NodeKind` (source/transform/tee/merge/join/sink), a bounded-channel **cooperative** executor (backpressure; no `tokio::spawn`, so no extra `rt` feature), sink nodes reuse `run_stream` (DLQ/bookmark/observability for free), full graph validation (arity, tee fan-out, join edge labels, cycle, source→sink reachability), per-sink bookmarks with `min()` resume, and `faucet_tee_*` / `faucet_merge_*` / `faucet_join_*` metrics (labels `pipeline` + `node`).

**`faucet-cli`**
- `pipeline.nodes` / `edges` grammar (`NodeSpec`, `EdgeSpec`, `JoinSpec`, `JoinSide`).
- `topology.rs` — resolves node connector templates (`ref` + inline overrides) + transforms and drives the core topology; `run` / `validate` / `preview` all branch to it.
- New typed errors: `MatrixAndNodesBothPresent`, `EdgeEndpointMissing`, `InvalidTopology`, `TopologyHadFailures`.

**Docs / examples / schema**
- cli/README.md + mdBook cookbook page + config reference; three runnable examples (`topology_tee_users`, `topology_merge_files`, `topology_join_orders_countries`); regenerated `schemas/faucet.schema.json`.

## Testing

- 30 join unit tests, 29 core topology unit tests, 18 CLI integration tests (tee/merge/join end-to-end via the binary, plus validate/preview/output-format/failure/error paths).
- Line coverage of the new files: join.rs **97.8%**, core topology.rs **96.0%**, cli topology.rs **98.2%**.
- `cargo fmt`, `cargo clippy` (core `--all-features`; cli on the changed paths), core docs, and the three examples' `validate` + `run` all pass locally.

Closes #71
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)