### PR TITLE
docs: fix Guide badge 404 (escape hyphen in shields static badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-stream.svg)](https://crates.io/crates/faucet-stream)
 [![Docs.rs](https://docs.rs/faucet-stream/badge.svg)](https://docs.rs/faucet-stream)
-[![Guide](https://img.shields.io/badge/guide-faucet-hq.github.io-1f6feb)](https://faucet-hq.github.io/faucet-stream/)
+[![Guide](https://img.shields.io/badge/guide-faucet--hq.github.io-1f6feb)](https://faucet-hq.github.io/faucet-stream/)
 [![CI](https://github.com/faucet-hq/faucet-stream/actions/workflows/ci.yml/badge.svg)](https://github.com/faucet-hq/faucet-stream/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/faucet-hq/faucet-stream/branch/main/graph/badge.svg)](https://codecov.io/gh/faucet-hq/faucet-stream)
 [![Downloads](https://img.shields.io/crates/d/faucet-core.svg)](https://crates.io/crates/faucet-stream)


### PR DESCRIPTION
The re-host scrub turned the Guide badge's `pawansikawat.github.io` into `faucet-hq.github.io`. shields.io **static** badges use `/badge/LABEL-MESSAGE-COLOR` with `-` as the field separator, so the new hyphen in `faucet-hq` made a 3-dash path shields can't parse → **"404: badge not found"**.

Fix: escape the literal hyphen as `--` → `faucet--hq.github.io` (renders "faucet-hq.github.io"). Verified against shields.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)