### PR TITLE
fix(release): static commit message (multi-crate release can't fill placeholders)

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -18,7 +18,12 @@ shared-version = false
 tag-prefix = ""
 tag-name = "{{crate_name}}-v{{version}}"
 
-# Commit message format
-pre-release-commit-message = "release: {{crate_name}} v{{version}}"
+# Commit message format. Must be a STATIC string: this workspace releases many
+# crates in one consolidated commit (shared-version = false, and scope=all in
+# release.yml), so per-crate placeholders like {{crate_name}}/{{version}} are
+# ambiguous for a multi-crate commit and cargo-release leaves them un-rendered
+# (that's how a literal "release: {{crate_name}} v{{version}}" landed on main).
+# Per-crate identity still lives in the tags (tag-name above).
+pre-release-commit-message = "chore: release"
 
 push-remote = "origin"


### PR DESCRIPTION
`release.toml` set `pre-release-commit-message = "release: {{crate_name}} v{{version}}"`. Because `shared-version = false` and `release.yml` does `scope=all` (many crates → one consolidated commit), cargo-release can't resolve `{{crate_name}}`/`{{version}}` for that commit and leaves them **literal** — which is why `main` HEAD showed `release: {{crate_name}} v{{version}}`.

Fix: use a static `chore: release` (matches release-plz's convention). Per-crate identity is still carried by the per-crate **tags** (`tag-name = "{{crate_name}}-v{{version}}"`, which substitute correctly).

Cosmetic-only; the past commit in history is left as-is (not worth rewriting protected `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)