### PR TITLE
ci(release): manual release checks out with RELEASE_PLZ_TOKEN (admin PAT)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Check out (and thus push commits/tags) with an admin PAT, not the
+          # bot GITHUB_TOKEN. Two reasons:
+          #  1. GitHub suppresses workflow triggers from GITHUB_TOKEN-pushed
+          #     refs, so tags pushed here would NOT trigger release-binaries.yml
+          #     (no CLI binaries / Homebrew update). A PAT-pushed tag does.
+          #  2. With a `main` ruleset bypass for this token/App, the version-bump
+          #     commit can push to protected `main` without disabling protection.
+          # Falls back to GITHUB_TOKEN if the PAT secret is unset.
+          token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
 
       # ── DISABLED 2026-08-07 ──────────────────────────────────────────────
       # This job no longer compiles the workspace (fmt/clippy/test were removed


### PR DESCRIPTION
Part B of the release-automation fix (#2): the **manual** `release.yml` checked out (and pushed commits/tags) with the bot `GITHUB_TOKEN`. That caused two of the pains we hit this session:

1. **`release-binaries.yml` never fired** — GitHub suppresses workflow triggers from `GITHUB_TOKEN`-pushed refs, so the CLI binaries + Homebrew tap update didn't happen for the last release.
2. **Push to protected `main` was GH006-rejected** — the bot isn't an admin.

Switch the checkout token to `RELEASE_PLZ_TOKEN` (the admin PAT already used by `release-plz.yml`), falling back to `GITHUB_TOKEN` if unset. Then tag pushes trigger `release-binaries.yml`, and — combined with **Part A** (a `main` ruleset with a bypass entry for this token/App, an org setting) — the version-bump commit pushes to `main` without disabling branch protection.

**Part A is not in this PR** (it's a repo/org settings change only you can make). This PR is the one-line workflow half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)