### PR TITLE
fix: resolve the fourth hardening audit — topology governance bypass, SQS at-most-once, control-plane secret leaks (#456)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,18 @@ ARG SINKS=""
 # Deliberately excludes the `source`/`sink`/`default` aggregates so a lean build
 # stays lean. `state` = all state backends (memory+file are free; redis/postgres
 # link a driver — drop it from EXTRAS if you don't need them).
-ARG EXTRAS="observability,state,transforms,compression,quality,contract,masking,cli-progress,serve,serve-ui,schedule,catalog,serve-history-postgres,serve-history-sqlite,notify,triggers"
+#
+# `triggers` here is the framework + the webhook trigger type only. The
+# `object_arrival` and `queue_depth` watchers need `triggers-object-store` /
+# `triggers-redis` / `triggers-kafka`, which pull heavy (and for Kafka, native)
+# dependency trees — add them explicitly when a lean image needs them. The
+# complete image below includes all three.
+ARG EXTRAS="observability,state,transforms,compression,quality,contract,masking,cli-progress,serve,serve-ui,schedule,catalog,serve-history-postgres,serve-history-sqlite,notify,lineage,templates,mcp,triggers"
 # The "complete" set used when neither SOURCES nor SINKS is given. `default`
-# already pulls every source+sink+state+transform; we add the runtime modes.
-ARG DEFAULT_FEATURES="default,serve,serve-ui,schedule,catalog,serve-history-postgres,serve-history-sqlite,notify,triggers"
+# already pulls every source+sink+state+transform; we add every runtime mode —
+# including all three trigger watchers, the template registry, and the MCP
+# endpoint, so nothing the Helm chart or docs reference 404s at runtime.
+ARG DEFAULT_FEATURES="default,serve,serve-ui,schedule,catalog,serve-history-postgres,serve-history-sqlite,notify,templates,mcp,lineage,triggers,triggers-object-store,triggers-redis,triggers-kafka"
 # Raw override — when set, wins over everything above.
 ARG FEATURES=""
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -185,7 +185,17 @@ pub(crate) async fn execute(
     // surfaces (`--output text|json|ndjson`), then return.
     if crate::topology::is_topology(&cfg) {
         let started_at = Utc::now();
-        let summary = crate::topology::run_topology(&cfg, &auth, None).await?;
+        let summary = crate::topology::run_topology(
+            &cfg,
+            &auth,
+            crate::topology::TopologyRunOptions {
+                cancel: None,
+                dry_run: args.dry_run,
+                limit: args.limit,
+                clock: Some(resolve_run_clock(args.clock.as_deref())?),
+            },
+        )
+        .await?;
         let finished_at = Utc::now();
         return finish_topology_run(
             &pipeline_name,

--- a/cli/src/commands/template.rs
+++ b/cli/src/commands/template.rs
@@ -457,17 +457,16 @@ async fn run_template(args: TemplateRunArgs) -> CliResult<()> {
     let env = crate::params::collect_env_overrides(&args.param_env)?;
     let selector = VersionSelector::parse(&args.version)?;
     let want = crate::templates::resolve_version(&store, &args.id, selector).await?;
-    let materialized =
-        crate::templates::materialize(
-            &store,
-            &args.id,
-            want,
-            &supplied,
-            &env,
-            // `faucet template run` executes locally; nothing is persisted.
-            crate::templates::Materialize::Local,
-        )
-        .await?;
+    let materialized = crate::templates::materialize(
+        &store,
+        &args.id,
+        want,
+        &supplied,
+        &env,
+        // `faucet template run` executes locally; nothing is persisted.
+        crate::templates::Materialize::Local,
+    )
+    .await?;
 
     tracing::info!(
         template = %materialized.template_id,

--- a/cli/src/commands/template.rs
+++ b/cli/src/commands/template.rs
@@ -458,7 +458,16 @@ async fn run_template(args: TemplateRunArgs) -> CliResult<()> {
     let selector = VersionSelector::parse(&args.version)?;
     let want = crate::templates::resolve_version(&store, &args.id, selector).await?;
     let materialized =
-        crate::templates::materialize(&store, &args.id, want, &supplied, &env).await?;
+        crate::templates::materialize(
+            &store,
+            &args.id,
+            want,
+            &supplied,
+            &env,
+            // `faucet template run` executes locally; nothing is persisted.
+            crate::templates::Materialize::Local,
+        )
+        .await?;
 
     tracing::info!(
         template = %materialized.template_id,

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -101,6 +101,12 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         for n in topo.nodes() {
             println!("  - {} ({})", n.id, n.kind.kind_str());
         }
+        // Say what topology mode will *not* do. Printing "valid" while silently
+        // ignoring a declared block is how an operator ends up believing a policy
+        // is enforced when it is not (#456 M2).
+        for (block, consequence) in crate::topology::inert_blocks(&cfg) {
+            println!("  WARNING: `{block}:` is ignored in topology mode — {consequence}");
+        }
         return Ok(());
     }
 

--- a/cli/src/dlq_replay/plan.rs
+++ b/cli/src/dlq_replay/plan.rs
@@ -147,6 +147,23 @@ pub fn build_replay_node(
 
     let reader = DlqReaderSource::new(from_files, reason, decryptor);
     node.source_override = Some(SourceOverride::new(Box::new(reader)));
+
+    // A DLQ envelope's `payload` is the record as it entered the *write* path —
+    // i.e. already transformed and already masked (the masking pass runs first per
+    // page, so quarantine and write-failure envelopes both hold masked values).
+    // Re-running those two passes on replay would apply them a second time, and
+    // neither is idempotent: the `hash` transform and masking's `hash`/`tokenize`
+    // actions would produce H(H(x)), breaking the joinability masking exists to
+    // guarantee; `set` would re-stamp `${now.*}` with the replay time; `cast` /
+    // `json_parse` / `split` would re-run against already-converted values. So a
+    // replay skips both (#456 H3).
+    //
+    // The quality and contract passes are deliberately kept: they are pure
+    // predicates over the record, so re-checking is idempotent — and a replay is
+    // exactly when you want them re-enforced.
+    node.transforms.clear();
+    node.masking = None;
+
     // A replay reads the whole DLQ location once — no bookmarking, and never
     // exactly-once (the reader is not a deterministic-replay source).
     node.state = None;
@@ -340,5 +357,80 @@ mod tests {
             Some("quality"),
             None
         ));
+    }
+}
+
+#[cfg(test)]
+mod replay_shaping_tests {
+    use super::*;
+    use crate::config::PipelineConfig;
+
+    fn cfg(extra: &str) -> PipelineConfig {
+        let yaml = format!(
+            r#"version: 1
+name: replay-shape
+pipeline:
+{extra}  source: {{ type: csv, config: {{ path: ./in.csv }} }}
+  sink: {{ type: jsonl, config: {{ path: ./out.jsonl }} }}
+  dlq:
+    sink: {{ type: jsonl, config: {{ path: ./dlq.jsonl }} }}
+"#
+        );
+        PipelineConfig::from_text(&yaml, Path::new("test.yaml")).expect("parses")
+    }
+
+    /// #456 H3: a DLQ payload is already transformed and already masked, so a
+    /// replay must not run either pass again — `hash`, `set ${now.*}`, `cast`,
+    /// and masking's `hash`/`tokenize` are not idempotent, and re-applying them
+    /// writes values the original path would never have produced.
+    #[test]
+    fn replay_drops_the_transform_chain_and_masking() {
+        let cfg = cfg("  transforms:\n    - { type: keys_case, config: { mode: snake } }\n  masking:\n    rules:\n      - name: h\n        match: { fields: [email] }\n        action: { type: hash }\n");
+        // Sanity: the config really does declare both, so the assertions below are
+        // about the replay shaping and not about an empty config.
+        let expanded = crate::expand::expand(&cfg).unwrap();
+        assert_eq!(expanded[0].transforms.len(), 1);
+        assert!(expanded[0].masking.is_some());
+
+        let node = build_replay_node(
+            &cfg,
+            vec![PathBuf::from("./dlq.jsonl")],
+            None,
+            Path::new("./failed.jsonl"),
+            None,
+            DlqDecryptor::default(),
+        )
+        .expect("builds");
+
+        assert!(
+            node.transforms.is_empty(),
+            "the chain already ran before the payload was captured"
+        );
+        assert!(
+            node.masking.is_none(),
+            "the payload in the envelope is already masked"
+        );
+        // Pure predicates stay on: re-checking a replayed record is idempotent.
+        assert!(node.source_override.is_some());
+        assert_eq!(node.delivery, DeliveryMode::AtLeastOnce);
+        assert!(node.state.is_none());
+    }
+
+    /// Quality and contract are pure checks, so a replay keeps enforcing them.
+    #[test]
+    fn replay_keeps_quality_and_contract() {
+        let cfg = cfg(
+            "  quality:\n    record:\n      - { type: not_null, field: id, on_failure: abort }\n",
+        );
+        let node = build_replay_node(
+            &cfg,
+            vec![PathBuf::from("./dlq.jsonl")],
+            None,
+            Path::new("./failed.jsonl"),
+            None,
+            DlqDecryptor::default(),
+        )
+        .expect("builds");
+        assert!(node.quality.is_some(), "checks are idempotent; keep them");
     }
 }

--- a/cli/src/dlq_replay/plan.rs
+++ b/cli/src/dlq_replay/plan.rs
@@ -385,7 +385,9 @@ pipeline:
     /// writes values the original path would never have produced.
     #[test]
     fn replay_drops_the_transform_chain_and_masking() {
-        let cfg = cfg("  transforms:\n    - { type: keys_case, config: { mode: snake } }\n  masking:\n    rules:\n      - name: h\n        match: { fields: [email] }\n        action: { type: hash }\n");
+        let cfg = cfg(
+            "  transforms:\n    - { type: keys_case, config: { mode: snake } }\n  masking:\n    rules:\n      - name: h\n        match: { fields: [email] }\n        action: { type: hash }\n",
+        );
         // Sanity: the config really does declare both, so the assertions below are
         // about the replay shaping and not about an empty config.
         let expanded = crate::expand::expand(&cfg).unwrap();

--- a/cli/src/dlq_replay/plan.rs
+++ b/cli/src/dlq_replay/plan.rs
@@ -162,7 +162,10 @@ pub fn build_replay_node(
     // predicates over the record, so re-checking is idempotent — and a replay is
     // exactly when you want them re-enforced.
     node.transforms.clear();
-    node.masking = None;
+    #[cfg(feature = "masking")]
+    {
+        node.masking = None;
+    }
 
     // A replay reads the whole DLQ location once — no bookmarking, and never
     // exactly-once (the reader is not a deterministic-replay source).
@@ -365,6 +368,19 @@ mod replay_shaping_tests {
     use super::*;
     use crate::config::PipelineConfig;
 
+    /// Build the replay node for `cfg` with fixed paths.
+    fn replay_node(cfg: &PipelineConfig) -> ExpandedNode {
+        build_replay_node(
+            cfg,
+            vec![PathBuf::from("./dlq.jsonl")],
+            None,
+            Path::new("./failed.jsonl"),
+            None,
+            DlqDecryptor::default(),
+        )
+        .expect("builds")
+    }
+
     fn cfg(extra: &str) -> PipelineConfig {
         let yaml = format!(
             r#"version: 1
@@ -379,48 +395,48 @@ pipeline:
         PipelineConfig::from_text(&yaml, Path::new("test.yaml")).expect("parses")
     }
 
-    /// #456 H3: a DLQ payload is already transformed and already masked, so a
-    /// replay must not run either pass again — `hash`, `set ${now.*}`, `cast`,
-    /// and masking's `hash`/`tokenize` are not idempotent, and re-applying them
-    /// writes values the original path would never have produced.
+    /// #456 H3: a DLQ payload is already transformed, so a replay must not run the
+    /// chain again — `hash`, `set ${now.*}`, `cast`, and `json_parse` are not
+    /// idempotent, and re-applying them writes values the original path would
+    /// never have produced.
     #[test]
-    fn replay_drops_the_transform_chain_and_masking() {
-        let cfg = cfg(
-            "  transforms:\n    - { type: keys_case, config: { mode: snake } }\n  masking:\n    rules:\n      - name: h\n        match: { fields: [email] }\n        action: { type: hash }\n",
-        );
-        // Sanity: the config really does declare both, so the assertions below are
+    fn replay_drops_the_transform_chain() {
+        let cfg = cfg("  transforms:\n    - { type: keys_case, config: { mode: snake } }\n");
+        // Sanity: the config really does declare a chain, so the assertion below is
         // about the replay shaping and not about an empty config.
         let expanded = crate::expand::expand(&cfg).unwrap();
         assert_eq!(expanded[0].transforms.len(), 1);
-        assert!(expanded[0].masking.is_some());
 
-        let node = build_replay_node(
-            &cfg,
-            vec![PathBuf::from("./dlq.jsonl")],
-            None,
-            Path::new("./failed.jsonl"),
-            None,
-            DlqDecryptor::default(),
-        )
-        .expect("builds");
-
+        let node = replay_node(&cfg);
         assert!(
             node.transforms.is_empty(),
             "the chain already ran before the payload was captured"
         );
-        assert!(
-            node.masking.is_none(),
-            "the payload in the envelope is already masked"
-        );
-        // Pure predicates stay on: re-checking a replayed record is idempotent.
         assert!(node.source_override.is_some());
         assert_eq!(node.delivery, DeliveryMode::AtLeastOnce);
         assert!(node.state.is_none());
     }
 
-    /// Quality and contract are pure checks, so a replay keeps enforcing them.
+    /// …and the payload is already masked, so the masking pass is dropped too:
+    /// masking's `hash`/`tokenize` would produce H(H(x)), breaking the
+    /// joinability masking exists to guarantee.
+    #[cfg(feature = "masking")]
     #[test]
-    fn replay_keeps_quality_and_contract() {
+    fn replay_drops_masking() {
+        let cfg = cfg(
+            "  masking:\n    rules:\n      - name: h\n        match: { fields: [email] }\n        action: { type: hash }\n",
+        );
+        assert!(crate::expand::expand(&cfg).unwrap()[0].masking.is_some());
+        assert!(
+            replay_node(&cfg).masking.is_none(),
+            "the payload in the envelope is already masked"
+        );
+    }
+
+    /// Quality is a pure check, so a replay keeps enforcing it.
+    #[cfg(feature = "quality")]
+    #[test]
+    fn replay_keeps_quality() {
         let cfg = cfg(
             "  quality:\n    record:\n      - { type: not_null, field: id, on_failure: abort }\n",
         );

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1583,7 +1583,7 @@ fn faucet_error_kind(err: &FaucetError) -> &'static str {
 /// `faucet backfill`, which substitutes them per window unit before the
 /// executor runs. Reaching here means another runtime picked up a
 /// window-scoped config.
-fn reject_unresolved_backfill_tokens(value: &Value, owner: &str) -> CliResult<()> {
+pub(crate) fn reject_unresolved_backfill_tokens(value: &Value, owner: &str) -> CliResult<()> {
     fn walk(value: &Value, owner: &str) -> CliResult<()> {
         match value {
             Value::String(s) if s.contains("${backfill.") => Err(CliError::Config(format!(
@@ -1642,8 +1642,8 @@ fn resolve_inplace(value: &mut Value, ctx: &HashMap<String, Value>) -> CliResult
 /// (audit #321 H1; for postgres-cdc it also lets Postgres recycle WAL for
 /// undelivered changes). Reads still pass through so the preview faithfully
 /// resumes from the existing bookmark.
-struct ReadOnlyStateStore {
-    inner: Arc<dyn StateStore>,
+pub(crate) struct ReadOnlyStateStore {
+    pub(crate) inner: Arc<dyn StateStore>,
 }
 
 #[async_trait]
@@ -1824,13 +1824,13 @@ impl Sink for CapturingSink {
 
 /// Cap on records written. Each `write_batch` call truncates `records` to the
 /// remaining budget before delegating.
-struct LimitedSink {
+pub(crate) struct LimitedSink {
     inner: Box<dyn Sink>,
     remaining: AtomicUsize,
 }
 
 impl LimitedSink {
-    fn wrap(inner: Box<dyn Sink>, cap: usize) -> Self {
+    pub(crate) fn wrap(inner: Box<dyn Sink>, cap: usize) -> Self {
         Self {
             inner,
             remaining: AtomicUsize::new(cap),
@@ -1865,12 +1865,12 @@ impl Sink for LimitedSink {
 
 /// No-op sink used in `--dry-run`. Counts records seen so the rest of the
 /// pipeline (transforms, source) still runs.
-struct CountingSink {
+pub(crate) struct CountingSink {
     seen: AtomicUsize,
 }
 
 impl CountingSink {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             seen: AtomicUsize::new(0),
         }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -98,6 +98,15 @@ pub fn run_main(registry: PluginRegistry) -> std::process::ExitCode {
         return ExitCode::from(1);
     }
 
+    // Hand `faucet-core` the secret scrubber before anything can produce output.
+    // Core builds two things that leave the process and that it cannot redact on
+    // its own: the DLQ envelope's `error.message`, and error text a caller
+    // forwards on. Installed here, at the single entry point, so every subcommand
+    // and runtime gets it (#456 H5).
+    faucet_core::redact::install(Box::new(|s: &str| {
+        secrets::registry::redact(s).into_owned()
+    }));
+
     // Dynamic shell completion (#383): when the shell invokes us with the
     // `COMPLETE` env var set, compute and print candidates, then exit — before
     // any normal parsing/tracing/runtime setup. A no-op otherwise. The registry

--- a/cli/src/mcp/mod.rs
+++ b/cli/src/mcp/mod.rs
@@ -29,6 +29,18 @@ pub struct McpContext {
     /// Whether mutating tools (`run_pipeline`, `register_template`,
     /// `run_template`) are exposed and callable.
     pub allow_mutations: bool,
+    /// Whether tools that **act on a caller-supplied config** — `validate_config`
+    /// and `preview` — are exposed and callable.
+    ///
+    /// These are read-only in the sense that they write nothing, but they are not
+    /// harmless: `preview` constructs the connector the caller describes and
+    /// returns its records, and both resolve `${env:}` / `${file:}` /
+    /// `${secret:}` against the *server's* environment and filesystem. On the
+    /// HTTP transport that is server-side file read and outbound network reach,
+    /// so it requires the same scope as `POST /v1/doctor` (operator+) rather than
+    /// the schema-read scope the route's baseline uses (#456 C4). The stdio
+    /// transport runs as the local user and sets this `true`.
+    pub allow_config_execution: bool,
     /// The pipeline template registry (#444), when one is wired: `faucet serve
     /// --mcp` passes its own `--history` backend; `faucet mcp` needs
     /// `--template-store`. Absent = the template tools are not advertised at all,
@@ -38,13 +50,24 @@ pub struct McpContext {
 }
 
 impl McpContext {
+    /// A context for a **local** caller (the `faucet mcp` stdio transport), which
+    /// already runs with the user's own privileges: config-executing tools are
+    /// enabled, mutations follow `allow_mutations`.
     pub fn new(auth: AuthCatalog, allow_mutations: bool) -> Self {
         Self {
             auth,
             allow_mutations,
+            allow_config_execution: true,
             #[cfg(feature = "templates")]
             templates: None,
         }
+    }
+
+    /// Set whether `validate_config` / `preview` are available. The HTTP
+    /// transport passes the caller's RBAC decision here.
+    pub fn with_config_execution(mut self, allow: bool) -> Self {
+        self.allow_config_execution = allow;
+        self
     }
 
     /// Attach a template registry, enabling the template tools.
@@ -209,6 +232,41 @@ mod tests {
         assert!(names.contains(&"list_connectors".to_string()));
         assert!(names.contains(&"validate_config".to_string()));
         assert!(!names.contains(&"run_pipeline".to_string()));
+    }
+
+    /// #456 C4: a caller without the config-execution scope must neither see nor
+    /// be able to invoke the tools that build connectors from a config they
+    /// supply — that is server-side file read and outbound network reach.
+    #[tokio::test]
+    async fn config_executing_tools_are_hidden_and_refused_without_the_scope() {
+        let ctx = McpContext::new(
+            crate::auth_catalog::build_auth_catalog(None).unwrap(),
+            false,
+        )
+        .with_config_execution(false);
+
+        let listed = handle_message(&ctx, r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+            .await
+            .unwrap();
+        assert!(
+            !listed.contains("validate_config") && !listed.contains("\"preview\""),
+            "must not be advertised: {listed}"
+        );
+        // Still present: pure introspection needs no elevated scope.
+        assert!(listed.contains("list_connectors"), "{listed}");
+
+        // Naming an unadvertised tool must be refused, not executed.
+        for tool in ["validate_config", "preview"] {
+            let out = tools::call_tool(
+                &ctx,
+                tool,
+                &json!({ "config": "version: 1\npipeline: {}\n" }),
+            )
+            .await;
+            assert_eq!(out["isError"], true, "{tool} must be refused");
+            let text = out["content"][0]["text"].as_str().unwrap();
+            assert!(text.contains("operator"), "{tool}: {text}");
+        }
     }
 
     #[tokio::test]

--- a/cli/src/mcp/tools.rs
+++ b/cli/src/mcp/tools.rs
@@ -715,8 +715,8 @@ async fn run_template(ctx: &McpContext, args: &Value) -> Result<String, String> 
         // The MCP tool runs the pipeline in this process; nothing is persisted.
         crate::templates::Materialize::Local,
     )
-        .await
-        .map_err(|e| e.to_string())?;
+    .await
+    .map_err(|e| e.to_string())?;
 
     if dry_run {
         // Validate the materialized config without touching a sink, and never

--- a/cli/src/mcp/tools.rs
+++ b/cli/src/mcp/tools.rs
@@ -52,7 +52,14 @@ pub fn tool_defs(ctx: &McpContext) -> Vec<ToolDef> {
                 "required": ["source", "sink"]
             }),
         },
-        ToolDef {
+    ];
+    // `validate_config` and `preview` act on a caller-supplied config: they
+    // resolve `${env:}`/`${file:}`/`${secret:}` server-side and (for `preview`)
+    // build the described connector and return its records. That is a strictly
+    // higher capability than schema introspection, so it is separately gated
+    // (#456 C4) and not advertised when the caller may not use it.
+    if ctx.allow_config_execution {
+        defs.push(ToolDef {
             name: "validate_config",
             description: "Fully validate a pipeline YAML/JSON config (structure, templates, matrix/topology graph). Returns a per-node report or the validation error.",
             input_schema: json!({
@@ -62,8 +69,8 @@ pub fn tool_defs(ctx: &McpContext) -> Vec<ToolDef> {
                 },
                 "required": ["config"]
             }),
-        },
-        ToolDef {
+        });
+        defs.push(ToolDef {
             name: "preview",
             description: "Fetch a bounded sample of records from a config's first source (source side only; downstream sinks are not run). Capped at 100 rows.",
             input_schema: json!({
@@ -74,8 +81,8 @@ pub fn tool_defs(ctx: &McpContext) -> Vec<ToolDef> {
                 },
                 "required": ["config"]
             }),
-        },
-    ];
+        });
+    }
     if ctx.allow_mutations {
         defs.push(ToolDef {
             name: "run_pipeline",
@@ -94,7 +101,7 @@ pub fn tool_defs(ctx: &McpContext) -> Vec<ToolDef> {
     if ctx.templates.is_some() {
         defs.push(ToolDef {
             name: "list_templates",
-            description: "List registered pipeline templates (latest version of each) with the typed params each one takes.",
+            description: "List registered pipeline templates (newest version of each, plus its release status) with the typed params each one takes.",
             input_schema: json!({ "type": "object", "properties": {} }),
         });
         defs.push(ToolDef {
@@ -104,7 +111,7 @@ pub fn tool_defs(ctx: &McpContext) -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "id": { "type": "string", "description": "Template id." },
-                    "version": { "description": "Version: a number, or a named channel (\"latest\" — the default — \"prod\", \"pre-prod\", \"staging\", \"canary\", \"stable\", \"test\", \"dev\", \"previous\").", "oneOf": [{ "type": "integer" }, { "type": "string" }] }
+                    "version": { "description": "Version: a number, or a named channel. Derived: \"stable\" (the launched version — the default), \"previous\", \"newest\". Assignable: \"dev\", \"test\", \"staging\", \"pre-prod\", \"canary\", \"prod\". Note \"latest\" is deliberately not a channel — use \"stable\" for the current release or \"newest\" for the highest version number.", "oneOf": [{ "type": "integer" }, { "type": "string" }] }
                 },
                 "required": ["id"]
             }),
@@ -166,7 +173,7 @@ pub fn tool_defs(ctx: &McpContext) -> Vec<ToolDef> {
                     "type": "object",
                     "properties": {
                         "id": { "type": "string" },
-                        "version": { "description": "Version: a number, or a named channel (\"latest\" — the default — \"prod\", \"pre-prod\", \"staging\", \"canary\", \"stable\", \"test\", \"dev\", \"previous\").", "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                        "version": { "description": "Version: a number, or a named channel. Derived: \"stable\" (the launched version — the default), \"previous\", \"newest\". Assignable: \"dev\", \"test\", \"staging\", \"pre-prod\", \"canary\", \"prod\". Note \"latest\" is deliberately not a channel — use \"stable\" for the current release or \"newest\" for the highest version number.", "oneOf": [{ "type": "integer" }, { "type": "string" }] },
                         "params": { "type": "object", "description": "Values for the template's declared params." },
                         "env": { "type": "object", "description": "Per-run overrides for ${env:VAR} resolution." },
                         "dry_run": { "type": "boolean", "description": "If true, materialize + validate only; do not write to any sink." }
@@ -187,8 +194,22 @@ pub async fn call_tool(ctx: &McpContext, name: &str, args: &Value) -> Value {
         "list_connectors" => list_connectors(args),
         "get_connector_schema" => get_connector_schema(args),
         "scaffold_config" => scaffold_config(args),
-        "validate_config" => validate_config(ctx, args).await,
-        "preview" => preview(ctx, args).await,
+        // Gated at call time as well as in the advertised list: an agent can
+        // always name a tool it was never offered.
+        "validate_config" => {
+            if !ctx.allow_config_execution {
+                Err(CONFIG_EXEC_GATE.to_string())
+            } else {
+                validate_config(ctx, args).await
+            }
+        }
+        "preview" => {
+            if !ctx.allow_config_execution {
+                Err(CONFIG_EXEC_GATE.to_string())
+            } else {
+                preview(ctx, args).await
+            }
+        }
         "run_pipeline" => {
             if !ctx.allow_mutations {
                 Err("run_pipeline is disabled; start the MCP server with --allow-mutations to enable mutating tools".to_string())
@@ -486,6 +507,13 @@ fn pretty(v: &Value) -> String {
 const MUTATION_GATE: &str =
     "this tool is disabled; start the MCP server with --allow-mutations to enable mutating tools";
 
+/// Refusal text for the config-executing tools when the caller lacks the scope.
+/// Phrased for the HTTP transport, which is the only place the gate closes.
+const CONFIG_EXEC_GATE: &str = "this tool acts on a config you supply — it resolves \
+     ${env:}/${file:}/${secret:} on the server and builds the connectors you name — so it \
+     requires the same scope as POST /v1/doctor (role `operator` or `admin`), not a read-only \
+     token";
+
 /// The wired template registry, or a tool error explaining how to wire one.
 #[cfg(feature = "templates")]
 fn template_store(ctx: &McpContext) -> Result<&crate::templates::TemplateStore, String> {
@@ -510,8 +538,9 @@ async fn list_templates(ctx: &McpContext) -> Result<String, String> {
 }
 
 /// Read the optional `version` argument: a number, or one of the closed set of
-/// named channels. Absent = `latest`, so an agent that never mentions versions
-/// always gets the newest registration.
+/// named channels. Absent = `stable` (the *launched* version), so an agent that
+/// never mentions versions rides releases rather than picking up every new
+/// registration.
 #[cfg(feature = "templates")]
 fn version_arg(args: &Value) -> Result<crate::serve::history::templates::VersionSelector, String> {
     use crate::serve::history::templates::VersionSelector;
@@ -521,8 +550,8 @@ fn version_arg(args: &Value) -> Result<crate::serve::history::templates::Version
     }
 }
 
-/// Resolve the `version` argument against the registry (a named channel needs a
-/// lookup). `Ok(None)` = the newest version.
+/// Resolve the `version` argument against the registry (every channel, derived or
+/// assigned, needs a lookup — nothing falls back to "the newest build").
 #[cfg(feature = "templates")]
 async fn resolved_version_arg(
     store: &crate::templates::TemplateStore,
@@ -677,7 +706,15 @@ async fn run_template(ctx: &McpContext, args: &Value) -> Result<String, String> 
         })
         .unwrap_or_default();
 
-    let materialized = crate::templates::materialize(store, id, version, &supplied, &env)
+    let materialized = crate::templates::materialize(
+        store,
+        id,
+        version,
+        &supplied,
+        &env,
+        // The MCP tool runs the pipeline in this process; nothing is persisted.
+        crate::templates::Materialize::Local,
+    )
         .await
         .map_err(|e| e.to_string())?;
 

--- a/cli/src/notify/event.rs
+++ b/cli/src/notify/event.rs
@@ -291,7 +291,11 @@ mod redaction_tests {
             "http",
             format!("HTTP error for url (https://api.example.com/v1?api_key={secret})"),
         );
-        assert!(!ev.message.contains(secret), "message leaked: {}", ev.message);
+        assert!(
+            !ev.message.contains(secret),
+            "message leaked: {}",
+            ev.message
+        );
         assert!(ev.message.contains("***"), "{}", ev.message);
 
         // Titles and string details go into the same payload.

--- a/cli/src/notify/event.rs
+++ b/cli/src/notify/event.rs
@@ -8,6 +8,11 @@
 use super::spec::{EventKind, Severity};
 use serde_json::{Map, Value};
 
+/// Scrub every resolved secret from text bound for an external channel.
+fn redact(s: String) -> String {
+    crate::secrets::registry::redact(&s).into_owned()
+}
+
 /// A single thing worth notifying about.
 #[derive(Debug, Clone)]
 pub struct NotifyEvent {
@@ -27,6 +32,17 @@ pub struct NotifyEvent {
 }
 
 impl NotifyEvent {
+    /// The one constructor every event goes through — and therefore the single
+    /// place to scrub secrets.
+    ///
+    /// A notification leaves the trust boundary entirely: Slack, PagerDuty, or a
+    /// customer webhook. `message` is frequently a raw `FaucetError`, whose
+    /// `Display` can carry the material that produced it — `reqwest` includes the
+    /// full request URL, so a REST source with its API key in a query parameter
+    /// would post that key to a third party, and connection-string leakage in a
+    /// CDC error has already been a filed bug (#84). Every other outbound-ish
+    /// surface already redacts (MCP tool errors, the serve log layer, doctor
+    /// probe output); notifications did not (#456 H5).
     fn base(
         kind: EventKind,
         severity: Severity,
@@ -40,13 +56,19 @@ impl NotifyEvent {
             severity,
             pipeline: pipeline.into(),
             row: row.into(),
-            title: title.into(),
-            message: message.into(),
+            title: redact(title.into()),
+            message: redact(message.into()),
             details: Map::new(),
         }
     }
 
     fn with(mut self, key: &str, value: Value) -> Self {
+        // Detail values are rendered into the same outbound payload as `message`,
+        // so a string detail is scrubbed too.
+        let value = match value {
+            Value::String(s) => Value::String(redact(s)),
+            other => other,
+        };
         self.details.insert(key.to_string(), value);
         self
     }
@@ -246,5 +268,45 @@ mod tests {
     fn details_carry_structured_context() {
         let e = NotifyEvent::dlq_threshold("p", "", 42);
         assert_eq!(e.details.get("records_dlq").unwrap(), &Value::from(42u64));
+    }
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    /// #456 H5: a notification is delivered to Slack / PagerDuty / a customer
+    /// webhook, i.e. outside the trust boundary, so a resolved secret that landed
+    /// in the error text must not ride along.
+    #[test]
+    fn secrets_are_scrubbed_from_every_outbound_field() {
+        // A realistic leak: the API key is a query parameter, and reqwest's error
+        // Display embeds the whole URL.
+        let secret = "sk-live-456-audit-secret";
+        crate::secrets::registry::register(secret);
+
+        let ev = NotifyEvent::run_failure(
+            "p",
+            "row",
+            "http",
+            format!("HTTP error for url (https://api.example.com/v1?api_key={secret})"),
+        );
+        assert!(!ev.message.contains(secret), "message leaked: {}", ev.message);
+        assert!(ev.message.contains("***"), "{}", ev.message);
+
+        // Titles and string details go into the same payload.
+        let ev = NotifyEvent::sla_breach("p", "row", "staleness", format!("token {secret} stale"));
+        assert!(!ev.message.contains(secret));
+
+        let ev = NotifyEvent::run_failure("p", "row", "cfg", "boom")
+            .with("detail", Value::String(format!("url={secret}")));
+        assert!(
+            !ev.details["detail"].as_str().unwrap().contains(secret),
+            "detail leaked: {:?}",
+            ev.details
+        );
+        // Non-string details pass through untouched.
+        let ev = NotifyEvent::run_success("p", "row", 7);
+        assert_eq!(ev.details["records_written"], Value::from(7u64));
     }
 }

--- a/cli/src/serve/handlers/templates.rs
+++ b/cli/src/serve/handlers/templates.rs
@@ -1278,7 +1278,11 @@ mod tests {
         )
         .await
         .expect("materialize");
-        assert!(local.body.contains("hunter2-should-not-persist"), "{}", local.body);
+        assert!(
+            local.body.contains("hunter2-should-not-persist"),
+            "{}",
+            local.body
+        );
         unsafe { std::env::remove_var("FAUCET_TEST_C5_SECRET") };
     }
 

--- a/cli/src/serve/handlers/templates.rs
+++ b/cli/src/serve/handlers/templates.rs
@@ -1180,7 +1180,7 @@ mod tests {
             "version: 1\nname: tpl-env\npipeline:\n  source:\n    type: csv\n    config:\n      path: \"${{env:SRC_PATH}}\"\n  sink:\n    type: jsonl\n    config:\n      path: {}\n",
             dir.path().join("o.jsonl").display()
         );
-        register_template(
+        let _registered = register_template(
             State(state.clone()),
             Extension(actor()),
             Json(RegisterBody {

--- a/cli/src/serve/handlers/templates.rs
+++ b/cli/src/serve/handlers/templates.rs
@@ -524,23 +524,41 @@ pub async fn trigger_template(
             "triggering a DEPRECATED pipeline template"
         );
     }
-    let materialized = crate::templates::materialize(&s, &id, want, &supplied, &body.env)
+    // A clustered submit persists the materialized config so any instance can
+    // re-run it, so nothing secret may be baked into that body. In cluster mode we
+    // therefore materialize in `Persisted` mode: `${env:}` / `${file:}` /
+    // `${secret:}` stay as tokens and are resolved by the executing instance
+    // (#456 C5). What cannot be deferred is a value the *caller* supplied, so
+    // those are refused below.
+    let clustered = state.cluster().enabled();
+    let mode = if clustered {
+        crate::templates::Materialize::Persisted
+    } else {
+        crate::templates::Materialize::Local
+    };
+    let materialized = crate::templates::materialize(&s, &id, want, &supplied, &body.env, mode)
         .await
         .map_err(map_err)?;
 
-    // A clustered submit persists the raw config so any instance can re-run it.
-    // A `secret: true` param value would therefore be written to the shared
-    // history database — which is deliberately never a secret store. Refuse
-    // instead, and point at the two safe ways to get a secret into a clustered
-    // template run.
-    if state.cluster().enabled() && materialized.used_secret_params {
+    // Caller-supplied values that would land in the persisted body: a
+    // `secret: true` param, or an `env:` override (which substitutes into the
+    // config exactly like a param and is equally likely to be a credential —
+    // #456 M4). Both are refused rather than written to a shared database that is
+    // deliberately not a secret store.
+    if clustered && (materialized.used_secret_params || !body.env.is_empty()) {
+        let what = if materialized.used_secret_params {
+            "declares `secret: true` param(s)"
+        } else {
+            "was triggered with `env` overrides"
+        };
         return Err(ServeError::Unprocessable {
-            message: "this template declares `secret: true` param(s), and a clustered server \
-                      persists the materialized config so a peer can execute it — which would \
-                      store the secret in the shared run-history database. Reference the secret \
-                      from the template body instead (`${env:VAR}` or `${vault:…}`, resolved on \
-                      the executing instance), or trigger it on a non-clustered server"
-                .into(),
+            message: format!(
+                "this template {what}, and a clustered server persists the materialized config \
+                 so a peer can execute it — which would store the value in the shared \
+                 run-history database. Reference the secret from the template body instead \
+                 (`${{env:VAR}}`, `${{vault:…}}`, `${{aws-sm:…}}`, … — all resolved on the \
+                 executing instance, never persisted), or trigger it on a non-clustered server"
+            ),
             details: None,
         });
     }
@@ -1148,6 +1166,120 @@ mod tests {
             }
             other => panic!("expected 422, got {other:?}"),
         }
+    }
+
+    /// #456 M4: an `env` override substitutes into the config exactly like a
+    /// param and is just as likely to be a credential, so on a clustered server —
+    /// where the materialized body is persisted for a peer — it must be refused
+    /// alongside `secret: true` params.
+    #[tokio::test]
+    async fn env_overrides_are_refused_on_a_clustered_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = crate::serve::test_support::test_state_clustered();
+        let body = format!(
+            "version: 1\nname: tpl-env\npipeline:\n  source:\n    type: csv\n    config:\n      path: \"${{env:SRC_PATH}}\"\n  sink:\n    type: jsonl\n    config:\n      path: {}\n",
+            dir.path().join("o.jsonl").display()
+        );
+        register_template(
+            State(state.clone()),
+            Extension(actor()),
+            Json(RegisterBody {
+                id: None,
+                config: body,
+                config_format: ConfigFormatWire::Yaml,
+                description: None,
+                tags: vec![],
+                launch: true,
+            }),
+        )
+        .await
+        .expect("register");
+
+        let err = trigger_template(
+            State(state),
+            Extension(actor()),
+            Path("tpl-env".into()),
+            Json(TriggerBody {
+                env: [("SRC_PATH".to_string(), "s3cret-path".to_string())].into(),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+        match err {
+            ServeError::Unprocessable { message, .. } => {
+                assert!(message.contains("env"), "{message}");
+                assert!(!message.contains("s3cret-path"), "leaked: {message}");
+            }
+            other => panic!("expected 422, got {other:?}"),
+        }
+    }
+
+    /// #456 C5: on a clustered server the persisted body must still carry the
+    /// load-time directives as *tokens* — resolving them here would serialise the
+    /// server's own credentials into the shared run-history database. The
+    /// executing instance resolves them instead.
+    #[tokio::test]
+    async fn a_clustered_trigger_persists_tokens_not_resolved_values() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: single-threaded test; the value is read back below only via the
+        // materialize path we are asserting about.
+        unsafe { std::env::set_var("FAUCET_TEST_C5_SECRET", "hunter2-should-not-persist") };
+        let s = store(&crate::serve::test_support::test_state_clustered());
+        let body = format!(
+            "version: 1\nname: tpl-c5\npipeline:\n  source:\n    type: csv\n    config:\n      path: \"${{env:FAUCET_TEST_C5_SECRET}}\"\n  sink:\n    type: jsonl\n    config:\n      path: {}\n",
+            dir.path().join("o.jsonl").display()
+        );
+        crate::templates::register(
+            &s,
+            crate::templates::RegisterRequest {
+                id: None,
+                body,
+                format: crate::serve::load::ConfigFormat::Yaml,
+                description: None,
+                tags: vec![],
+                launch: true,
+                created_by: None,
+            },
+        )
+        .await
+        .expect("register");
+
+        let persisted = crate::templates::materialize(
+            &s,
+            "tpl-c5",
+            1,
+            &Default::default(),
+            &Default::default(),
+            crate::templates::Materialize::Persisted,
+        )
+        .await
+        .expect("materialize");
+        assert!(
+            !persisted.body.contains("hunter2-should-not-persist"),
+            "a resolved secret must never reach a persisted body: {}",
+            persisted.body
+        );
+        assert!(
+            persisted.body.contains("${env:FAUCET_TEST_C5_SECRET}"),
+            "the directive must survive as a token for the executor: {}",
+            persisted.body
+        );
+
+        // The local (non-clustered) path still resolves, so behaviour there is
+        // unchanged — nothing is persisted in that mode.
+        let local = crate::templates::materialize(
+            &s,
+            "tpl-c5",
+            1,
+            &Default::default(),
+            &Default::default(),
+            crate::templates::Materialize::Local,
+        )
+        .await
+        .expect("materialize");
+        assert!(local.body.contains("hunter2-should-not-persist"), "{}", local.body);
+        unsafe { std::env::remove_var("FAUCET_TEST_C5_SECRET") };
     }
 
     #[test]

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -900,19 +900,44 @@ impl Stmts {
 }
 
 /// Bounded retry count for the atomic idempotency claim (handles a claim being
-/// purged concurrently between the insert attempt and the read-back).
-pub const CLAIM_ATTEMPTS: usize = 4;
+/// purged concurrently between the insert attempt and the read-back) and for the
+/// read-max-then-insert paths (template versions, launch-log seqs).
+///
+/// Sized for *contention*, not just for a lost race. SQLite serializes writers
+/// and answers a write-write overlap on a deferred transaction with `database is
+/// locked` **immediately** (waiting would deadlock), so `busy_timeout` does not
+/// help there and the attempt budget is the only thing standing between a
+/// concurrent writer and a surfaced error. With N concurrent writers each needing
+/// its own turn, a budget of 4 is thinner than it looks: six writers on a loaded
+/// machine exhausted it and failed a register (#457 CI).
+pub const CLAIM_ATTEMPTS: usize = 8;
+
+/// Distinguishes concurrent retriers so their backoffs do not re-collide.
+///
+/// Every waiter sleeping the *same* duration just reproduces the same race one
+/// beat later. A per-call sequence number is a dependency-free way to stagger
+/// them (the alternative, a random jitter, would mean pulling in an RNG here).
+static RETRY_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 /// Sleep before a read-max-then-insert retry (no-op on the first attempt).
 ///
-/// The retry exists for lost races, and under real contention an immediate retry
-/// tends to lose the same race again — SQLite in particular serializes writers, so
-/// a few milliseconds of stagger is the difference between converging and
-/// exhausting the attempt budget.
+/// Exponential (5ms, 10ms, 20ms, …, capped) plus a per-caller stagger, so a set
+/// of writers that collided on attempt 1 spreads out instead of colliding again.
+/// Worst case across the whole budget is a few hundred milliseconds — cheap next
+/// to failing a write the caller expected to succeed.
 pub async fn retry_backoff(attempt: usize) {
-    if attempt > 1 {
-        tokio::time::sleep(std::time::Duration::from_millis(5 * (attempt as u64 - 1))).await;
+    if attempt <= 1 {
+        return;
     }
+    const BASE_MS: u64 = 5;
+    const CAP_MS: u64 = 160;
+    let exp = BASE_MS
+        .saturating_mul(1u64 << (attempt - 2).min(6))
+        .min(CAP_MS);
+    // 0..BASE_MS of per-caller offset, so equal-length sleeps do not re-align.
+    let stagger =
+        (RETRY_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as u64) % (BASE_MS + 1);
+    tokio::time::sleep(std::time::Duration::from_millis(exp + stagger)).await;
 }
 
 /// Fixed-width RFC3339 (nanoseconds + `Z`) — lexicographically sortable.

--- a/cli/src/serve/mcp_route.rs
+++ b/cli/src/serve/mcp_route.rs
@@ -29,6 +29,14 @@ pub async fn handle(
 ) -> axum::response::Response {
     // Mutating tools require BOTH the server flag and the caller's RunWrite scope.
     let can_mutate = flags.allow_mutations && actor.role.grants(Permission::RunWrite);
+    // The config-executing tools (`validate_config`, `preview`) build the
+    // connectors the caller describes and resolve `${env:}` / `${file:}` /
+    // `${secret:}` against this process's environment and filesystem. That is
+    // server-side file read plus outbound network reach, so it takes the same
+    // scope as `POST /v1/doctor` — which submits a config to be probed — rather
+    // than the route's baseline read scope. Without this a `viewer` token could
+    // read arbitrary server files via a `csv` source (#456 C4).
+    let can_execute_config = actor.role.grants(Permission::Doctor);
 
     let auth = match crate::auth_catalog::build_auth_catalog(None) {
         Ok(a) => a,
@@ -43,7 +51,7 @@ pub async fn handle(
     // The server's run-history backend doubles as the pipeline-template registry
     // (#444), so an agent on `/mcp` sees the same templates the `/v1/templates`
     // endpoints and `faucet template` do.
-    let ctx = crate::mcp::McpContext::new(auth, can_mutate);
+    let ctx = crate::mcp::McpContext::new(auth, can_mutate).with_config_execution(can_execute_config);
     #[cfg(feature = "templates")]
     let ctx = ctx.with_templates(state.history());
     let response = crate::mcp::handle_message(&ctx, &body).await;
@@ -110,6 +118,66 @@ mod tests {
         )
         .await;
         assert!(!body_text(resp).await.contains("run_pipeline"));
+    }
+
+    /// #456 C4: `/mcp`'s baseline scope is `SchemaRead` (Viewer), but `preview`
+    /// builds the source a caller names and returns its records — so a Viewer
+    /// could read any file the server can (`csv` with `path: /etc/passwd`) and
+    /// reach any host it can. Those two tools now need the `Doctor` scope, the
+    /// same one `POST /v1/doctor` requires for submitting a config to be probed.
+    #[tokio::test]
+    async fn viewer_cannot_reach_the_config_executing_tools() {
+        let state = test_state();
+        let resp = handle(
+            State(state),
+            Extension(actor(Role::Viewer)),
+            Extension(McpRouteFlags {
+                allow_mutations: false,
+            }),
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#.to_string(),
+        )
+        .await;
+        let body = body_text(resp).await;
+        assert!(!body.contains("validate_config"), "{body}");
+        assert!(!body.contains("\"preview\""), "{body}");
+        assert!(body.contains("list_connectors"), "{body}");
+    }
+
+    /// …and calling one anyway is refused rather than executed.
+    #[tokio::test]
+    async fn viewer_calling_preview_is_refused() {
+        let state = test_state();
+        let resp = handle(
+            State(state),
+            Extension(actor(Role::Viewer)),
+            Extension(McpRouteFlags {
+                allow_mutations: false,
+            }),
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"preview","arguments":{"config":"version: 1\npipeline:\n  source: { type: csv, config: { path: /etc/passwd } }\n  sink: { type: stdout, config: {} }\n"}}}"#.to_string(),
+        )
+        .await;
+        let body = body_text(resp).await;
+        assert!(body.contains("\"isError\":true"), "{body}");
+        assert!(body.contains("operator"), "{body}");
+        assert!(!body.contains("root:"), "no file content may leak: {body}");
+    }
+
+    /// An operator holds `Doctor`, so the tools are available to them.
+    #[tokio::test]
+    async fn operator_can_see_the_config_executing_tools() {
+        let state = test_state();
+        let resp = handle(
+            State(state),
+            Extension(actor(Role::Operator)),
+            Extension(McpRouteFlags {
+                allow_mutations: false,
+            }),
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#.to_string(),
+        )
+        .await;
+        let body = body_text(resp).await;
+        assert!(body.contains("validate_config"), "{body}");
+        assert!(body.contains("preview"), "{body}");
     }
 
     #[tokio::test]

--- a/cli/src/serve/mcp_route.rs
+++ b/cli/src/serve/mcp_route.rs
@@ -51,7 +51,8 @@ pub async fn handle(
     // The server's run-history backend doubles as the pipeline-template registry
     // (#444), so an agent on `/mcp` sees the same templates the `/v1/templates`
     // endpoints and `faucet template` do.
-    let ctx = crate::mcp::McpContext::new(auth, can_mutate).with_config_execution(can_execute_config);
+    let ctx =
+        crate::mcp::McpContext::new(auth, can_mutate).with_config_execution(can_execute_config);
     #[cfg(feature = "templates")]
     let ctx = ctx.with_templates(state.history());
     let response = crate::mcp::handle_message(&ctx, &body).await;

--- a/cli/src/templates/mod.rs
+++ b/cli/src/templates/mod.rs
@@ -53,7 +53,7 @@
 pub mod store;
 
 pub use store::{
-    LaunchOutcome, MaterializedConfig, RegisterRequest, TemplateStore, launch, list_with_state,
-    materialize, promote, register, resolve_store_url, resolve_version, rollback, set_deprecated,
-    template_state,
+    LaunchOutcome, Materialize, MaterializedConfig, RegisterRequest, TemplateStore, launch,
+    list_with_state, materialize, promote, register, resolve_store_url, resolve_version, rollback,
+    set_deprecated, template_state,
 };

--- a/cli/src/templates/store.rs
+++ b/cli/src/templates/store.rs
@@ -456,21 +456,45 @@ pub async fn set_deprecated(
     Ok(TemplateStatus::derive(state.stable.is_some(), deprecated))
 }
 
-/// Fetch a template (the launched version when `version` is `None`), binding the
-/// Fetch a template (latest version when `version` is `None`), binding the
-/// supplied params and env overrides into a runnable config document.
+/// Where the materialized config is going — which decides whether load-time
+/// directives may be resolved here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Materialize {
+    /// The body is executed by *this* process and never stored. Load-time
+    /// directives (`${env:}` / `${file:}` / `${secret:}`) are resolved here, so a
+    /// caller-supplied `env` overlay takes effect.
+    Local,
+    /// The body will be **persisted** for another instance to execute (a
+    /// clustered submit). Load-time directives are left as tokens for the
+    /// executing instance to resolve, so a resolved credential is never written
+    /// to the shared run-history database (#456 C5).
+    Persisted,
+}
+
+/// Fetch a template version and bind the supplied params into a runnable config
+/// document.
 ///
-/// Ordering matters and mirrors the file-load path exactly: `${env:}` /
-/// `${file:}` / `${secret:}` resolve **first** (with `env_overrides` taking
-/// precedence over the process environment), then `${param.*}` binds. A supplied
-/// param value is therefore never itself scanned for directives, so a caller
-/// cannot use a param to read the server's environment or secret store.
+/// Ordering mirrors the file-load path: `${env:}` / `${file:}` / `${secret:}`
+/// resolve **first** (with `env_overrides` taking precedence over the process
+/// environment), then `${param.*}` binds. A supplied param value is therefore
+/// never itself scanned for directives, so a caller cannot use a param to read
+/// the server's environment or secret store.
+///
+/// Under [`Materialize::Persisted`] the first step is **skipped**: the directives
+/// stay as tokens and are resolved later by `load_submission` on whichever
+/// instance runs the job. Resolving them here would serialise the *values* into
+/// the body that gets stored in the shared database — which is how a
+/// `${env:DB_PASSWORD}` in a template body ended up in plaintext there. The
+/// trade-off is that a typed (`int`/`float`/`bool`) param whose `default` is
+/// itself a directive cannot be coerced in this mode; it fails loudly at trigger
+/// time naming the param, rather than silently.
 pub async fn materialize(
     store: &TemplateStore,
     id: &str,
     version: u32,
     supplied: &SuppliedParams,
     env_overrides: &BTreeMap<String, String>,
+    mode: Materialize,
 ) -> CliResult<MaterializedConfig> {
     // Takes a concrete version, never an `Option`: "no version given" is resolved
     // by `resolve_version` against the registry, so there is no code path where a
@@ -485,11 +509,13 @@ pub async fn materialize(
         })?;
 
     let mut doc = parse_body(&record.body, record.format)?;
-    let overlay: crate::interpolate::EnvOverlay = env_overrides
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
-    crate::interpolate::interpolate_value_with_env(&mut doc, &overlay)?;
+    if mode == Materialize::Local {
+        let overlay: crate::interpolate::EnvOverlay = env_overrides
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        crate::interpolate::interpolate_value_with_env(&mut doc, &overlay)?;
+    }
     let bound = params::bind_document(&mut doc, supplied, BindMode::Strict)?;
     // Drop the declaration block: materialization is the moment params cease to
     // exist. Leaving it would make any later load re-run the bind pass with no
@@ -928,7 +954,7 @@ pipeline:
         let want = resolve_version(&s, "tenant-sync", VersionSelector::stable())
             .await
             .unwrap();
-        let out = materialize(&s, "tenant-sync", want, &supplied, &BTreeMap::new())
+        let out = materialize(&s, "tenant-sync", want, &supplied, &BTreeMap::new(), Materialize::Local)
             .await
             .unwrap();
         assert_eq!(out.version, 1);
@@ -954,6 +980,7 @@ pipeline:
             1,
             &SuppliedParams::new(),
             &BTreeMap::new(),
+            Materialize::Local,
         )
         .await
         .unwrap_err();
@@ -964,7 +991,7 @@ pipeline:
             ("bogus".to_string(), json!("b")),
         ]
         .into();
-        let err = materialize(&s, "tenant-sync", 1, &supplied, &BTreeMap::new())
+        let err = materialize(&s, "tenant-sync", 1, &supplied, &BTreeMap::new(), Materialize::Local)
             .await
             .unwrap_err();
         assert!(matches!(err, CliError::UnknownParam { .. }), "{err:?}");
@@ -982,7 +1009,7 @@ pipeline:
             "{err:?}"
         );
         let supplied: SuppliedParams = [("tenant_id".to_string(), json!("a"))].into();
-        let err = materialize(&s, "tenant-sync", 9, &supplied, &BTreeMap::new())
+        let err = materialize(&s, "tenant-sync", 9, &supplied, &BTreeMap::new(), Materialize::Local)
             .await
             .unwrap_err();
         assert!(
@@ -1016,6 +1043,7 @@ pipeline:
             1,
             &SuppliedParams::new(),
             &BTreeMap::new(),
+            Materialize::Local,
         )
         .await
         .unwrap();
@@ -1027,7 +1055,7 @@ pipeline:
 
         let overrides: BTreeMap<String, String> =
             [("FAUCET_TPL_REGION".to_string(), "from-request".to_string())].into();
-        let out = materialize(&s, "env-template", 1, &SuppliedParams::new(), &overrides)
+        let out = materialize(&s, "env-template", 1, &SuppliedParams::new(), &overrides, Materialize::Local)
             .await
             .unwrap();
         let doc: Value = serde_json::from_str(&out.body).unwrap();
@@ -1058,7 +1086,7 @@ pipeline:
         register(&s, req_launched(body)).await.unwrap();
         let supplied: SuppliedParams =
             [("api_token".to_string(), json!("tok-abcdefghijklmnop"))].into();
-        let out = materialize(&s, "secret-template", 1, &supplied, &BTreeMap::new())
+        let out = materialize(&s, "secret-template", 1, &supplied, &BTreeMap::new(), Materialize::Local)
             .await
             .unwrap();
         assert!(out.used_secret_params);
@@ -1249,6 +1277,7 @@ pipeline:
             1,
             &SuppliedParams::new(),
             &BTreeMap::new(),
+            Materialize::Local,
         )
         .await
         .unwrap();

--- a/cli/src/templates/store.rs
+++ b/cli/src/templates/store.rs
@@ -954,9 +954,16 @@ pipeline:
         let want = resolve_version(&s, "tenant-sync", VersionSelector::stable())
             .await
             .unwrap();
-        let out = materialize(&s, "tenant-sync", want, &supplied, &BTreeMap::new(), Materialize::Local)
-            .await
-            .unwrap();
+        let out = materialize(
+            &s,
+            "tenant-sync",
+            want,
+            &supplied,
+            &BTreeMap::new(),
+            Materialize::Local,
+        )
+        .await
+        .unwrap();
         assert_eq!(out.version, 1);
         assert_eq!(out.name.as_deref(), Some("tenant-sync"));
         assert_eq!(out.format(), ConfigFormat::Json);
@@ -991,9 +998,16 @@ pipeline:
             ("bogus".to_string(), json!("b")),
         ]
         .into();
-        let err = materialize(&s, "tenant-sync", 1, &supplied, &BTreeMap::new(), Materialize::Local)
-            .await
-            .unwrap_err();
+        let err = materialize(
+            &s,
+            "tenant-sync",
+            1,
+            &supplied,
+            &BTreeMap::new(),
+            Materialize::Local,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, CliError::UnknownParam { .. }), "{err:?}");
     }
 
@@ -1009,9 +1023,16 @@ pipeline:
             "{err:?}"
         );
         let supplied: SuppliedParams = [("tenant_id".to_string(), json!("a"))].into();
-        let err = materialize(&s, "tenant-sync", 9, &supplied, &BTreeMap::new(), Materialize::Local)
-            .await
-            .unwrap_err();
+        let err = materialize(
+            &s,
+            "tenant-sync",
+            9,
+            &supplied,
+            &BTreeMap::new(),
+            Materialize::Local,
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -1055,9 +1076,16 @@ pipeline:
 
         let overrides: BTreeMap<String, String> =
             [("FAUCET_TPL_REGION".to_string(), "from-request".to_string())].into();
-        let out = materialize(&s, "env-template", 1, &SuppliedParams::new(), &overrides, Materialize::Local)
-            .await
-            .unwrap();
+        let out = materialize(
+            &s,
+            "env-template",
+            1,
+            &SuppliedParams::new(),
+            &overrides,
+            Materialize::Local,
+        )
+        .await
+        .unwrap();
         let doc: Value = serde_json::from_str(&out.body).unwrap();
         assert_eq!(
             doc["pipeline"]["source"]["config"]["url"],
@@ -1086,9 +1114,16 @@ pipeline:
         register(&s, req_launched(body)).await.unwrap();
         let supplied: SuppliedParams =
             [("api_token".to_string(), json!("tok-abcdefghijklmnop"))].into();
-        let out = materialize(&s, "secret-template", 1, &supplied, &BTreeMap::new(), Materialize::Local)
-            .await
-            .unwrap();
+        let out = materialize(
+            &s,
+            "secret-template",
+            1,
+            &supplied,
+            &BTreeMap::new(),
+            Materialize::Local,
+        )
+        .await
+        .unwrap();
         assert!(out.used_secret_params);
         assert_eq!(out.params_redacted["api_token"], json!("***"));
         assert!(out.body.contains("tok-abcdefghijklmnop"));

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -515,9 +515,8 @@ pub async fn run_topology(
     if let Some(c) = run.cancel.clone() {
         opts = opts.with_cancel(c);
     }
-    opts = opts.with_governance(build_governance(cfg)?);
 
-    let result = topo.run(opts).await?;
+    let result = topo.run_with(opts, build_governance(cfg)?).await?;
 
     let mut invocations: Vec<InvocationOutcome> = result
         .per_sink

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -15,9 +15,10 @@ use crate::executor::{InvocationOutcome, RunSummary};
 use crate::merge::merge_value;
 use crate::registry::{build_sink, build_source};
 use crate::transforms::compile_transforms;
+use chrono::{DateTime, FixedOffset};
 use faucet_core::stage::compile_stage;
 use faucet_core::topology::{
-    JoinConfig, JoinNode, NodeKind, Topology, TopologyOnError, TopologyOptions,
+    JoinConfig, JoinNode, NodeKind, Topology, TopologyGovernance, TopologyOnError, TopologyOptions,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -26,6 +27,72 @@ use tokio_util::sync::CancellationToken;
 /// Whether the config selects topology mode (a non-empty `pipeline.nodes`).
 pub fn is_topology(cfg: &PipelineConfig) -> bool {
     !cfg.pipeline.nodes.is_empty()
+}
+
+/// Per-run knobs for topology mode, mirroring the matrix path's
+/// [`crate::executor::ExecuteOptions`] subset that applies to a node graph.
+#[derive(Default, Clone)]
+pub struct TopologyRunOptions {
+    /// External cancellation (serve run-cancel / timeout / shutdown, TUI quit).
+    pub cancel: Option<CancellationToken>,
+    /// Preview: build no real sinks, count records instead, and never persist a
+    /// bookmark (#456 C2).
+    pub dry_run: bool,
+    /// Preview: stop after this many records per sink, and never persist a
+    /// bookmark (#456 C2).
+    pub limit: Option<usize>,
+    /// Clock backing `${now.*}` in node configs. `None` = process start.
+    pub clock: Option<DateTime<FixedOffset>>,
+}
+
+impl TopologyRunOptions {
+    /// The effective `${now.*}` clock.
+    fn clock(&self) -> DateTime<FixedOffset> {
+        self.clock.unwrap_or_else(|| chrono::Utc::now().fixed_offset())
+    }
+
+    /// Whether this is a non-writing preview, which must not persist bookmarks.
+    fn is_preview(&self) -> bool {
+        self.dry_run || self.limit.is_some()
+    }
+}
+
+/// Config blocks that topology mode does not (yet) act on.
+///
+/// Returned as `(block, consequence)` pairs so both `faucet validate` and the run
+/// path can say exactly what is inert and why it matters. Silence here was the
+/// original defect: a config could declare a policy, validate as "valid", and run
+/// with the policy doing nothing (#456 M2).
+pub fn inert_blocks(cfg: &PipelineConfig) -> Vec<(&'static str, &'static str)> {
+    let mut out = Vec::new();
+    if cfg.resilience.is_some() {
+        out.push((
+            "resilience",
+            "sink writes are not retried and the circuit breaker never trips",
+        ));
+    }
+    #[cfg(feature = "notify")]
+    if !cfg.notifications.is_empty() {
+        out.push((
+            "notifications",
+            "no alert is sent when the run fails or breaches an SLA",
+        ));
+    }
+    #[cfg(feature = "lineage")]
+    if cfg.lineage.is_some() {
+        out.push(("lineage", "no OpenLineage events are emitted"));
+    }
+    #[cfg(feature = "catalog")]
+    if cfg.catalog.is_some() {
+        out.push(("catalog", "no datasets, schemas, or lineage edges are recorded"));
+    }
+    if cfg.sla.is_some() {
+        out.push((
+            "sla",
+            "freshness and volume are not evaluated after the run",
+        ));
+    }
+    out
 }
 
 /// Config-level graph validation: the checks that need only the `nodes:` /
@@ -40,6 +107,20 @@ pub fn is_topology(cfg: &PipelineConfig) -> bool {
 pub fn validate_topology_spec(cfg: &PipelineConfig) -> CliResult<()> {
     if !cfg.matrix.is_empty() {
         return Err(CliError::MatrixAndNodesBothPresent);
+    }
+    // Exactly-once is not implemented for node graphs: there is no per-sink
+    // commit-token/watermark path here. The matrix path gates this combination in
+    // `expand`, which topology mode never runs — so without this check the run
+    // would silently execute at-least-once and duplicate on retry (#456 H2).
+    if cfg.delivery == faucet_core::DeliveryMode::ExactlyOnce {
+        return Err(CliError::Config(
+            "`delivery: exactly_once` is not supported in topology mode (`pipeline.nodes`): a \
+             node graph has no atomic commit-token path, so the run would silently be \
+             at-least-once. Use the matrix form (`pipeline.source`/`sink` + `matrix:`) for \
+             exactly-once, or make the sinks idempotent with `write_mode: upsert` and set \
+             `delivery: at_least_once`"
+                .into(),
+        ));
     }
     let spec = &cfg.pipeline;
     let mut known: Vec<String> = spec.nodes.keys().cloned().collect();
@@ -108,11 +189,31 @@ fn resolve_connector(
 }
 
 /// Build a [`faucet_core::Topology`] from the config's `pipeline.nodes` /
-/// `edges` block.
+/// `edges` block, with default run options (no preview, process-start clock).
 pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResult<Topology> {
+    build_topology_with(cfg, auth, &TopologyRunOptions::default()).await
+}
+
+/// Build a [`faucet_core::Topology`], honouring the run options.
+///
+/// Two things happen here that the matrix path does per invocation in
+/// [`crate::executor`], and that topology mode used to skip entirely:
+///
+/// - **`${now.*}` is resolved** in every node's source/sink config, and a
+///   leftover `${backfill.*}` token is rejected. Without this the literal token
+///   string reached the connector, so a dated path became a directory named
+///   `${now.date}` (#456 H4).
+/// - **Preview modes wrap the sinks**: `--dry-run` swaps in a counting sink and
+///   `--limit` truncates, so neither performs a real write (#456 C2).
+pub async fn build_topology_with(
+    cfg: &PipelineConfig,
+    auth: &AuthCatalog,
+    opts: &TopologyRunOptions,
+) -> CliResult<Topology> {
     // Cheap graph checks first, so a wiring typo never costs a connector build.
     validate_topology_spec(cfg)?;
 
+    let clock = opts.clock();
     let spec = &cfg.pipeline;
     let mut builder = Topology::builder();
 
@@ -128,7 +229,7 @@ pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResu
                 kind,
                 config,
             } => {
-                let (k, c) = resolve_connector(
+                let (k, mut c) = resolve_connector(
                     &spec.sources,
                     &spec.source,
                     template.as_deref(),
@@ -137,6 +238,8 @@ pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResu
                     id,
                     "source",
                 )?;
+                crate::executor::resolve_now_inplace(&mut c, clock)?;
+                crate::executor::reject_unresolved_backfill_tokens(&c, "source")?;
                 NodeKind::Source(build_source(&k, c, auth, None).await?)
             }
             NodeSpec::Sink {
@@ -144,7 +247,7 @@ pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResu
                 kind,
                 config,
             } => {
-                let (k, c) = resolve_connector(
+                let (k, mut c) = resolve_connector(
                     &spec.sinks,
                     &spec.sink,
                     template.as_deref(),
@@ -153,7 +256,19 @@ pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResu
                     id,
                     "sink",
                 )?;
-                NodeKind::Sink(build_sink(&k, c, auth).await?)
+                crate::executor::resolve_now_inplace(&mut c, clock)?;
+                crate::executor::reject_unresolved_backfill_tokens(&c, "sink")?;
+                // Preview modes must never reach the real destination.
+                let sink: Box<dyn faucet_core::Sink> = if opts.dry_run {
+                    Box::new(crate::executor::CountingSink::new())
+                } else {
+                    build_sink(&k, c, auth).await?
+                };
+                let sink = match opts.limit {
+                    Some(n) => Box::new(crate::executor::LimitedSink::wrap(sink, n)) as Box<_>,
+                    None => sink,
+                };
+                NodeKind::Sink(sink)
             }
             NodeSpec::Transform { transforms } => {
                 let stages = compile_transforms(transforms)?;
@@ -202,6 +317,71 @@ pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResu
     builder.build().map_err(|e| CliError::InvalidTopology {
         message: e.to_string(),
     })
+}
+
+/// Compile the config's governance blocks for a node graph.
+///
+/// Mirrors the matrix path in [`crate::executor`] so a topology enforces the same
+/// policies — before this existed, a config declaring `masking:` ran with no
+/// masking at all and PII reached every destination in the clear (#456 C3).
+///
+/// Masking is destination-scoped, so it is compiled **per sink node** against
+/// that node's identifiers (node id, template ref, connector kind) — any of which
+/// an `applies_to` rule may name. A sink for which no rule applies gets no entry,
+/// so the pass is skipped entirely for it.
+fn build_governance(cfg: &PipelineConfig) -> CliResult<TopologyGovernance> {
+    #[allow(unused_mut)]
+    let mut g = TopologyGovernance::new();
+
+    #[cfg(feature = "quality")]
+    if let Some(spec) = &cfg.pipeline.quality {
+        g.quality = Some(std::sync::Arc::new(
+            faucet_core::CompiledQuality::compile(spec)
+                .map_err(|e| CliError::Config(format!("quality: {e}")))?,
+        ));
+    }
+    #[cfg(feature = "contract")]
+    if let Some(spec) = &cfg.pipeline.contract {
+        g.contract = Some(std::sync::Arc::new(
+            faucet_core::CompiledContract::compile(spec)
+                .map_err(|e| CliError::Config(format!("contract: {e}")))?,
+        ));
+    }
+    if let Some(spec) = &cfg.pipeline.schema {
+        g.schema_drift = Some(faucet_core::SchemaDriftPolicy::compile(spec));
+    }
+    if let Some(spec) = &cfg.resilience {
+        g.resilience = Some(spec.to_policy()?);
+    }
+
+    #[cfg(feature = "masking")]
+    if let Some(spec) = &cfg.pipeline.masking {
+        for (node_id, node) in &cfg.pipeline.nodes {
+            let NodeSpec::Sink { template, kind, .. } = node else {
+                continue;
+            };
+            let template_ref = template.as_deref().unwrap_or("default");
+            // The node's own kind override, else the template's declared kind.
+            let resolved_kind = kind.clone().or_else(|| {
+                cfg.pipeline
+                    .sinks
+                    .get(template_ref)
+                    .or(cfg.pipeline.sink.as_ref())
+                    .map(|t| t.kind.clone())
+            });
+            let mut ids: Vec<&str> = vec![node_id.as_str(), template_ref];
+            if let Some(k) = resolved_kind.as_deref() {
+                ids.push(k);
+            }
+            let compiled = faucet_core::CompiledMasking::compile_for_sink(spec, &ids)
+                .map_err(|e| CliError::Config(format!("masking: {e}")))?;
+            if !compiled.is_empty() {
+                g.masking_by_sink
+                    .insert(node_id.clone(), std::sync::Arc::new(compiled));
+            }
+        }
+    }
+    Ok(g)
 }
 
 /// Collect a bounded preview of each `source` node's records (source side
@@ -289,9 +469,16 @@ pub async fn preview_to_string(
 pub async fn run_topology(
     cfg: &PipelineConfig,
     auth: &AuthCatalog,
-    cancel: Option<CancellationToken>,
+    run: TopologyRunOptions,
 ) -> CliResult<RunSummary> {
-    let topo = build_topology(cfg, auth).await?;
+    for (block, consequence) in inert_blocks(cfg) {
+        tracing::warn!(
+            block,
+            "`{block}:` is not applied in topology mode (`pipeline.nodes`) — {consequence}"
+        );
+    }
+
+    let topo = build_topology_with(cfg, auth, &run).await?;
 
     let pipeline_name = cfg.name.clone().unwrap_or_else(|| "unnamed".to_string());
     let run_id = uuid::Uuid::now_v7().to_string();
@@ -305,14 +492,26 @@ pub async fn run_topology(
     opts.run_id = run_id;
 
     if let Some(state) = &cfg.pipeline.state {
-        opts = opts.with_state_store(crate::state::build_state_store(state).await?);
+        let store = crate::state::build_state_store(state).await?;
+        // A preview must not advance a durable bookmark: the counting/truncating
+        // sinks return `Ok` without a real write, so a persisted bookmark would
+        // make the next real run resume past records nobody wrote (#456 C2,
+        // mirroring #321 H1 on the matrix path). Reads still pass through.
+        let store = if run.is_preview() {
+            std::sync::Arc::new(crate::executor::ReadOnlyStateStore { inner: store })
+                as std::sync::Arc<dyn faucet_core::StateStore>
+        } else {
+            store
+        };
+        opts = opts.with_state_store(store);
     }
     if let Some(dlq) = &cfg.pipeline.dlq {
         opts = opts.with_dlq(crate::executor::build_dlq_config(dlq).await?);
     }
-    if let Some(c) = cancel {
+    if let Some(c) = run.cancel.clone() {
         opts = opts.with_cancel(c);
     }
+    opts = opts.with_governance(build_governance(cfg)?);
 
     let result = topo.run(opts).await?;
 

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -48,7 +48,8 @@ pub struct TopologyRunOptions {
 impl TopologyRunOptions {
     /// The effective `${now.*}` clock.
     fn clock(&self) -> DateTime<FixedOffset> {
-        self.clock.unwrap_or_else(|| chrono::Utc::now().fixed_offset())
+        self.clock
+            .unwrap_or_else(|| chrono::Utc::now().fixed_offset())
     }
 
     /// Whether this is a non-writing preview, which must not persist bookmarks.
@@ -84,7 +85,10 @@ pub fn inert_blocks(cfg: &PipelineConfig) -> Vec<(&'static str, &'static str)> {
     }
     #[cfg(feature = "catalog")]
     if cfg.catalog.is_some() {
-        out.push(("catalog", "no datasets, schemas, or lineage edges are recorded"));
+        out.push((
+            "catalog",
+            "no datasets, schemas, or lineage edges are recorded",
+        ));
     }
     if cfg.sla.is_some() {
         out.push((

--- a/cli/tests/topology_end_to_end.rs
+++ b/cli/tests/topology_end_to_end.rs
@@ -446,9 +446,16 @@ pipeline:
     ));
     let auth = build_auth_catalog(None).unwrap();
     let cancel = faucet_core::CancellationToken::new();
-    let summary = faucet_cli::topology::run_topology(&cfg, &auth, Some(cancel))
-        .await
-        .unwrap();
+    let summary = faucet_cli::topology::run_topology(
+        &cfg,
+        &auth,
+        faucet_cli::topology::TopologyRunOptions {
+            cancel: Some(cancel),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
     assert_eq!(summary.invocations.len(), 1);
     assert_eq!(summary.invocations[0].records_written, 4);
     assert_eq!(summary.invocations[0].row_id, "w");
@@ -666,4 +673,205 @@ pipeline:
     let auth = build_auth_catalog(None).unwrap();
     let err = build_topology(&cfg, &auth).await.unwrap_err();
     assert!(matches!(err, CliError::InvalidTopology { .. }), "{err:?}");
+}
+
+// ── #456: topology mode must not bypass the governance layer ─────────────────
+
+/// #456 C2: `--dry-run` used to be silently ignored in topology mode, so it
+/// performed real writes. It must now write nothing.
+#[test]
+fn dry_run_writes_nothing_in_topology_mode() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("out.jsonl");
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: dry
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            out = out.display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", cfg_path.to_str().unwrap(), "--dry-run"])
+        .assert()
+        .success();
+    assert!(
+        !out.exists(),
+        "--dry-run must not create the destination file"
+    );
+}
+
+/// #456 C3: a topology declaring `masking:` must actually mask. Before the fix
+/// the block parsed, validated, ran — and PII reached the sink in the clear.
+#[test]
+#[cfg(feature = "masking")]
+fn masking_applies_in_topology_mode() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("people.csv");
+    write(&src, "id,email\n1,a@b.c\n");
+    let out = dir.path().join("masked.jsonl");
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: masked
+pipeline:
+  masking:
+    rules:
+      - name: hide-email
+        match: {{ fields: [email] }}
+        action: {{ type: redact, mask: "***" }}
+  sources:
+    o: {{ type: csv, config: {{ path: {src} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            src = src.display(),
+            out = out.display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", cfg_path.to_str().unwrap()])
+        .assert()
+        .success();
+    let body = fs::read_to_string(&out).unwrap();
+    assert!(body.contains("***"), "email must be masked: {body}");
+    assert!(
+        !body.contains("a@b.c"),
+        "raw PII must not reach the sink: {body}"
+    );
+}
+
+/// #456 H2: `delivery: exactly_once` has no watermark path in a node graph, so
+/// it must be rejected rather than silently downgraded to at-least-once.
+#[tokio::test]
+async fn rejects_exactly_once_in_topology_mode() {
+    let cfg = parse(
+        r#"version: 1
+name: eo
+delivery: exactly_once
+pipeline:
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: jsonl, config: { path: /tmp/y.jsonl } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("exactly_once"), "{msg}");
+    assert!(msg.contains("topology mode"), "{msg}");
+}
+
+/// #456 H4: `${now.*}` was never resolved in topology mode, so the literal token
+/// reached the connector and a dated path became a directory named `${now.date}`.
+#[test]
+fn now_tokens_resolve_in_topology_mode() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let cfg_path = dir.path().join("faucet.yaml");
+    let out_dir = dir.path().join("dt=${now.date}");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: dated
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: "{base}/dt=${{now.date}}/part.jsonl" }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            base = dir.path().display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args([
+            "run",
+            cfg_path.to_str().unwrap(),
+            "--clock",
+            "2026-03-04T00:00:00Z",
+        ])
+        .assert()
+        .success();
+    assert!(
+        dir.path().join("dt=2026-03-04/part.jsonl").exists(),
+        "the clock must be substituted into the sink path"
+    );
+    assert!(
+        !out_dir.exists(),
+        "the literal `${{now.date}}` token must never reach the connector"
+    );
+}
+
+/// #456 M2: blocks topology mode does not act on must be called out, not
+/// silently swallowed behind a "valid" line.
+#[test]
+fn validate_warns_about_blocks_topology_ignores() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: inert
+sla:
+  max_staleness_secs: 3600
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: stdout, config: {{}} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate", cfg_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("WARNING"))
+        .stdout(contains("sla"));
 }

--- a/crates/core/src/dlq.rs
+++ b/crates/core/src/dlq.rs
@@ -160,7 +160,11 @@ pub fn build_envelope(
     record_index: usize,
 ) -> Value {
     let kind = crate::observability::decorator::error_kind(error);
-    let message = error.to_string();
+    // The envelope is written to a file / object store, so it leaves the process:
+    // scrub any resolved secret the error text picked up (a `reqwest` error
+    // embeds the request URL, which may carry an API key in a query parameter).
+    // No-op unless the host installed a redactor (#456 H5).
+    let message = crate::redact::redact(&error.to_string());
     // `as_millis()` returns u128. Convert via TryFrom so we saturate at
     // i64::MAX instead of silently wrapping to a negative number. The
     // saturation ceiling (year ~292,000,000) is impossible in practice,

--- a/crates/core/src/idempotency.rs
+++ b/crates/core/src/idempotency.rs
@@ -252,6 +252,56 @@ pub const COMMIT_TOKEN_TOKEN_COL: &str = "token";
 pub const ICEBERG_SCOPE_PROP: &str = "faucet.commit-scope";
 pub const ICEBERG_TOKEN_PROP: &str = "faucet.commit-token";
 
+/// Fit a watermark scope into a length-capped, indexable key column.
+///
+/// The scope is the pipeline state key — `{name}::{row}` for a root, plus
+/// `::{parent_record_key}` for a child — and a child's key comes from *record
+/// data*, so it has no length bound. The SQL sinks store it as a PRIMARY KEY, and
+/// a key column cannot be unbounded (MySQL's index limit, SQL Server's 900-byte
+/// key budget), so an over-long scope either errors or — under a non-strict MySQL
+/// `sql_mode` — is **truncated**, silently collapsing two distinct rows onto one
+/// watermark so one row's committed token suppresses the other's pages (#456 L1).
+///
+/// Scopes at or under `max` are returned verbatim, so every watermark written
+/// before this existed still resolves. A longer one is replaced by a
+/// deterministic, collision-resistant digest form (`__h:<64-hex>`), which is
+/// stable across restarts — the only property the watermark needs.
+/// Length of the `__h:` + 16 hex-digit suffix appended to a shortened scope.
+const SCOPE_DIGEST_LEN: usize = 4 + 16;
+
+pub fn scope_key(scope: &str, max: usize) -> String {
+    if scope.len() <= max {
+        return scope.to_owned();
+    }
+    // FNV-1a rather than a crypto hash: `sha2` is an optional dependency of this
+    // crate (masking / transform-hash / encryption) and this module is always
+    // compiled. The requirement is determinism, not preimage resistance — the same
+    // choice the backfill progress marker makes.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in scope.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    // Keep as much of the readable head as fits, so an operator inspecting the
+    // watermark table can still tell which pipeline a row belongs to. Truncate on
+    // a char boundary — a scope may hold non-ASCII.
+    let room = max.saturating_sub(SCOPE_DIGEST_LEN);
+    let mut head = 0usize;
+    for (i, _) in scope.char_indices() {
+        if i > room {
+            break;
+        }
+        head = i;
+    }
+    let shortened = format!("{}__h:{h:016x}", &scope[..head]);
+    tracing::debug!(
+        scope_len = scope.len(),
+        max,
+        "exactly-once scope exceeds the sink's key-column width; shortening with a digest"
+    );
+    shortened
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,5 +490,53 @@ mod tests {
         );
         let m: DeliveryMode = serde_json::from_str("\"at_least_once\"").unwrap();
         assert_eq!(m, DeliveryMode::AtLeastOnce);
+    }
+}
+
+#[cfg(test)]
+mod scope_key_tests {
+    use super::*;
+
+    /// #456 L1: the SQL sinks store the scope as a length-capped PRIMARY KEY, so
+    /// a long child scope (its key comes from record data and has no bound) either
+    /// errored or — under a non-strict MySQL sql_mode — truncated, collapsing two
+    /// rows onto one watermark.
+    #[test]
+    fn scope_key_passes_short_scopes_through_and_shortens_long_ones() {
+        // Backwards compatible: anything that fit before is returned verbatim, so
+        // watermarks written before this existed still resolve.
+        assert_eq!(scope_key("pipe::row", 255), "pipe::row");
+        let exactly = "x".repeat(255);
+        assert_eq!(scope_key(&exactly, 255), exactly);
+
+        // Over the cap: shortened, and within the cap.
+        let long = format!("pipe::row::{}", "k".repeat(400));
+        let key = scope_key(&long, 255);
+        assert!(key.len() <= 255, "len {}", key.len());
+        assert_ne!(key, long);
+        // Keeps a readable head so the row is still attributable.
+        assert!(key.starts_with("pipe::row::"), "{key}");
+        assert!(key.contains("__h:"), "{key}");
+    }
+
+    #[test]
+    fn scope_key_is_deterministic_and_distinguishes_scopes() {
+        let a = format!("pipe::row::{}", "a".repeat(400));
+        let b = format!("pipe::row::{}", "b".repeat(400));
+        // Stable across calls — the watermark must resolve after a restart.
+        assert_eq!(scope_key(&a, 255), scope_key(&a, 255));
+        // Two distinct scopes must not collide onto one watermark. Under plain
+        // truncation both of these would become the same 255-char prefix.
+        assert_ne!(scope_key(&a, 255), scope_key(&b, 255));
+        assert_eq!(&a[..255], &format!("pipe::row::{}", "a".repeat(400))[..255]);
+    }
+
+    #[test]
+    fn scope_key_truncates_on_a_char_boundary() {
+        // A multi-byte head must not be split mid-character (that would panic).
+        let long = format!("pipé::{}", "é".repeat(400));
+        let key = scope_key(&long, 255);
+        assert!(key.len() <= 255);
+        assert!(key.contains("__h:"), "{key}");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod observability;
 pub mod pipeline;
 #[cfg(feature = "quality")]
 pub mod quality;
+pub mod redact;
 pub mod replication;
 pub mod resilience;
 pub mod retry;

--- a/crates/core/src/redact.rs
+++ b/crates/core/src/redact.rs
@@ -1,0 +1,79 @@
+//! A process-global redaction hook (#456 H5).
+//!
+//! Secrets are resolved on raw config text long before they become typed values,
+//! so the CLI tracks the resolved *values* in `cli::secrets::registry` and scrubs
+//! them from anything it emits. `faucet-core` cannot see that registry — it has
+//! no secrets layer and must not gain one — yet core is where two outbound
+//! surfaces are built:
+//!
+//! - the **DLQ envelope**'s `error.message` ([`crate::dlq::build_envelope`]),
+//!   which is written to a file or object store, and
+//! - any error text a host application forwards onward.
+//!
+//! An error string routinely embeds the material that produced it: `reqwest`'s
+//! `Display` includes the request URL, so a REST source whose API key rides a
+//! query parameter leaks the key; connection-string leakage in a CDC error has
+//! already been a filed bug here (#84).
+//!
+//! So core exposes a hook: a host installs a scrubber once at startup, and core
+//! routes outbound text through [`redact`]. With no hook installed, [`redact`] is
+//! the identity function and costs one atomic load — library users who never
+//! resolve secrets pay nothing and see no behaviour change.
+
+use std::sync::OnceLock;
+
+/// A scrubber: takes text, returns it with every known secret replaced.
+pub type Redactor = Box<dyn Fn(&str) -> String + Send + Sync>;
+
+fn hook() -> &'static OnceLock<Redactor> {
+    static HOOK: OnceLock<Redactor> = OnceLock::new();
+    &HOOK
+}
+
+/// Install the process-wide redactor. The **first** call wins; later calls are
+/// ignored and return `false`, so a second `install_observability` (or a test
+/// that runs after one) can never swap the scrubber out from under a run.
+pub fn install(redactor: Redactor) -> bool {
+    hook().set(redactor).is_ok()
+}
+
+/// Whether a redactor has been installed.
+pub fn is_installed() -> bool {
+    hook().get().is_some()
+}
+
+/// Scrub `text` with the installed redactor, or return it unchanged when none is
+/// installed.
+///
+/// Call this on every string core hands to a destination outside the process.
+pub fn redact(text: &str) -> String {
+    match hook().get() {
+        Some(f) => f(text),
+        None => text.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The hook is process-global and `install` is first-wins, so the whole
+    /// contract is asserted in one test — two `#[test]` fns would race for the
+    /// single `OnceLock`.
+    #[test]
+    fn install_is_first_wins_and_redact_applies_it() {
+        // Before install: identity, and reported as absent.
+        if !is_installed() {
+            assert_eq!(redact("token=abcd"), "token=abcd");
+        }
+
+        assert!(install(Box::new(|s: &str| s.replace("abcd", "***"))));
+        assert!(is_installed());
+        assert_eq!(redact("token=abcd"), "token=***");
+        assert_eq!(redact("nothing to do"), "nothing to do");
+
+        // A second install is refused — the first redactor stays in force.
+        assert!(!install(Box::new(|_: &str| "clobbered".to_owned())));
+        assert_eq!(redact("token=abcd"), "token=***");
+    }
+}

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -687,7 +687,7 @@ impl Topology {
                         quality: opts.governance.quality.clone(),
                         #[cfg(feature = "contract")]
                         contract: opts.governance.contract.clone(),
-                        schema_drift: opts.governance.schema_drift.clone(),
+                        schema_drift: opts.governance.schema_drift,
                         resilience: opts.governance.resilience.clone(),
                     };
                     Box::pin(run_sink_node(id, sink, rx, sopts))
@@ -738,11 +738,7 @@ impl Topology {
                 // (#146 H16, #456 M1). A node that does not stop within the grace
                 // window is still dropped, so a sink wedged mid-write cannot hang
                 // the run.
-                let coop = opts
-                    .cancel
-                    .clone()
-                    .unwrap_or_else(CancellationToken::new)
-                    .child_token();
+                let coop = opts.cancel.clone().unwrap_or_default().child_token();
                 let first_err: Arc<std::sync::Mutex<Option<FaucetError>>> =
                     Arc::new(std::sync::Mutex::new(None));
                 let wrapped = joined.map(|f| {
@@ -2015,10 +2011,7 @@ mod tests {
         // above "0/10…" lexicographically while being *behind* it numerically.
         assert_eq!(
             start_bookmark(
-                &[
-                    json!({"lsn": "0/9FFFFFF"}),
-                    json!({"lsn": "0/10000000"}),
-                ],
+                &[json!({"lsn": "0/9FFFFFF"}), json!({"lsn": "0/10000000"}),],
                 1
             ),
             None

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -56,7 +56,7 @@
 //! Sink nodes reuse [`run_stream`], so the masking / quality / contract /
 //! schema-drift passes and the resilience policy apply exactly as they do to a
 //! single-source pipeline — supply them via
-//! [`TopologyOptions::with_governance`]. Masking is destination-scoped and is
+//! [`Topology::run_with`]. Masking is destination-scoped and is
 //! therefore keyed by sink node id.
 
 use crate::dlq::DlqConfig;
@@ -184,7 +184,13 @@ pub enum TopologyOnError {
 /// gets identical enforcement. Masking is destination-scoped (a rule may name
 /// the sinks it applies to), so it is keyed by **sink node id** and compiled by
 /// the caller; the rest are pipeline-wide.
+///
+/// `#[non_exhaustive]`: construct with [`TopologyGovernance::new`] (or
+/// `Default`) and assign the fields you need. This is deliberate — adding a pass
+/// later would otherwise be a major-version break for every downstream crate,
+/// which is exactly the trap `TopologyOptions` is already in.
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub struct TopologyGovernance {
     /// Compiled data-quality checks, applied per page in every sink node.
     #[cfg(feature = "quality")]
@@ -229,20 +235,16 @@ pub struct TopologyOptions {
     pub on_error: TopologyOnError,
     /// Default bounded-channel capacity for edges not fed by a tee.
     pub default_channel_capacity: usize,
-    /// Governance passes applied to every sink node (masking / quality /
-    /// contract / schema drift / resilience).
-    pub governance: TopologyGovernance,
-    /// How long a node gets to stop at its next page boundary and flush after
-    /// another node has failed under [`TopologyOnError::Propagate`]. Mirrors the
-    /// CLI executor's `on_error: stop` grace: without it a buffered sink is
-    /// dropped mid-write, orphaning a multipart upload or a footer-less Parquet
-    /// file (#146 H16).
-    pub stop_flush_grace: Duration,
 }
 
-/// Default grace granted to sibling nodes to flush after a node failure under
-/// [`TopologyOnError::Propagate`].
-pub const DEFAULT_STOP_FLUSH_GRACE: Duration = Duration::from_secs(30);
+/// How long a node gets to stop at its next page boundary and flush after another
+/// node has failed under [`TopologyOnError::Propagate`], before it is aborted.
+///
+/// Mirrors the CLI executor's `on_error: stop` grace: without it a buffered sink
+/// is dropped mid-write, orphaning a multipart upload or leaving a footer-less
+/// Parquet file (#146 H16, #456 M1). The window opens only once a failure has
+/// cancelled the run, so a healthy run is never bounded by it.
+pub const STOP_FLUSH_GRACE: Duration = Duration::from_secs(30);
 
 impl Default for TopologyOptions {
     fn default() -> Self {
@@ -255,8 +257,6 @@ impl Default for TopologyOptions {
             cancel: None,
             on_error: TopologyOnError::default(),
             default_channel_capacity: DEFAULT_CHANNEL_CAPACITY,
-            governance: TopologyGovernance::default(),
-            stop_flush_grace: DEFAULT_STOP_FLUSH_GRACE,
         }
     }
 }
@@ -297,19 +297,6 @@ impl TopologyOptions {
     /// Set the batch-size hint.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
-        self
-    }
-
-    /// Attach the governance passes applied to every sink node.
-    pub fn with_governance(mut self, governance: TopologyGovernance) -> Self {
-        self.governance = governance;
-        self
-    }
-
-    /// Override the post-failure flush grace (see
-    /// [`TopologyOptions::stop_flush_grace`]).
-    pub fn with_stop_flush_grace(mut self, grace: Duration) -> Self {
-        self.stop_flush_grace = grace;
         self
     }
 }
@@ -579,8 +566,25 @@ impl Topology {
         Ok(())
     }
 
-    /// Run the topology to completion.
+    /// Run the topology to completion with no governance passes.
+    ///
+    /// Equivalent to [`Topology::run_with`] with a default
+    /// [`TopologyGovernance`] — kept as-is so existing callers are unaffected.
     pub async fn run(self, opts: TopologyOptions) -> Result<TopologyResult, FaucetError> {
+        self.run_with(opts, TopologyGovernance::default()).await
+    }
+
+    /// Run the topology to completion, applying `governance` to every sink node.
+    ///
+    /// Separate from [`Topology::run`] rather than a field on
+    /// [`TopologyOptions`]: that struct is exhaustively constructible through the
+    /// public API, so adding a field to it would be a major-version break for
+    /// every downstream crate. A new method is additive.
+    pub async fn run_with(
+        self,
+        opts: TopologyOptions,
+        governance: TopologyGovernance,
+    ) -> Result<TopologyResult, FaucetError> {
         self.validate()?;
         let Topology { nodes, edges } = self;
 
@@ -682,13 +686,13 @@ impl Topology {
                         // the policy compiled for it (if any); the rest are
                         // pipeline-wide.
                         #[cfg(feature = "masking")]
-                        masking: opts.governance.masking_by_sink.get(&id).cloned(),
+                        masking: governance.masking_by_sink.get(&id).cloned(),
                         #[cfg(feature = "quality")]
-                        quality: opts.governance.quality.clone(),
+                        quality: governance.quality.clone(),
                         #[cfg(feature = "contract")]
-                        contract: opts.governance.contract.clone(),
-                        schema_drift: opts.governance.schema_drift,
-                        resilience: opts.governance.resilience.clone(),
+                        contract: governance.contract.clone(),
+                        schema_drift: governance.schema_drift,
+                        resilience: governance.resilience.clone(),
                     };
                     Box::pin(run_sink_node(id, sink, rx, sopts))
                 }
@@ -765,7 +769,7 @@ impl Topology {
                 // The grace window opens only once something has cancelled the
                 // token — a healthy run is never bounded by it.
                 let all = futures::future::join_all(wrapped);
-                let grace = opts.stop_flush_grace;
+                let grace = STOP_FLUSH_GRACE;
                 let deadline = {
                     let coop = coop.clone();
                     async move {
@@ -1921,9 +1925,7 @@ mod tests {
             .edge("t", "good")
             .build()
             .unwrap();
-        let opts = TopologyOptions::new("p")
-            .with_on_error(TopologyOnError::Propagate)
-            .with_stop_flush_grace(Duration::from_secs(5));
+        let opts = TopologyOptions::new("p").with_on_error(TopologyOnError::Propagate);
         let err = topo.run(opts).await.unwrap_err();
         assert!(matches!(err, FaucetError::Sink(_)), "{err:?}");
         assert!(
@@ -1962,8 +1964,9 @@ mod tests {
 
         let mut governance = TopologyGovernance::new();
         governance.masking_by_sink.insert("k".to_string(), compiled);
-        let opts = TopologyOptions::new("p").with_governance(governance);
-        topo.run(opts).await.unwrap();
+        topo.run_with(TopologyOptions::new("p"), governance)
+            .await
+            .unwrap();
 
         let written = store.lock().unwrap();
         assert_eq!(written.len(), 1);

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -36,13 +36,34 @@
 //! has a stored bookmark; otherwise the source replays in full. Sinks whose
 //! bookmarks have diverged must therefore be idempotent — a faster sink will
 //! re-see already-written pages.
+//!
+//! Resuming is deliberately conservative, because the only safe direction to err
+//! is *replay* (duplicates) and never *skip* (loss) — see [`start_bookmark`]:
+//!
+//! - **One source node only.** With two or more sources there is no way to tell
+//!   which source a given sink's bookmark came from, so applying one to all of
+//!   them would resume a source at a position that is not its own. Multi-source
+//!   graphs therefore replay in full.
+//! - **Comparable, agreeing bookmarks only.** Sink bookmarks are compared for
+//!   equality, not ordered. Resume positions are frequently structured (CDC LSN
+//!   maps, Kafka offset maps), and [`json_gt`]'s object arm orders by *serialized
+//!   text*, which is not the replication order — so a "minimum" picked that way
+//!   can sit ahead of the true minimum and skip records. Divergent bookmarks
+//!   therefore replay in full rather than guess.
+//!
+//! ## Governance passes
+//!
+//! Sink nodes reuse [`run_stream`], so the masking / quality / contract /
+//! schema-drift passes and the resilience policy apply exactly as they do to a
+//! single-source pipeline — supply them via
+//! [`TopologyOptions::with_governance`]. Masking is destination-scoped and is
+//! therefore keyed by sink node id.
 
 use crate::dlq::DlqConfig;
 use crate::error::FaucetError;
 use crate::join::HashJoin;
 use crate::observability::{Labels, RunStreamOptions, instrumented_apply_stages};
 use crate::pipeline::{DEFAULT_BATCH_SIZE, StreamPage, run_stream};
-use crate::replication::json_gt;
 use crate::stage::CompiledStage;
 use crate::state::StateStore;
 use crate::traits::{Sink, Source};
@@ -53,6 +74,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -155,6 +177,39 @@ pub enum TopologyOnError {
     Continue,
 }
 
+/// The per-run governance passes applied to every sink node.
+///
+/// These are the same passes [`crate::Pipeline`] applies in matrix mode; a
+/// topology wires them through [`run_stream`] per sink node so a graph pipeline
+/// gets identical enforcement. Masking is destination-scoped (a rule may name
+/// the sinks it applies to), so it is keyed by **sink node id** and compiled by
+/// the caller; the rest are pipeline-wide.
+#[derive(Clone, Default)]
+pub struct TopologyGovernance {
+    /// Compiled data-quality checks, applied per page in every sink node.
+    #[cfg(feature = "quality")]
+    pub quality: Option<Arc<crate::quality::CompiledQuality>>,
+    /// Compiled data contract, applied per page in every sink node.
+    #[cfg(feature = "contract")]
+    pub contract: Option<Arc<crate::contract::CompiledContract>>,
+    /// Compiled masking policy per sink node id. A sink node with no entry runs
+    /// no masking pass (the caller found no rule that applies to it).
+    #[cfg(feature = "masking")]
+    pub masking_by_sink: HashMap<String, Arc<crate::masking::CompiledMasking>>,
+    /// Compiled schema-drift policy, applied per page in every sink node.
+    pub schema_drift: Option<crate::drift::SchemaDriftPolicy>,
+    /// Resilience policy (retry / circuit breaker / poison) for sink-side
+    /// writes, flushes, and state puts.
+    pub resilience: Option<crate::resilience::ResiliencePolicy>,
+}
+
+impl TopologyGovernance {
+    /// A governance set with no passes configured.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Per-run options for [`Topology::run`].
 #[derive(Clone)]
 pub struct TopologyOptions {
@@ -174,7 +229,20 @@ pub struct TopologyOptions {
     pub on_error: TopologyOnError,
     /// Default bounded-channel capacity for edges not fed by a tee.
     pub default_channel_capacity: usize,
+    /// Governance passes applied to every sink node (masking / quality /
+    /// contract / schema drift / resilience).
+    pub governance: TopologyGovernance,
+    /// How long a node gets to stop at its next page boundary and flush after
+    /// another node has failed under [`TopologyOnError::Propagate`]. Mirrors the
+    /// CLI executor's `on_error: stop` grace: without it a buffered sink is
+    /// dropped mid-write, orphaning a multipart upload or a footer-less Parquet
+    /// file (#146 H16).
+    pub stop_flush_grace: Duration,
 }
+
+/// Default grace granted to sibling nodes to flush after a node failure under
+/// [`TopologyOnError::Propagate`].
+pub const DEFAULT_STOP_FLUSH_GRACE: Duration = Duration::from_secs(30);
 
 impl Default for TopologyOptions {
     fn default() -> Self {
@@ -187,6 +255,8 @@ impl Default for TopologyOptions {
             cancel: None,
             on_error: TopologyOnError::default(),
             default_channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            governance: TopologyGovernance::default(),
+            stop_flush_grace: DEFAULT_STOP_FLUSH_GRACE,
         }
     }
 }
@@ -227,6 +297,19 @@ impl TopologyOptions {
     /// Set the batch-size hint.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Attach the governance passes applied to every sink node.
+    pub fn with_governance(mut self, governance: TopologyGovernance) -> Self {
+        self.governance = governance;
+        self
+    }
+
+    /// Override the post-failure flush grace (see
+    /// [`TopologyOptions::stop_flush_grace`]).
+    pub fn with_stop_flush_grace(mut self, grace: Duration) -> Self {
+        self.stop_flush_grace = grace;
         self
     }
 }
@@ -511,13 +594,15 @@ impl Topology {
             })
             .collect();
 
-        // Compute the source start bookmark = min across sink bookmarks.
+        // Resume point for the source node(s) — only when provably safe (see
+        // `start_bookmark`); otherwise every source replays in full.
         let sink_ids: Vec<String> = nodes
             .iter()
             .filter(|n| n.kind.is_sink())
             .map(|n| n.id.clone())
             .collect();
-        let start_bookmark = compute_start_bookmark(&opts, &sink_ids).await;
+        let source_count = nodes.iter().filter(|n| n.kind.is_source()).count();
+        let start_bookmark = compute_start_bookmark(&opts, &sink_ids, source_count).await;
 
         // Build channels.
         let mut outs: HashMap<String, Vec<mpsc::Sender<StreamPage>>> = HashMap::new();
@@ -536,8 +621,9 @@ impl Topology {
             });
         }
 
-        // Build one future per node.
-        type NodeFut = Pin<Box<dyn Future<Output = Result<NodeOutcome, FaucetError>>>>;
+        // Build one future per node. `Send + 'static` so each node can own a
+        // task (see the spawn below).
+        type NodeFut = Pin<Box<dyn Future<Output = Result<NodeOutcome, FaucetError>> + Send>>;
         let mut futs: Vec<NodeFut> = Vec::with_capacity(nodes.len());
 
         for node in nodes {
@@ -592,6 +678,17 @@ impl Topology {
                         state_store: opts.state_store.clone(),
                         dlq: opts.dlq.clone(),
                         cancel: cancel.clone(),
+                        // Masking is destination-scoped, so each sink node takes
+                        // the policy compiled for it (if any); the rest are
+                        // pipeline-wide.
+                        #[cfg(feature = "masking")]
+                        masking: opts.governance.masking_by_sink.get(&id).cloned(),
+                        #[cfg(feature = "quality")]
+                        quality: opts.governance.quality.clone(),
+                        #[cfg(feature = "contract")]
+                        contract: opts.governance.contract.clone(),
+                        schema_drift: opts.governance.schema_drift.clone(),
+                        resilience: opts.governance.resilience.clone(),
                     };
                     Box::pin(run_sink_node(id, sink, rx, sopts))
                 }
@@ -603,13 +700,103 @@ impl Topology {
         drop(outs);
         drop(ins);
 
+        // One task per node, so nodes run on the runtime's whole thread pool
+        // instead of sharing a single task. A synchronous stage (the DuckDB `sql`
+        // transform, a wasm transform) would otherwise occupy the one task and
+        // stall every other node including the sinks (#456 M5). A spawned node
+        // also isolates panics: they arrive as a `JoinError` we report, rather
+        // than unwinding the caller.
+        let handles: Vec<tokio::task::JoinHandle<Result<NodeOutcome, FaucetError>>> =
+            futs.into_iter().map(tokio::spawn).collect();
+        // Dropping a `JoinHandle` detaches the task rather than cancelling it, so
+        // every abandon path below aborts explicitly.
+        let aborts: Vec<tokio::task::AbortHandle> =
+            handles.iter().map(|h| h.abort_handle()).collect();
+        let abort_all = || {
+            for a in &aborts {
+                a.abort();
+            }
+        };
+        let joined = handles.into_iter().map(|h| async move {
+            match h.await {
+                Ok(r) => r,
+                Err(e) if e.is_panic() => {
+                    Err(FaucetError::Source(format!("topology node panicked: {e}")))
+                }
+                Err(e) => Err(FaucetError::Source(format!("topology node aborted: {e}"))),
+            }
+        });
+
         match opts.on_error {
             TopologyOnError::Propagate => {
-                let outcomes = futures::future::try_join_all(futs).await?;
-                Ok(aggregate(outcomes))
+                // Do NOT `try_join_all`: it returns on the first error and drops
+                // the remaining node futures where they stand, so a buffered sink
+                // never flushes — orphaning a multipart upload or writing a
+                // footer-less Parquet file. Instead signal the shared cancel
+                // token and let the siblings stop at their next page boundary and
+                // flush, exactly as the CLI executor's `on_error: stop` does
+                // (#146 H16, #456 M1). A node that does not stop within the grace
+                // window is still dropped, so a sink wedged mid-write cannot hang
+                // the run.
+                let coop = opts
+                    .cancel
+                    .clone()
+                    .unwrap_or_else(CancellationToken::new)
+                    .child_token();
+                let first_err: Arc<std::sync::Mutex<Option<FaucetError>>> =
+                    Arc::new(std::sync::Mutex::new(None));
+                let wrapped = joined.map(|f| {
+                    let coop = coop.clone();
+                    let slot = Arc::clone(&first_err);
+                    async move {
+                        match f.await {
+                            Ok(o) => Some(o),
+                            Err(e) => {
+                                tracing::error!(
+                                    error = %e,
+                                    "topology node failed; cancelling siblings so they flush"
+                                );
+                                let mut guard = slot.lock().unwrap_or_else(|p| p.into_inner());
+                                if guard.is_none() {
+                                    *guard = Some(e);
+                                }
+                                coop.cancel();
+                                None
+                            }
+                        }
+                    }
+                });
+                // The grace window opens only once something has cancelled the
+                // token — a healthy run is never bounded by it.
+                let all = futures::future::join_all(wrapped);
+                let grace = opts.stop_flush_grace;
+                let deadline = {
+                    let coop = coop.clone();
+                    async move {
+                        coop.cancelled().await;
+                        tokio::time::sleep(grace).await;
+                    }
+                };
+                let outcomes = tokio::select! {
+                    biased;
+                    v = all => v,
+                    () = deadline => {
+                        tracing::warn!(
+                            grace_secs = grace.as_secs(),
+                            "topology: nodes did not stop within the flush grace after a failure; \
+                             aborting them"
+                        );
+                        abort_all();
+                        Vec::new()
+                    }
+                };
+                if let Some(e) = first_err.lock().unwrap_or_else(|p| p.into_inner()).take() {
+                    return Err(e);
+                }
+                Ok(aggregate(outcomes.into_iter().flatten().collect()))
             }
             TopologyOnError::Continue => {
-                let results = futures::future::join_all(futs).await;
+                let results = futures::future::join_all(joined).await;
                 let mut ok = Vec::new();
                 let mut errs = Vec::new();
                 for r in results {
@@ -684,9 +871,16 @@ fn reaches_any(start: &str, adj: &HashMap<&str, Vec<&str>>, targets: &HashSet<&s
     false
 }
 
-/// Read every sink node's stored bookmark; return the minimum only when every
-/// sink has one (so the slowest sink is not skipped past on restart).
-async fn compute_start_bookmark(opts: &TopologyOptions, sink_ids: &[String]) -> Option<Value> {
+/// Read every sink node's stored bookmark and decide the source's resume point.
+///
+/// Returns `Some(bookmark)` only when it is provably safe to resume there;
+/// `None` means "replay in full", which costs duplicates on a non-idempotent
+/// sink but can never skip a record. See [`start_bookmark`] for the rules.
+async fn compute_start_bookmark(
+    opts: &TopologyOptions,
+    sink_ids: &[String],
+    source_count: usize,
+) -> Option<Value> {
     let store = opts.state_store.as_ref()?;
     if sink_ids.is_empty() {
         return None;
@@ -699,20 +893,48 @@ async fn compute_start_bookmark(opts: &TopologyOptions, sink_ids: &[String]) -> 
             _ => return None, // a sink with no bookmark → full replay.
         }
     }
-    min_bookmark(&values)
+    start_bookmark(&values, source_count)
 }
 
-/// The minimum of a set of bookmarks under the replication ordering.
-fn min_bookmark(vals: &[Value]) -> Option<Value> {
-    let mut min: Option<&Value> = None;
-    for v in vals {
-        match min {
-            None => min = Some(v),
-            Some(m) if json_gt(m, v) => min = Some(v),
-            _ => {}
+/// Pure resume-point decision: the bookmark every source node is started from,
+/// or `None` to replay in full.
+///
+/// Deliberately conservative — the only safe way to be wrong is to replay:
+///
+/// 1. **More than one source node → `None`.** A sink's bookmark records the
+///    position of whichever source fed its pages, and nothing in the graph
+///    records which one that was. Applying one source's position to another
+///    resumes it somewhere it has never been. (#456 H1)
+/// 2. **Sink bookmarks that are not all equal → `None`.** Bookmarks are compared
+///    for *equality*, never ordered: resume positions are routinely structured
+///    (CDC LSN maps, Kafka/Kinesis offset maps) and
+///    [`json_gt`](crate::replication::json_gt)'s object arm falls back to
+///    comparing serialized text, an order unrelated to replication progress. A
+///    "minimum" chosen that way can sit *ahead* of the true minimum and silently
+///    skip the lagging sink's records. (#456 H1)
+/// 3. **All sinks agree → resume there.** No ordering needed, so no guessing.
+pub fn start_bookmark(sink_bookmarks: &[Value], source_count: usize) -> Option<Value> {
+    if sink_bookmarks.is_empty() || source_count != 1 {
+        if source_count > 1 && !sink_bookmarks.is_empty() {
+            tracing::warn!(
+                sources = source_count,
+                "topology: multi-source graph cannot attribute a sink bookmark to a source; \
+                 replaying every source in full. Make the sinks idempotent \
+                 (`write_mode: upsert`) or split the graph into one pipeline per source."
+            );
         }
+        return None;
     }
-    min.cloned()
+    let first = &sink_bookmarks[0];
+    if sink_bookmarks.iter().any(|v| v != first) {
+        tracing::warn!(
+            "topology: sink bookmarks have diverged and resume positions are not safely \
+             ordered; replaying the source in full so no sink is skipped past. Faster sinks \
+             will re-see already-written pages — make them idempotent."
+        );
+        return None;
+    }
+    Some(first.clone())
 }
 
 /// Send `page` to every live output, moving into the last and cloning for the
@@ -906,6 +1128,15 @@ struct SinkNodeOpts {
     state_store: Option<Arc<dyn StateStore>>,
     dlq: Option<DlqConfig>,
     cancel: Option<CancellationToken>,
+    /// Masking policy compiled for *this* sink node (destination-scoped).
+    #[cfg(feature = "masking")]
+    masking: Option<Arc<crate::masking::CompiledMasking>>,
+    #[cfg(feature = "quality")]
+    quality: Option<Arc<crate::quality::CompiledQuality>>,
+    #[cfg(feature = "contract")]
+    contract: Option<Arc<crate::contract::CompiledContract>>,
+    schema_drift: Option<crate::drift::SchemaDriftPolicy>,
+    resilience: Option<crate::resilience::ResiliencePolicy>,
 }
 
 async fn run_sink_node(
@@ -933,6 +1164,27 @@ async fn run_sink_node(
     }
     if let Some(cancel) = opts.cancel {
         run_opts = run_opts.with_cancel(cancel);
+    }
+    // Governance passes, in the same order `Pipeline` applies them: masking
+    // first (so nothing downstream — sink, DLQ, lineage sample — ever sees
+    // unmasked PII), then quality, contract, and drift.
+    #[cfg(feature = "masking")]
+    if let Some(m) = opts.masking {
+        run_opts = run_opts.with_masking(m);
+    }
+    #[cfg(feature = "quality")]
+    if let Some(q) = opts.quality {
+        run_opts = run_opts.with_quality(q);
+    }
+    #[cfg(feature = "contract")]
+    if let Some(c) = opts.contract {
+        run_opts = run_opts.with_contract(c);
+    }
+    if let Some(d) = opts.schema_drift {
+        run_opts.schema_drift = Some(d);
+    }
+    if let Some(r) = opts.resilience {
+        run_opts.resilience = Some(r);
     }
 
     let result = run_stream(pages, sink.as_ref(), run_opts).await?;
@@ -1131,6 +1383,22 @@ mod tests {
     impl Sink for FailingSink {
         async fn write_batch(&self, _records: &[Value]) -> Result<usize, FaucetError> {
             Err(FaucetError::Sink("sink boom".into()))
+        }
+    }
+
+    /// A sink that records whether `flush` was called — the observable proof that
+    /// a node was allowed to finish cooperatively rather than being dropped.
+    struct FlushTrackingSink {
+        flushed: Arc<Mutex<bool>>,
+    }
+    #[async_trait]
+    impl Sink for FlushTrackingSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            Ok(records.len())
+        }
+        async fn flush(&self) -> Result<(), FaucetError> {
+            *self.flushed.lock().unwrap() = true;
+            Ok(())
         }
     }
 
@@ -1500,10 +1768,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn state_min_bookmark_applied_to_source() {
+    async fn state_agreeing_bookmarks_resume_the_source() {
         let store = Arc::new(MemoryStateStore::new());
-        // Two sinks with diverged bookmarks; source must resume from min.
-        store.put("p::a", &json!(250)).await.unwrap();
+        // Both sinks committed the same page → that position is a safe resume.
+        store.put("p::a", &json!(100)).await.unwrap();
         store.put("p::b", &json!(100)).await.unwrap();
         let applied = Arc::new(Mutex::new(None));
         let src = RecordingSource {
@@ -1525,6 +1793,74 @@ mod tests {
         let opts = TopologyOptions::new("p").with_state_store(store.clone());
         topo.run(opts).await.unwrap();
         assert_eq!(*applied.lock().unwrap(), Some(json!(100)));
+    }
+
+    #[tokio::test]
+    async fn state_diverged_bookmarks_replay_in_full() {
+        // #456 H1: bookmarks are compared for equality, never ordered — an
+        // ordered "minimum" over structured positions can sit ahead of the true
+        // minimum and skip the lagging sink's records. Diverged → full replay.
+        let store = Arc::new(MemoryStateStore::new());
+        store.put("p::a", &json!(250)).await.unwrap();
+        store.put("p::b", &json!(100)).await.unwrap();
+        let applied = Arc::new(Mutex::new(None));
+        let src = RecordingSource {
+            records: recs(1),
+            applied: applied.clone(),
+        };
+        let (s1, _) = CollectSink::new();
+        let (s2, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", Box::new(src))
+            .tee("t", 4, Some(2))
+            .sink("a", Box::new(s1))
+            .sink("b", Box::new(s2))
+            .edge("s", "t")
+            .edge("t", "a")
+            .edge("t", "b")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        topo.run(opts).await.unwrap();
+        assert_eq!(
+            *applied.lock().unwrap(),
+            None,
+            "diverged bookmarks must replay, never guess an order"
+        );
+    }
+
+    #[tokio::test]
+    async fn state_multi_source_never_cross_applies_a_bookmark() {
+        // #456 H1: nothing records which source a sink's bookmark came from, so
+        // applying one to every source would resume a source somewhere it has
+        // never been. Multi-source graphs replay in full.
+        let store = Arc::new(MemoryStateStore::new());
+        store.put("p::k", &json!(500)).await.unwrap();
+        let a_applied = Arc::new(Mutex::new(None));
+        let b_applied = Arc::new(Mutex::new(None));
+        let a = RecordingSource {
+            records: recs(1),
+            applied: a_applied.clone(),
+        };
+        let b = RecordingSource {
+            records: recs(1),
+            applied: b_applied.clone(),
+        };
+        let (sink, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("a", Box::new(a))
+            .source("b", Box::new(b))
+            .merge("m")
+            .sink("k", Box::new(sink))
+            .edge("a", "m")
+            .edge("b", "m")
+            .edge("m", "k")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        topo.run(opts).await.unwrap();
+        assert_eq!(*a_applied.lock().unwrap(), None);
+        assert_eq!(*b_applied.lock().unwrap(), None);
     }
 
     #[tokio::test]
@@ -1570,6 +1906,75 @@ mod tests {
         assert_eq!(store.get("p::k").await.unwrap(), Some(json!("v9")));
     }
 
+    /// #456 M1: a node failure under `Propagate` must let its siblings stop at a
+    /// page boundary and **flush**, not drop them where they stand (which
+    /// orphans a multipart upload / writes a footer-less file).
+    #[tokio::test]
+    async fn propagate_lets_siblings_flush_before_returning_the_error() {
+        let flushed = Arc::new(Mutex::new(false));
+        let tracker = FlushTrackingSink {
+            flushed: flushed.clone(),
+        };
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(64)))
+            .tee("t", 4, Some(2))
+            .sink("bad", Box::new(FailingSink))
+            .sink("good", Box::new(tracker))
+            .edge("s", "t")
+            .edge("t", "bad")
+            .edge("t", "good")
+            .build()
+            .unwrap();
+        let opts = TopologyOptions::new("p")
+            .with_on_error(TopologyOnError::Propagate)
+            .with_stop_flush_grace(Duration::from_secs(5));
+        let err = topo.run(opts).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Sink(_)), "{err:?}");
+        assert!(
+            *flushed.lock().unwrap(),
+            "the healthy sink node must be flushed, not dropped mid-write"
+        );
+    }
+
+    /// #456 C3: the governance passes must apply to a topology's sink nodes, or a
+    /// config declaring masking writes PII in the clear.
+    #[cfg(feature = "masking")]
+    #[tokio::test]
+    async fn masking_applies_to_a_sink_node() {
+        use crate::masking::{CompiledMasking, MaskingSpec};
+
+        let spec: MaskingSpec = serde_json::from_value(json!({
+            "rules": [{
+                "name": "hide-email",
+                "match": { "fields": ["email"] },
+                "action": { "type": "redact", "mask": "***" }
+            }]
+        }))
+        .unwrap();
+        let compiled = Arc::new(CompiledMasking::compile(&spec).unwrap());
+
+        let (sink, store) = CollectSink::new();
+        let topo = Topology::builder()
+            .source(
+                "s",
+                VecSource::boxed(vec![json!({"id": 1, "email": "a@b.c"})]),
+            )
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+
+        let mut governance = TopologyGovernance::new();
+        governance.masking_by_sink.insert("k".to_string(), compiled);
+        let opts = TopologyOptions::new("p").with_governance(governance);
+        topo.run(opts).await.unwrap();
+
+        let written = store.lock().unwrap();
+        assert_eq!(written.len(), 1);
+        assert_eq!(written[0]["email"], json!("***"), "PII must be masked");
+        assert_eq!(written[0]["id"], json!(1));
+    }
+
     #[tokio::test]
     async fn cancellation_stops_the_run() {
         let cancel = CancellationToken::new();
@@ -1589,12 +1994,41 @@ mod tests {
     }
 
     #[test]
-    fn min_bookmark_picks_smallest() {
+    fn start_bookmark_only_resumes_when_provably_safe() {
+        // Every sink agrees, single source → resume there.
         assert_eq!(
-            min_bookmark(&[json!(250), json!(100), json!(300)]),
+            start_bookmark(&[json!(100), json!(100)], 1),
             Some(json!(100))
         );
-        assert_eq!(min_bookmark(&[]), None);
+        // Structured positions that agree are fine too — no ordering needed.
+        let lsn = json!({"slot": "s", "lsn": "0/16B3748"});
+        assert_eq!(
+            start_bookmark(&[lsn.clone(), lsn.clone()], 1),
+            Some(lsn.clone())
+        );
+
+        // Diverged scalars → replay. The old code returned `min` = 100 here;
+        // for the structured case below that "minimum" was text-ordered and
+        // could sit ahead of the true minimum (#456 H1).
+        assert_eq!(start_bookmark(&[json!(250), json!(100)], 1), None);
+        // The exact shape that made a text-ordered minimum unsafe: "0/9…" sorts
+        // above "0/10…" lexicographically while being *behind* it numerically.
+        assert_eq!(
+            start_bookmark(
+                &[
+                    json!({"lsn": "0/9FFFFFF"}),
+                    json!({"lsn": "0/10000000"}),
+                ],
+                1
+            ),
+            None
+        );
+
+        // More than one source → never cross-apply.
+        assert_eq!(start_bookmark(&[json!(100), json!(100)], 2), None);
+        // No sinks / no bookmarks → nothing to resume from.
+        assert_eq!(start_bookmark(&[], 1), None);
+        assert_eq!(start_bookmark(&[], 3), None);
     }
 
     #[test]

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -46,7 +46,8 @@
 //!   graphs therefore replay in full.
 //! - **Comparable, agreeing bookmarks only.** Sink bookmarks are compared for
 //!   equality, not ordered. Resume positions are frequently structured (CDC LSN
-//!   maps, Kafka offset maps), and [`json_gt`]'s object arm orders by *serialized
+//!   maps, Kafka offset maps), and [`json_gt`](crate::replication::json_gt)'s
+//!   object arm orders by *serialized
 //!   text*, which is not the replication order — so a "minimum" picked that way
 //!   can sit ahead of the true minimum and skip records. Divergent bookmarks
 //!   therefore replay in full rather than guess.

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -1935,6 +1935,16 @@ fn hash_fields(
                 let Some(current) = map.get(field) else {
                     continue;
                 };
+                // Null is left alone, matching `faucet_core::masking` (whose
+                // `hash`/`tokenize` actions skip null for the same reasons).
+                // Hashing it would (a) destroy nullability — a NOT NULL column
+                // silently accepts the digest and `IS NULL` stops matching
+                // downstream — and (b) give *every* null-valued row the same
+                // digest, so hashing a nullable field and keying an upsert or a
+                // join on it collapses all of those rows into one (#456 M3).
+                if current.is_null() {
+                    continue;
+                }
                 // String values hash over their raw UTF-8 bytes; every other
                 // JSON value hashes over its canonical serialization.
                 let input = match current {
@@ -4077,6 +4087,34 @@ mod tests {
             &compiled(&hash_spec(&["email"], HashEncoding::Hex, None)),
         );
         assert_eq!(out, json!({"id": 1}));
+    }
+
+    /// #456 M3: null must stay null. Hashing it destroys nullability *and* gives
+    /// every null-valued row the same digest — so hashing a nullable column and
+    /// keying an upsert/join on it would collapse all of those rows into one.
+    /// `faucet_core::masking` skips null for the same reason.
+    #[cfg(feature = "transform-hash")]
+    #[test]
+    fn hash_leaves_null_alone() {
+        let out = apply_all(
+            json!({"email": null, "other": "x"}),
+            &compiled(&hash_spec(&["email"], HashEncoding::Hex, None)),
+        );
+        assert_eq!(out["email"], Value::Null, "null must not be hashed");
+        assert_eq!(out["other"], json!("x"));
+
+        // Two distinct records with a null in the hashed field must not become
+        // indistinguishable.
+        let a = apply_all(
+            json!({"id": 1, "email": null}),
+            &compiled(&hash_spec(&["email"], HashEncoding::Hex, None)),
+        );
+        let b = apply_all(
+            json!({"id": 2, "email": null}),
+            &compiled(&hash_spec(&["email"], HashEncoding::Hex, None)),
+        );
+        assert_ne!(a, b);
+        assert!(a["email"].is_null() && b["email"].is_null());
     }
 
     #[cfg(feature = "transform-hash")]

--- a/crates/sink/duckdb/src/sink.rs
+++ b/crates/sink/duckdb/src/sink.rs
@@ -12,9 +12,31 @@ use duckdb::types::Value as DuckValue;
 use duckdb::{AccessMode, Config, Connection};
 use faucet_core::FaucetError;
 use faucet_core::util::quote_ident;
+
 use serde_json::Value;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+
+/// Quote a possibly schema-qualified table name, one segment at a time, so
+/// `analytics.events` becomes `"analytics"."events"` rather than the single
+/// identifier `"analytics.events"` (which names a table with a dot in it and can
+/// never resolve). Mirrors the ClickHouse sink's `quote_table` (#456 L3).
+fn quote_table(table: &str) -> String {
+    table
+        .split('.')
+        .map(quote_ident)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// The bare table name of a possibly schema-qualified target, plus its schema —
+/// `information_schema.columns` stores the two separately.
+fn split_table(table: &str) -> (Option<&str>, &str) {
+    match table.rsplit_once('.') {
+        Some((schema, name)) => (Some(schema), name),
+        None => (None, table),
+    }
+}
 
 /// A sink that writes JSON records to a DuckDB table.
 pub struct DuckdbSink {
@@ -69,7 +91,7 @@ fn insert_json(
     let placeholders = vec!["(?)"; records.len()].join(", ");
     let sql = format!(
         "INSERT INTO {} ({}) VALUES {}",
-        quote_ident(table),
+        quote_table(table),
         quote_ident(column),
         placeholders
     );
@@ -98,17 +120,37 @@ fn insert_auto_map(
     }
 
     // Discover the table's columns (in declared order) via information_schema.
-    let mut cstmt = conn
-        .prepare(
-            "SELECT column_name FROM information_schema.columns \
-             WHERE table_name = ? ORDER BY ordinal_position",
-        )
-        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?;
-    let cols: Vec<String> = cstmt
-        .query_map([table], |row| row.get::<_, String>(0))
-        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
-        .collect::<Result<Vec<String>, _>>()
-        .map_err(|e| FaucetError::Sink(format!("failed to decode table columns: {e}")))?;
+    // `table` may be schema-qualified, and information_schema keeps the schema and
+    // the name in separate columns — matching `table_name` against the whole
+    // dotted string would find nothing (#456 L3).
+    let (schema, name) = split_table(table);
+    let cols: Vec<String> = match schema {
+        Some(schema) => {
+            let mut cstmt = conn
+                .prepare(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position",
+                )
+                .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?;
+            cstmt
+                .query_map([schema, name], |row| row.get::<_, String>(0))
+                .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
+                .collect::<Result<Vec<String>, _>>()
+        }
+        None => {
+            let mut cstmt = conn
+                .prepare(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE table_name = ? ORDER BY ordinal_position",
+                )
+                .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?;
+            cstmt
+                .query_map([name], |row| row.get::<_, String>(0))
+                .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
+                .collect::<Result<Vec<String>, _>>()
+        }
+    }
+    .map_err(|e| FaucetError::Sink(format!("failed to decode table columns: {e}")))?;
 
     if cols.is_empty() {
         return Err(FaucetError::Sink(format!(
@@ -155,7 +197,7 @@ fn insert_auto_map(
     let values = vec![row_ph.as_str(); rows.len()].join(", ");
     let sql = format!(
         "INSERT INTO {} ({}) VALUES {}",
-        quote_ident(table),
+        quote_table(table),
         col_list,
         values
     );
@@ -262,7 +304,7 @@ impl DuckdbSink {
     #[doc(hidden)]
     pub async fn scalar_count(&self, table: &str) -> Result<i64, FaucetError> {
         let conn = self.conn.clone();
-        let sql = format!("SELECT count(*) FROM {}", quote_ident(table));
+        let sql = format!("SELECT count(*) FROM {}", quote_table(table));
         tokio::task::spawn_blocking(move || {
             let guard = conn
                 .lock()
@@ -333,7 +375,7 @@ mod tests {
         let guard = sink.conn.lock().unwrap();
         guard
             .query_row(
-                &format!("SELECT count(*) FROM {}", quote_ident(table)),
+                &format!("SELECT count(*) FROM {}", quote_table(table)),
                 [],
                 |r| r.get::<_, i64>(0),
             )
@@ -397,5 +439,33 @@ mod tests {
         .await
         .unwrap();
         assert!(sink.write_batch(&[json!({"a": 1})]).await.is_err());
+    }
+}
+
+#[cfg(test)]
+mod schema_qualified_tests {
+    use super::*;
+
+    /// #456 L3: a schema-qualified target must quote each segment, or it names a
+    /// table with a literal dot in it and can never resolve. The ClickHouse sink
+    /// already did this; DuckDB used a single `quote_ident`.
+    #[test]
+    fn quote_table_quotes_each_segment() {
+        assert_eq!(quote_table("events"), "\"events\"");
+        assert_eq!(quote_table("analytics.events"), "\"analytics\".\"events\"");
+    }
+
+    #[test]
+    fn split_table_separates_schema_from_name() {
+        assert_eq!(split_table("events"), (None, "events"));
+        assert_eq!(
+            split_table("analytics.events"),
+            (Some("analytics"), "events")
+        );
+        // Deepest qualifier wins (catalog.schema.table → schema is the prefix).
+        assert_eq!(
+            split_table("db.analytics.events"),
+            (Some("db.analytics"), "events")
+        );
     }
 }

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -13,6 +13,17 @@ use tiberius::ToSql;
 
 use faucet_common_mssql::{MssqlPool, MssqlPooledConnection, build_pool, quote_ident_mssql};
 
+/// Width of the watermark table's `scope` PRIMARY KEY column. SQL Server's index
+/// key budget is 900 bytes = 450 UTF-16 chars, so the column cannot be
+/// `NVARCHAR(MAX)`; a longer scope is shortened to a digest form rather than
+/// erroring or truncating onto another row's watermark (#456 L1).
+const SCOPE_COL_WIDTH: usize = 450;
+
+/// Fit a pipeline scope into [`SCOPE_COL_WIDTH`].
+fn scope_key(scope: &str) -> String {
+    faucet_core::idempotency::scope_key(scope, SCOPE_COL_WIDTH)
+}
+
 use crate::config::{MssqlColumnMapping, MssqlSinkConfig};
 use crate::encode::{
     BoundParam, auto_row_params, build_insert_sql, build_merge, build_merge_delete,
@@ -281,10 +292,11 @@ impl MssqlSink {
         // input in this string.
         let sql = format!(
             "IF OBJECT_ID(N'{tbl}', N'U') IS NULL \
-             CREATE TABLE [{tbl}] ([scope] NVARCHAR(450) PRIMARY KEY, \
+             CREATE TABLE [{tbl}] ([scope] NVARCHAR({w}) PRIMARY KEY, \
              [token] NVARCHAR(MAX) NOT NULL, \
              [updated_at] DATETIME2 DEFAULT SYSUTCDATETIME())",
             tbl = faucet_core::idempotency::COMMIT_TOKEN_TABLE,
+            w = SCOPE_COL_WIDTH,
         );
         control(conn, &sql).await
     }
@@ -839,7 +851,7 @@ impl Sink for MssqlSink {
     async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
         let mut conn = self.checkout().await?;
         self.ensure_commit_table(&mut conn).await?;
-        let scope_owned = scope.to_string();
+        let scope_owned = scope_key(scope);
         let rows = conn
             .query(
                 &format!(
@@ -942,7 +954,7 @@ impl Sink for MssqlSink {
              WHEN NOT MATCHED THEN INSERT ([scope], [token]) VALUES (s.[scope], s.[token]);",
             tbl = faucet_core::idempotency::COMMIT_TOKEN_TABLE,
         );
-        let (scope_owned, token_owned) = (scope.to_string(), token.to_string());
+        let (scope_owned, token_owned) = (scope_key(scope), token.to_string());
         let refs: Vec<&dyn ToSql> = vec![&scope_owned, &token_owned];
         if let Err(e) = conn.execute(merge.as_str(), &refs).await {
             let _ = control(&mut conn, "ROLLBACK TRAN").await;

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -7,6 +7,17 @@ use serde_json::Value;
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::{MySqlConnection, MySqlPool, Row};
 
+/// Width of the watermark table's `scope` PRIMARY KEY column. MySQL cannot index
+/// an unbounded column, so a scope longer than this is shortened to a digest
+/// form rather than risking silent truncation onto another row's watermark
+/// (#456 L1).
+const SCOPE_COL_WIDTH: usize = 255;
+
+/// Fit a pipeline scope into [`SCOPE_COL_WIDTH`].
+fn scope_key(scope: &str) -> String {
+    faucet_core::idempotency::scope_key(scope, SCOPE_COL_WIDTH)
+}
+
 /// A sink that writes JSON records to a MySQL table.
 pub struct MysqlSink {
     config: MysqlSinkConfig,
@@ -594,10 +605,11 @@ impl MysqlSink {
     /// and broke exactly-once delivery (audit #321 C3).
     async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
         let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {t} ({s} VARCHAR(255) PRIMARY KEY, {k} TEXT NOT NULL, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
+            "CREATE TABLE IF NOT EXISTS {t} ({s} VARCHAR({w}) PRIMARY KEY, {k} TEXT NOT NULL, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
             t = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
             s = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
             k = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+            w = SCOPE_COL_WIDTH,
         );
         sqlx::query(&sql)
             .execute(&self.pool)
@@ -874,7 +886,7 @@ impl faucet_core::Sink for MysqlSink {
             s = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
         );
         let row = sqlx::query(&sql)
-            .bind(scope)
+            .bind(scope_key(scope))
             .fetch_optional(&self.pool)
             .await
             .map_err(|e| FaucetError::Sink(format!("MySQL token read failed: {e}")))?;
@@ -946,7 +958,7 @@ impl faucet_core::Sink for MysqlSink {
             k = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
         );
         sqlx::query(&upsert)
-            .bind(scope)
+            .bind(scope_key(scope))
             .bind(token)
             .execute(&mut *tx)
             .await

--- a/crates/source/sqs/README.md
+++ b/crates/source/sqs/README.md
@@ -46,12 +46,20 @@ valid JSON, otherwise as a JSON **string** of the raw body:
 
 ## Delivery semantics
 
-Each page's receipt handles are deleted (via `DeleteMessageBatch`) right before
-the page is yielded. Delivery is **at-least-once**: any message whose delete
-does not land — or whose visibility window elapses before a downstream commit —
-is redelivered on a later run. There is no resumable bookmark (`bookmark: None`
-on every page); the queue itself is the cursor. Key downstream consumers on a
-message field (e.g. an upsert sink) when replays must converge.
+Each page's receipt handles are deleted (via `DeleteMessageBatch`) **after** the
+page has been written downstream — the deletes for a page are issued once the
+pipeline comes back for the next page, so nothing is removed from the queue
+before it has been persisted. Delivery is therefore **at-least-once**: a sink
+error, an abort, or a crash between the write and the delete leaves the messages
+in the queue, and they are redelivered once the visibility window elapses.
+
+There is no resumable bookmark (`bookmark: None` on every page); the queue itself
+is the cursor. Key downstream consumers on a message field (e.g. an upsert sink)
+when replays must converge.
+
+Set `visibility_timeout` on the queue comfortably above the time it takes to
+write one page, or a slow sink will let a message reappear while it is still
+in flight.
 
 ## LocalStack
 

--- a/crates/source/sqs/src/stream.rs
+++ b/crates/source/sqs/src/stream.rs
@@ -1,6 +1,21 @@
 //! The SQS `Source` implementation: long-poll `ReceiveMessage`, buffer to
-//! `batch_size`, delete each page's receipt handles right before yielding it,
-//! and terminate on `idle_timeout_secs` / `max_messages`.
+//! `batch_size`, delete each page's receipt handles **after** the page has been
+//! written downstream, and terminate on `idle_timeout_secs` / `max_messages`.
+//!
+//! ## Why deletion happens after the yield
+//!
+//! In an `async_stream` generator, statements before a `yield` run *before* the
+//! consumer sees the page; statements after it resume only once the consumer has
+//! come back for the next one — i.e. after the pipeline wrote the page to the
+//! sink and persisted it. Deleting on the near side of the `yield` would destroy
+//! the messages before anything durable had happened, so a sink error, an abort,
+//! or a crash would lose them permanently: at-most-once.
+//!
+//! So each page's receipt handles are parked in `pending` and deleted at the top
+//! of the following iteration (and once more after the final page resumes). A
+//! failure anywhere in between simply means the deletes never happen and SQS
+//! redelivers after the visibility timeout — at-least-once, as documented. This
+//! mirrors the Pub/Sub and NATS sources, which ack the same way (#456 C1).
 
 use crate::config::{MAX_RECEIVE_BATCH, SqsSourceConfig};
 use aws_sdk_sqs::Client;
@@ -120,10 +135,18 @@ impl faucet_core::Source for SqsSource {
             // redelivers it, preserving at-least-once).
             let mut buffer: Vec<Value> = Vec::new();
             let mut handles: Vec<Option<String>> = Vec::new();
+            // Receipt handles of pages already yielded but not yet deleted. Drained
+            // at the top of the next iteration — by then the consumer has resumed
+            // us, so the page is durable downstream (see the module docs).
+            let mut pending: Vec<String> = Vec::new();
             let mut total = 0usize;
             let mut last_activity = Instant::now();
 
             loop {
+                if !pending.is_empty() {
+                    self.delete_handles(&std::mem::take(&mut pending)).await?;
+                }
+
                 // Reached the message cap → stop.
                 let remaining = match max {
                     Some(m) if total >= m => break,
@@ -171,13 +194,15 @@ impl faucet_core::Source for SqsSource {
                     total += 1;
                 }
 
-                // Emit every full page, deleting its handles right before yield.
+                // Emit every full page. Its handles are parked, not deleted: the
+                // page is not durable until the consumer resumes us.
                 while buffer.len() >= chunk {
                     let page: Vec<Value> = buffer.drain(..chunk).collect();
                     let to_delete: Vec<String> =
                         handles.drain(..chunk).flatten().collect();
-                    self.delete_handles(&to_delete).await?;
                     yield StreamPage { records: page, bookmark: None };
+                    // Resumed ⇒ the page was written downstream; safe to delete.
+                    pending.extend(to_delete);
                 }
 
                 if let Some(m) = max
@@ -192,11 +217,18 @@ impl faucet_core::Source for SqsSource {
                 }
             }
 
-            // Flush whatever is left as a final (short) page.
+            // Flush whatever is left as a final (short) page, then delete the
+            // last two pages' handles: `pending` (yielded in the loop above) and
+            // this page's, which is durable once the consumer resumes us. If the
+            // consumer stops polling instead, nothing is deleted and SQS
+            // redelivers — the safe direction.
             if !buffer.is_empty() {
                 let to_delete: Vec<String> = handles.into_iter().flatten().collect();
-                self.delete_handles(&to_delete).await?;
                 yield StreamPage { records: buffer, bookmark: None };
+                pending.extend(to_delete);
+            }
+            if !pending.is_empty() {
+                self.delete_handles(&pending).await?;
             }
             tracing::info!(
                 queue = %self.config.queue_url,

--- a/crates/source/sqs/tests/conformance.rs
+++ b/crates/source/sqs/tests/conformance.rs
@@ -134,3 +134,94 @@ async fn conformance_bounded_memory() {
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
     // _container stays alive to here
 }
+
+// ── #456 C1: deletion must not precede the downstream write ─────────────────
+
+/// Create a queue whose messages become visible again immediately, so a
+/// non-deleted message can be observed without waiting out a visibility timeout.
+async fn create_queue_visible_immediately(client: &aws_sdk_sqs::Client, name: &str) -> String {
+    use aws_sdk_sqs::types::QueueAttributeName;
+    for _ in 0..120 {
+        match client
+            .create_queue()
+            .queue_name(name)
+            .attributes(QueueAttributeName::VisibilityTimeout, "0")
+            .send()
+            .await
+        {
+            Ok(out) => return out.queue_url().expect("queue url").to_string(),
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+        }
+    }
+    panic!("localstack sqs never became ready");
+}
+
+/// Count the distinct message bodies still retrievable from the queue.
+async fn count_remaining(client: &aws_sdk_sqs::Client, queue_url: &str) -> usize {
+    let mut seen = std::collections::HashSet::new();
+    // Several passes: SQS returns an arbitrary subset per call.
+    for _ in 0..10 {
+        let out = client
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .expect("receive_message");
+        for m in out.messages() {
+            if let Some(b) = m.body() {
+                seen.insert(b.to_string());
+            }
+        }
+    }
+    seen.len()
+}
+
+/// A page's messages must still be in the queue after the page has been yielded
+/// but before the consumer comes back for the next one — that is the window in
+/// which the sink write happens, and deleting inside it turns SQS's at-least-once
+/// contract into at-most-once (#456 C1).
+///
+/// The test abandons the stream after one page, which is what a sink error or a
+/// crash looks like from the source's point of view.
+#[tokio::test(flavor = "multi_thread")]
+async fn messages_survive_a_downstream_failure_after_the_page_is_yielded() {
+    use faucet_core::Source as _;
+    use futures::StreamExt;
+
+    let (_container, endpoint) = start_localstack().await;
+    let client = raw_client(&endpoint).await;
+    let queue_url = create_queue_visible_immediately(&client, "ack-ordering").await;
+    seed(&client, &queue_url, 4).await;
+
+    let mut cfg = SqsSourceConfig::new(&queue_url);
+    cfg.region = Some("us-east-1".into());
+    cfg.endpoint_url = Some(endpoint.clone());
+    cfg.credentials = test_credentials();
+    cfg.wait_time_seconds = 1;
+    cfg.idle_timeout_secs = Some(5);
+    cfg.batch_size = 2;
+
+    let source = SqsSource::new(cfg).await.expect("source");
+    {
+        let ctx = std::collections::HashMap::new();
+        let mut pages = source.stream_pages(&ctx, 2);
+        let first = pages
+            .next()
+            .await
+            .expect("one page")
+            .expect("page is not an error");
+        assert_eq!(first.records.len(), 2, "batch_size pages the queue");
+        // Abandon the stream: the consumer never resumed us, so nothing this page
+        // carried was ever written. Its messages must NOT have been deleted.
+        drop(pages);
+    }
+
+    assert_eq!(
+        count_remaining(&client, &queue_url).await,
+        4,
+        "no message may be deleted before the page it belongs to is written \
+         downstream — every one must still be redeliverable"
+    );
+}

--- a/crates/transform-wasm/src/instance.rs
+++ b/crates/transform-wasm/src/instance.rs
@@ -190,6 +190,13 @@ impl WasmInstance {
             return "wasm transform: module signalled an error (no error_ptr/error_len exports)"
                 .to_owned();
         };
+        // `error_ptr`/`error_len` are *guest* calls and so consume fuel. If the
+        // module errored with none left, both trap, we fall back to (0, 0), and the
+        // operator gets an empty message instead of the actual diagnosis — so name
+        // the real cause up front (#456 L5).
+        if let Some(msg) = out_of_fuel_message(self.store.get_fuel().ok(), self.fuel_limit) {
+            return msg;
+        }
         let ptr = ep.call(&mut self.store, ()).unwrap_or(0);
         let len = el.call(&mut self.store, ()).unwrap_or(0);
         let data = self.memory.data(&self.store);
@@ -229,4 +236,36 @@ fn trap_msg(ctx: &str, err: &wasmtime::Error) -> String {
     // WebAssembly", "out of bounds memory access", …) is preserved — the bare
     // `{}` display shows only the top-level backtrace line.
     format!("wasm transform: {ctx} failed: {err:?}")
+}
+
+/// The message to report when a module signalled an error with no fuel left.
+///
+/// Pure so the decision is testable: reproducing the state for real needs a
+/// module that returns the error sentinel at the exact instant its budget hits
+/// zero. `remaining` is `None` when fuel is not being metered (nothing to say).
+fn out_of_fuel_message(remaining: Option<u64>, limit: u64) -> Option<String> {
+    match remaining {
+        Some(0) => Some(format!(
+            "wasm transform: module signalled an error with no fuel left (budget {limit} units) — \
+             its error message could not be read back, because doing so calls into the module. \
+             Raise `fuel_per_record` or simplify the module"
+        )),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod fuel_message_tests {
+    use super::*;
+
+    #[test]
+    fn out_of_fuel_message_only_fires_when_the_budget_is_spent() {
+        let msg = out_of_fuel_message(Some(0), 10_000).expect("a message");
+        assert!(msg.contains("fuel"), "{msg}");
+        assert!(msg.contains("10000"), "names the budget: {msg}");
+
+        // Fuel left, or unmetered → let the normal error-export read proceed.
+        assert!(out_of_fuel_message(Some(1), 10_000).is_none());
+        assert!(out_of_fuel_message(None, 10_000).is_none());
+    }
 }

--- a/docs/book/src/cookbook/dlq.md
+++ b/docs/book/src/cookbook/dlq.md
@@ -46,7 +46,10 @@ record plus the metadata needed to inspect, fix, and replay it:
 }
 ```
 
-- `payload` — the original record, verbatim. This is what a replay re-feeds.
+- `payload` — the record **as it entered the write path**: after the transform
+  chain and after masking, since those passes run before the sink. This is what a
+  replay re-feeds, and it is why a replay does not re-run them (see
+  [Replaying](#replaying)).
 - `reason` — which stage quarantined the row: `quality`, `contract`,
   `schema_drift`, or `partial` / `dlq_all` for a sink-side row failure. This is
   the value the `--reason` filter matches.
@@ -113,8 +116,7 @@ summary.
 
 Once you've fixed the root cause — a transform, a contract, the destination
 schema — `faucet dlq replay` re-feeds the quarantined **payloads** through a
-pipeline config (transforms → quality → contract → sink), exactly as a normal
-run:
+pipeline config (quality → contract → sink):
 
 ```console
 $ faucet dlq replay orders.yaml --from ./dlq/contract_breaches.jsonl --dry-run
@@ -125,6 +127,15 @@ would be re-fed; 42 would reach the sink. Failures would go to
 $ faucet dlq replay orders.yaml --from ./dlq/contract_breaches.jsonl
 DLQ replay: 42 candidate record(s) re-fed; 42 written to the sink. …
 ```
+
+**A replay skips the transform chain and the masking pass**, because the payload
+already went through both before it was captured, and neither is idempotent:
+re-running the `hash` transform or masking's `hash`/`tokenize` action would
+produce `H(H(x))` — breaking the joinability masking exists to guarantee — a
+`set` stage would re-stamp `${now.*}` with the replay time, and `cast` /
+`json_parse` / `split` would re-run against already-converted values. The quality
+and contract passes *are* re-applied: they are pure checks over the record, so
+re-checking is idempotent, and a replay is exactly when you want them enforced.
 
 Rows that fail **again** on replay are quarantined to a *fresh* DLQ — a
 `replay-failed.jsonl` sibling of the source by default (override with

--- a/docs/book/src/cookbook/topology.md
+++ b/docs/book/src/cookbook/topology.md
@@ -106,12 +106,31 @@ remote API, and keep `max_build_records` as a guardrail.
 ## State and errors
 
 Each terminal sink owns a bookmark under `{name}::{node_id}`. On restart the
-source resumes from the **minimum** across every sink's stored bookmark (only
-when all sinks have one), so a lagging sink is never skipped — sinks whose
-bookmarks diverge must be idempotent.
+source resumes from a stored position only when **both** hold:
 
-`execution.on_error: stop` aborts the whole topology on the first failure;
-`continue` lets healthy branches finish and reports the failures at the end.
+1. the graph has exactly **one source node**, and
+2. **every** sink's stored bookmark is identical.
+
+Otherwise the source replays in full and logs why. That is deliberately
+conservative. A sink's bookmark records the position of whichever source fed its
+pages, and nothing in the graph records which one that was — so in a multi-source
+graph one source's position would be applied to another. And bookmarks are
+compared for *equality*, never ordered: a resume position is frequently structured
+(a CDC LSN map, a Kafka offset map), and ordering those falls back to comparing
+serialized text, which is unrelated to replication progress — an ordered "minimum"
+can sit *ahead* of the true minimum and skip the lagging sink's records.
+
+Replaying costs duplicates; skipping loses data. So when a graph is resumed
+routinely, make the sinks idempotent (`write_mode: upsert` with a `key`).
+
+`execution.on_error: stop` aborts the whole topology on the first failure —
+signalling the other nodes so they stop at a page boundary and **flush** (a
+buffered Parquet/S3 sink commits rather than orphaning its upload), then aborting
+anything still running after a grace window. `continue` lets healthy branches
+finish and reports the failures at the end.
+
+Each node runs as its own task, so a synchronous stage (the DuckDB `sql`
+transform, a `wasm` transform) does not stall the rest of the graph.
 
 ## Observability
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -322,6 +322,33 @@ with `matrix:` — both non-empty is a load-time error. `faucet run` / `validate
 [Topology mode](../cookbook/topology.md) for the full grammar, the `join:`
 node, state semantics, and runnable examples.
 
+**What applies in topology mode.** The per-page governance passes behave exactly
+as they do for a matrix pipeline — `pipeline.masking`, `pipeline.quality`,
+`pipeline.contract`, and `schema:` are enforced per sink node, and `resilience:`
+applies to sink-side writes. So do `--dry-run` / `--limit`, `${now.*}` /
+`--clock`, `state:`, and `dlq:`.
+
+Two things differ, and both are reported rather than silent:
+
+- **`delivery: exactly_once` is rejected.** A node graph has no per-sink
+  atomic commit-token path, so the config is refused at load time instead of
+  running at-least-once under an exactly-once label. Use the matrix form, or make
+  the sinks idempotent with `write_mode: upsert`.
+- **`notifications:`, `lineage:`, `catalog:`, and `sla:` are not applied.**
+  `faucet validate` prints a `WARNING:` line naming each one it finds, and the run
+  logs the same, so a declared-but-inert block is never silent.
+
+**Resume semantics are deliberately conservative.** Each sink node owns a
+bookmark under `{pipeline}::{node_id}`. The source resumes from a stored position
+only when the graph has **exactly one source node** and **every sink's bookmark is
+identical**; otherwise it replays in full (with a warning). Bookmarks are compared
+for equality, never ordered — a resume position is often structured (a CDC LSN
+map, a Kafka offset map), and an ordered "minimum" over those can sit *ahead* of
+the true minimum and skip the lagging sink's records. Replaying costs duplicates
+on a non-idempotent sink; skipping would lose data, so the trade is made in that
+direction. Use `write_mode: upsert` on the sinks when a graph is resumed
+routinely.
+
 ## Row selection
 
 Register many rows, run a few. Selection resolves **after** expansion and never


### PR DESCRIPTION
Fixes every actionable finding from the fourth hardening audit — 5 critical, 5 high, 5 medium, 4 low. One of the twenty (L2) turned out to be a **false positive in my own report**; it is corrected below and on the issue rather than "fixed".

Closes #456

---

## The two themes

**1. Topology mode was a second execution path that bypassed the governance layer.** `commands::run` returns from a dedicated topology branch *before* the executor, and `run_sink_node` wired only name/row/run_id/state/dlq/cancel into `run_stream`. So a graph pipeline silently skipped masking, quality, contracts, drift policy, `--dry-run`, `--limit`, `${now.*}`, the exactly-once gate, and more. The worst two: **a `--dry-run` performed real writes** (C2) and **a config declaring PII masking wrote PII in the clear** (C3).

Now: the four per-page passes plus `resilience:` are threaded through a new `TopologyGovernance` (masking keyed per sink node, since it is destination-scoped); preview modes wrap sinks and the state store exactly as the matrix path does; `${now.*}` resolves per node; `delivery: exactly_once` is **refused** rather than silently downgraded; and the blocks that genuinely don't apply yet (`notifications`/`lineage`/`catalog`/`sla`) are named in a `WARNING:` line by `faucet validate` and in the run log — never silent.

**2. The redaction boundary leaked outward.** `/mcp` handed a *viewer*-level token arbitrary server-side file reads (C4); a clustered template trigger persisted resolved secrets in plaintext, with the guard's own remediation text recommending the pattern that leaked (C5); and notifications shipped raw error text — which for `reqwest` embeds the request URL, API key and all — to Slack/PagerDuty/webhooks (H5).

---

## Fixes

| # | Fix | Verified by |
|---|---|---|
| **C1** | **SQS: delete receipt handles *after* the page is written.** `delete_handles` ran before `yield`, i.e. before the pipeline wrote a single record — so any sink error, abort, or crash lost the batch permanently. At-most-once, against a README promising at-least-once. Handles are now parked and deleted once the consumer resumes. Pub/Sub and NATS already did this; SQS was the outlier. | LocalStack test: abandon the stream after one page, assert all 4 messages are still redeliverable |
| **C2** | **Topology honours `--dry-run` / `--limit`** via `CountingSink`/`LimitedSink` + `ReadOnlyStateStore` | e2e: `--dry-run` creates no destination file |
| **C3** | **Topology enforces masking / quality / contract / drift** through `TopologyGovernance` | core test (sink node sees `***`) + e2e via the binary |
| **C4** | **`/mcp` gates `validate_config` + `preview` on `Doctor`** (operator+) — the scope `POST /v1/doctor` already needs — in both the advertised list and at call time. stdio keeps them (local user). | 4 tests: viewer can't see them, can't call them, no file content leaks, operator can |
| **C5** | **Clustered template triggers persist directive *tokens*, not resolved values.** New `Materialize::{Local,Persisted}`; `Persisted` defers `${env:}`/`${file:}`/`${secret:}` to `load_submission` on the executing instance. Guard text corrected. | test asserts the persisted body contains `${env:VAR}` and not the value, and that Local still resolves |
| **H1** | **Topology resumes only when provably safe**: exactly one source node *and* all sink bookmarks equal; else full replay + warning. Bookmarks are compared for equality, never ordered — `json_gt` orders objects by serialized *text*, so an ordered "minimum" can sit ahead of the true one and skip records. | pure `start_bookmark` test incl. the hex-LSN case, plus 3 integration tests |
| **H2** | **`delivery: exactly_once` refused in topology mode** | e2e test asserts the typed error |
| **H3** | **DLQ replay no longer re-applies transforms + masking.** The envelope payload is already transformed and masked; `hash`/`tokenize`/`set ${now.*}`/`cast` are not idempotent. Quality + contract are kept (pure predicates). | 2 tests: chain and masking cleared, quality retained |
| **H4** | **`${now.*}` resolves in topology mode**; a leftover `${backfill.*}` is rejected | e2e: `--clock` lands in the sink path, literal token never does |
| **H5** | **Notifications and DLQ envelopes are redacted.** `NotifyEvent::base`/`::with` scrub; `faucet-core` gains a first-wins `redact` hook (installed once in `run_main`) so `build_envelope`'s `error.message` is scrubbed too. No hook = identity, so library users are unaffected. | test with an API-key-in-URL error string; core hook contract test |
| **M1** | **Topology `on_error: stop` lets siblings flush.** `try_join_all` dropped node futures mid-write, orphaning multipart uploads / footer-less Parquet. Now cancels a shared token, waits out a grace window, then aborts. | test asserts the healthy sink node was flushed |
| **M2** | **Inert blocks are named**, in `validate` and at run start | e2e asserts the WARNING line |
| **M3** | **`hash` transform leaves `null` alone.** It hashed null to a constant digest — destroying nullability and giving every null-valued row the same key, so hashing a nullable column and keying an upsert/join on it collapsed those rows into one. Matches `masking`, which already skipped null. | test: null stays null; two null rows stay distinct |
| **M4** | **Caller-supplied `env` overrides refused on a clustered server**, like `secret: true` params | test asserts 422 and no value in the message |
| **M5** | **One `tokio` task per topology node**, so a synchronous stage (DuckDB `sql`, `wasm`) can't stall the graph. Panics now surface as a `JoinError` instead of unwinding the caller. | existing 33 topology tests + the new ones exercise the spawned path |
| **L1** | **Watermark scope fits its key column.** `scope` is the state key, and a child row's key comes from record data — unbounded — while MySQL stored it `VARCHAR(255)` and MSSQL `NVARCHAR(450)` PRIMARY KEY. New `idempotency::scope_key` returns short scopes verbatim (existing watermarks still resolve) and gives longer ones a readable head + FNV-1a digest. | 3 tests: passthrough, determinism, distinctness, char-boundary safety |
| **L3** | **DuckDB sink handles schema-qualified tables** (`quote_table` per segment + schema/name split in the `information_schema` probe), matching ClickHouse | 2 pure tests |
| **L4** | **Docker image ships the features it advertises** — `templates`/`mcp`/`lineage` and all three trigger watchers in the complete image; the lean path keeps only the cheap ones, with a comment | n/a (build config) |
| **L5** | **WASM: report fuel exhaustion** instead of an empty message when `error_ptr`/`error_len` trap for lack of fuel | pure helper test |

Plus one defect found while implementing: the MCP template tools advertised `"latest"` as the default version channel, but `latest` is deliberately **not** a channel and is rejected at parse time. Corrected to `stable` (with `newest` named for "highest version number").

---

## Correction to the audit: L2 was a false positive

I filed L2 claiming the `split` transform's empty delimiter produced `["", "a", "b", ""]` via `str::split("")`. **It does not.** `split_field` already special-cases it (`crates/core/src/transform.rs:2124-2128`) and returns a single optionally-trimmed element, with a comment saying exactly that and a test asserting it. I read the compile arm and inferred the apply behaviour instead of checking it.

I started a "fix", the pre-existing test caught it, and I reverted. Nothing in this PR changes `split`. The issue is annotated accordingly.

---

## Verification

- **`faucet-core`: 938 tests pass** (`quality,contract,masking,transforms,encryption`).
- **`faucet-cli`: 1138 pass**; 6 remaining failures are **feature-set artifacts of my local slice, not regressions** — `replication::compiled` (5) and `commands::conformance` (1) hardcode the `postgres` connector, which I excluded to avoid rebuilding bundled DuckDB. 4 earlier `commands::fmt` failures were the known `serde_json` `preserve_order` flip (enabled transitively by `bson`/`object_store`); adding `sink-mongodb` back made all 4 pass, confirming the cause. CI's full-feature run covers all of them.
- `cargo fmt --all` clean; clippy clean on the touched crates.
- Not run locally: `--all-features` (this machine cannot link it — arm64 `ld: B/BL out of range`, and bundled DuckDB alone is 8 GB of build output against limited disk) and the Docker-gated integration tests including the new SQS one. Both run in CI.

## Notes for review

- `TopologyOptions` and `SinkNodeOpts` gained fields; `TopologyOptions` has `Default` + builders, so `..Default::default()` construction is unaffected, but an exhaustive struct literal in a downstream crate would need updating.
- `run_topology` now takes `TopologyRunOptions`; `build_topology` keeps its signature and delegates to `build_topology_with`.
- `materialize` takes a `Materialize` mode. One behavioural edge of `Persisted`: a typed (`int`/`float`/`bool`) param whose `default` is itself a directive can't be coerced before resolution, so it fails loudly at trigger time naming the param. Documented in the function docs.
- C5's `Persisted` mode is the deliberate choice over threading a caller `env` overlay through the runner: it keeps credentials out of the shared DB without expanding `SubmitRequest`, and the caller-supplied half is refused outright (M4).
