### PR TITLE
fix: second-pass audit — wide-integer corruption in the Arrow/SQL shim and SQL binds, backfill DST windows (#460, #461, #462)

### DIFF
--- a/cli/src/backfill/orchestrator.rs
+++ b/cli/src/backfill/orchestrator.rs
@@ -40,7 +40,7 @@ pub enum BackfillRange {
     Time {
         from: DateTime<FixedOffset>,
         to: DateTime<FixedOffset>,
-        window: Option<Duration>,
+        window: Option<crate::backfill::plan::WindowStep>,
         tz: chrono_tz::Tz,
     },
     /// Explicit bookmark range (`--from-bookmark` / `--to-bookmark`): seed
@@ -65,7 +65,7 @@ impl BackfillRange {
                 from.to_rfc3339(),
                 to.to_rfc3339(),
                 window
-                    .map(|w| w.num_seconds().to_string())
+                    .map(|w| w.to_string())
                     .unwrap_or_else(|| "whole".into()),
             ),
             Self::Bookmark { from, to, .. } => format!(
@@ -685,7 +685,11 @@ pipeline:
     config: { path: ./out.jsonl }
 "#;
 
-    fn time_range(from: &str, to: &str, window: Option<chrono::Duration>) -> BackfillRange {
+    fn time_range(
+        from: &str,
+        to: &str,
+        window: Option<crate::backfill::plan::WindowStep>,
+    ) -> BackfillRange {
         let tz: chrono_tz::Tz = "UTC".parse().unwrap();
         BackfillRange::Time {
             from: crate::backfill::plan::parse_boundary(from, tz).unwrap(),
@@ -718,7 +722,7 @@ pipeline:
         let opts = base_opts(time_range(
             "2026-06-01",
             "2026-07-02",
-            Some(chrono::Duration::days(1)),
+            Some(crate::backfill::plan::WindowStep::Days(1)),
         ));
         let out = run_backfill(&cfg, opts).await.unwrap();
         assert!(out.dry_run);

--- a/cli/src/backfill/orchestrator.rs
+++ b/cli/src/backfill/orchestrator.rs
@@ -25,7 +25,7 @@ use crate::config::{ExecutionSpec, PipelineConfig};
 use crate::error::{CliError, CliResult};
 use crate::executor::{ExecuteOptions, run_expanded};
 use crate::expand::{ExpandedNode, expand};
-use chrono::{DateTime, Duration, FixedOffset};
+use chrono::{DateTime, FixedOffset};
 use faucet_core::{FaucetError, StateStore, Stream, StreamPage, json_gt};
 use serde::Serialize;
 use serde_json::Value;

--- a/cli/src/backfill/plan.rs
+++ b/cli/src/backfill/plan.rs
@@ -25,9 +25,59 @@ pub struct BackfillUnit {
     pub end: DateTime<FixedOffset>,
 }
 
+/// How a window advances the cursor.
+///
+/// The distinction matters only in a timezone that observes DST, and only for
+/// day/week windows: stepping a "day" by a fixed 24 hours drifts off local
+/// midnight after a transition, so the unit labelled `2026-03-08` would cover
+/// 00:00 → *next day* 01:00 (25 local hours) and every later unit would start an
+/// hour late. Sub-day windows have no such expectation — an hour is an hour — so
+/// they stay absolute (#461).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowStep {
+    /// A fixed elapsed duration (`s` / `m` / `h`, or a bare integer = seconds).
+    Absolute(Duration),
+    /// N calendar days in the backfill timezone.
+    Days(i64),
+    /// N calendar weeks in the backfill timezone.
+    Weeks(i64),
+}
+
+impl std::fmt::Display for WindowStep {
+    /// Stable form used in the range-hash descriptor that keys the progress
+    /// marker.
+    ///
+    /// An absolute window renders as its **seconds**, exactly as before this type
+    /// existed, so a backfill already in flight keeps its marker and resumes. A
+    /// calendar window renders as `Nd` / `Nw`, which deliberately hashes
+    /// differently: its unit boundaries are not the ones the old plan produced, so
+    /// resuming against a marker from that plan would mix two different unit sets.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Absolute(d) => write!(f, "{}", d.num_seconds()),
+            Self::Days(n) => write!(f, "{n}d"),
+            Self::Weeks(n) => write!(f, "{n}w"),
+        }
+    }
+}
+
+impl WindowStep {
+    /// The nominal duration, for logging and for the absolute fallback.
+    fn nominal(self) -> Duration {
+        match self {
+            Self::Absolute(d) => d,
+            Self::Days(n) => Duration::days(n),
+            Self::Weeks(n) => Duration::weeks(n),
+        }
+    }
+}
+
 /// Parse a `--window` duration: `45s`, `30m`, `6h`, `1d`, `1w` (or a bare
 /// integer = seconds). Must be positive.
-pub fn parse_window(s: &str) -> CliResult<Duration> {
+///
+/// `d` / `w` yield **calendar** steps; everything else is absolute. So `1d` and
+/// `24h` differ across a DST transition, deliberately.
+pub fn parse_window(s: &str) -> CliResult<WindowStep> {
     let s = s.trim();
     let err = || {
         CliError::Config(format!(
@@ -45,15 +95,38 @@ pub fn parse_window(s: &str) -> CliResult<Duration> {
             "window '{s}' must be a positive duration"
         )));
     }
-    let dur = match unit {
-        "s" => Duration::seconds(n),
-        "m" => Duration::minutes(n),
-        "h" => Duration::hours(n),
-        "d" => Duration::days(n),
-        "w" => Duration::weeks(n),
+    let step = match unit {
+        "s" => WindowStep::Absolute(Duration::seconds(n)),
+        "m" => WindowStep::Absolute(Duration::minutes(n)),
+        "h" => WindowStep::Absolute(Duration::hours(n)),
+        "d" => WindowStep::Days(n),
+        "w" => WindowStep::Weeks(n),
         _ => return Err(err()),
     };
-    Ok(dur)
+    Ok(step)
+}
+
+/// Advance `cursor` by a calendar amount in `tz`, keeping the local wall-clock
+/// time (so a day stays a day and midnight stays midnight across a DST change).
+///
+/// The naive local time is advanced first — naive arithmetic has no DST, so this
+/// *is* calendar arithmetic — then re-resolved in `tz`. A spring-forward gap
+/// (the wall-clock time does not exist that day) has no valid instant, so the
+/// time is nudged forward an hour at a time until it does; a fall-back
+/// (ambiguous, repeated) hour resolves to the **earliest** instant, matching
+/// [`parse_boundary`].
+fn advance_calendar(cursor: DateTime<Utc>, tz: chrono_tz::Tz, days: i64) -> Option<DateTime<Utc>> {
+    let naive = cursor
+        .with_timezone(&tz)
+        .naive_local()
+        .checked_add_signed(Duration::days(days))?;
+    for extra_hours in 0..=3 {
+        let candidate = naive.checked_add_signed(Duration::hours(extra_hours))?;
+        if let Some(local) = tz.from_local_datetime(&candidate).earliest() {
+            return Some(local.with_timezone(&Utc));
+        }
+    }
+    None
 }
 
 /// Parse a `--from` / `--to` boundary: RFC3339 (`2026-06-01T00:00:00Z`) or a
@@ -88,7 +161,7 @@ pub fn parse_boundary(s: &str, tz: chrono_tz::Tz) -> CliResult<DateTime<FixedOff
 pub fn plan_windows(
     from: DateTime<FixedOffset>,
     to: DateTime<FixedOffset>,
-    window: Option<Duration>,
+    window: Option<WindowStep>,
     tz: chrono_tz::Tz,
 ) -> CliResult<Vec<BackfillUnit>> {
     if from >= to {
@@ -99,7 +172,7 @@ pub fn plan_windows(
     let mut units = Vec::new();
     let mut cursor = from.with_timezone(&Utc);
     let end = to.with_timezone(&Utc);
-    let step = window.unwrap_or_else(|| end - cursor);
+    let step = window.unwrap_or(WindowStep::Absolute(end - cursor));
     while cursor < end {
         if units.len() >= MAX_UNITS {
             return Err(CliError::Config(format!(
@@ -107,7 +180,25 @@ pub fn plan_windows(
                  use a larger window"
             )));
         }
-        let unit_end = (cursor + step).min(end);
+        // Calendar steps keep the local wall clock; absolute steps add elapsed
+        // time. Either way the next boundary must be strictly ahead of the
+        // cursor, or the loop could not terminate — fall back to the nominal
+        // duration if a zone quirk ever produced a non-advancing instant.
+        let next = match step {
+            WindowStep::Absolute(d) => cursor + d,
+            WindowStep::Days(n) => {
+                advance_calendar(cursor, tz, n).unwrap_or(cursor + step.nominal())
+            }
+            WindowStep::Weeks(n) => {
+                advance_calendar(cursor, tz, n * 7).unwrap_or(cursor + step.nominal())
+            }
+        };
+        let next = if next > cursor {
+            next
+        } else {
+            cursor + step.nominal()
+        };
+        let unit_end = next.min(end);
         units.push(BackfillUnit {
             id: cursor.format("%Y%m%dT%H%M%SZ").to_string(),
             start: cursor.with_timezone(&tz).fixed_offset(),
@@ -188,6 +279,7 @@ pub fn range_hash(descriptor: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Timelike;
     use serde_json::json;
 
     fn tz(name: &str) -> chrono_tz::Tz {
@@ -196,12 +288,26 @@ mod tests {
 
     #[test]
     fn window_durations_parse() {
-        assert_eq!(parse_window("45s").unwrap(), Duration::seconds(45));
-        assert_eq!(parse_window("30m").unwrap(), Duration::minutes(30));
-        assert_eq!(parse_window("6h").unwrap(), Duration::hours(6));
-        assert_eq!(parse_window("1d").unwrap(), Duration::days(1));
-        assert_eq!(parse_window("2w").unwrap(), Duration::weeks(2));
-        assert_eq!(parse_window("3600").unwrap(), Duration::seconds(3600));
+        // Sub-day units are absolute elapsed time…
+        assert_eq!(
+            parse_window("45s").unwrap(),
+            WindowStep::Absolute(Duration::seconds(45))
+        );
+        assert_eq!(
+            parse_window("30m").unwrap(),
+            WindowStep::Absolute(Duration::minutes(30))
+        );
+        assert_eq!(
+            parse_window("6h").unwrap(),
+            WindowStep::Absolute(Duration::hours(6))
+        );
+        assert_eq!(
+            parse_window("3600").unwrap(),
+            WindowStep::Absolute(Duration::seconds(3600))
+        );
+        // …while day/week units are calendar steps (#461).
+        assert_eq!(parse_window("1d").unwrap(), WindowStep::Days(1));
+        assert_eq!(parse_window("2w").unwrap(), WindowStep::Weeks(2));
         assert!(parse_window("0d").is_err());
         assert!(parse_window("-1h").is_err());
         assert!(parse_window("soon").is_err());
@@ -227,7 +333,7 @@ mod tests {
         let utc = tz("UTC");
         let from = parse_boundary("2026-06-01", utc).unwrap();
         let to = parse_boundary("2026-07-02", utc).unwrap();
-        let units = plan_windows(from, to, Some(Duration::days(1)), utc).unwrap();
+        let units = plan_windows(from, to, Some(WindowStep::Days(1)), utc).unwrap();
         assert_eq!(units.len(), 31);
         assert_eq!(units[0].id, "20260601T000000Z");
         assert_eq!(units[0].start.to_rfc3339(), "2026-06-01T00:00:00+00:00");
@@ -244,7 +350,13 @@ mod tests {
         let utc = tz("UTC");
         let from = parse_boundary("2026-06-01T00:00:00Z", utc).unwrap();
         let to = parse_boundary("2026-06-01T05:30:00Z", utc).unwrap();
-        let units = plan_windows(from, to, Some(Duration::hours(2)), utc).unwrap();
+        let units = plan_windows(
+            from,
+            to,
+            Some(WindowStep::Absolute(Duration::hours(2))),
+            utc,
+        )
+        .unwrap();
         assert_eq!(units.len(), 3);
         assert_eq!(units[2].start.to_rfc3339(), "2026-06-01T04:00:00+00:00");
         assert_eq!(units[2].end.to_rfc3339(), "2026-06-01T05:30:00+00:00");
@@ -261,6 +373,94 @@ mod tests {
         assert_eq!(units[0].end, to);
     }
 
+    /// #461: a calendar day must stay a calendar day. Absolute 24h stepping used
+    /// to drift off local midnight after a DST change — the unit labelled
+    /// 2026-03-08 covered 00:00 → *next day* 01:00 (25 local hours) and every
+    /// later unit started an hour late, so `${backfill.start_date}` no longer
+    /// described the window it named.
+    #[test]
+    fn calendar_day_windows_stay_on_local_midnight_across_dst() {
+        let ny = tz("America/New_York");
+        let from = parse_boundary("2026-03-07", ny).unwrap();
+        let to = parse_boundary("2026-03-11", ny).unwrap();
+        let units = plan_windows(from, to, Some(WindowStep::Days(1)), ny).unwrap();
+
+        assert_eq!(units.len(), 4, "four calendar days");
+        for u in &units {
+            assert_eq!(
+                (u.start.hour(), u.start.minute()),
+                (0, 0),
+                "unit {} must start at local midnight, got {}",
+                u.id,
+                u.start
+            );
+        }
+        // Contiguous, and each unit's label matches the day it covers.
+        for w in units.windows(2) {
+            assert_eq!(w[0].end, w[1].start, "no gap/overlap");
+        }
+        let dates: Vec<String> = units
+            .iter()
+            .map(|u| u.start.format("%Y-%m-%d").to_string())
+            .collect();
+        assert_eq!(
+            dates,
+            ["2026-03-07", "2026-03-08", "2026-03-09", "2026-03-10"]
+        );
+        // The spring-forward day is genuinely 23 hours of elapsed time.
+        let spring_forward = &units[1];
+        assert_eq!(
+            (spring_forward.end - spring_forward.start).num_hours(),
+            23,
+            "2026-03-08 loses an hour"
+        );
+    }
+
+    /// Fall-back (an hour repeats) must also stay on midnight, at 25 elapsed hours.
+    #[test]
+    fn calendar_day_windows_handle_fall_back() {
+        let ny = tz("America/New_York");
+        let from = parse_boundary("2026-10-31", ny).unwrap();
+        let to = parse_boundary("2026-11-03", ny).unwrap();
+        let units = plan_windows(from, to, Some(WindowStep::Days(1)), ny).unwrap();
+        for u in &units {
+            assert_eq!((u.start.hour(), u.start.minute()), (0, 0), "{}", u.id);
+        }
+        // 2026-11-01 is the fall-back day: 25 hours.
+        let long_day = units
+            .iter()
+            .find(|u| u.start.format("%Y-%m-%d").to_string() == "2026-11-01")
+            .expect("the fall-back day is planned");
+        assert_eq!((long_day.end - long_day.start).num_hours(), 25);
+    }
+
+    /// `1d` and `24h` are deliberately different across a transition: one is a
+    /// calendar day, the other is elapsed time.
+    #[test]
+    fn calendar_and_absolute_windows_differ_across_dst() {
+        let ny = tz("America/New_York");
+        let from = parse_boundary("2026-03-07", ny).unwrap();
+        let to = parse_boundary("2026-03-10", ny).unwrap();
+        let cal = plan_windows(from, to, Some(parse_window("1d").unwrap()), ny).unwrap();
+        let abs = plan_windows(from, to, Some(parse_window("24h").unwrap()), ny).unwrap();
+        assert_eq!(cal[2].start.hour(), 0, "calendar stays on midnight");
+        assert_eq!(abs[2].start.hour(), 1, "absolute drifts by the DST delta");
+        assert_ne!(cal[2].start, abs[2].start);
+    }
+
+    /// The descriptor an absolute window contributes to the range hash is
+    /// unchanged, so a backfill already in flight keeps resuming.
+    #[test]
+    fn window_descriptor_is_stable_for_absolute_and_distinct_for_calendar() {
+        assert_eq!(
+            WindowStep::Absolute(Duration::hours(6)).to_string(),
+            "21600"
+        );
+        assert_eq!(WindowStep::Absolute(Duration::days(1)).to_string(), "86400");
+        assert_eq!(WindowStep::Days(1).to_string(), "1d");
+        assert_eq!(WindowStep::Weeks(2).to_string(), "2w");
+    }
+
     #[test]
     fn dst_transition_produces_no_gap_or_overlap() {
         // US spring-forward 2026: March 8, 02:00 EST → 03:00 EDT. Absolute
@@ -268,7 +468,8 @@ mod tests {
         let ny = tz("America/New_York");
         let from = parse_boundary("2026-03-07", ny).unwrap();
         let to = parse_boundary("2026-03-10T00:00:00-04:00", ny).unwrap();
-        let units = plan_windows(from, to, Some(Duration::days(1)), ny).unwrap();
+        let units =
+            plan_windows(from, to, Some(WindowStep::Absolute(Duration::days(1))), ny).unwrap();
         for w in units.windows(2) {
             assert_eq!(w[0].end, w[1].start, "no gap/overlap across DST");
         }
@@ -286,7 +487,13 @@ mod tests {
 
         let from = parse_boundary("2020-01-01", utc).unwrap();
         let to = parse_boundary("2026-01-01", utc).unwrap();
-        let err = plan_windows(from, to, Some(Duration::minutes(1)), utc).unwrap_err();
+        let err = plan_windows(
+            from,
+            to,
+            Some(WindowStep::Absolute(Duration::minutes(1))),
+            utc,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("larger window"), "{err}");
     }
 

--- a/cli/src/backfill/state.rs
+++ b/cli/src/backfill/state.rs
@@ -116,7 +116,13 @@ mod tests {
         let utc: chrono_tz::Tz = "UTC".parse().unwrap();
         let from = parse_boundary("2026-06-01", utc).unwrap();
         let to = parse_boundary(&format!("2026-06-{:02}", n + 1), utc).unwrap();
-        plan_windows(from, to, Some(chrono::Duration::days(1)), utc).unwrap()
+        plan_windows(
+            from,
+            to,
+            Some(crate::backfill::plan::WindowStep::Days(1)),
+            utc,
+        )
+        .unwrap()
     }
 
     #[test]

--- a/cli/src/commands/backfill.rs
+++ b/cli/src/commands/backfill.rs
@@ -95,7 +95,7 @@ fn build_range(
     from_bookmark: &Option<String>,
     to_bookmark: &Option<String>,
     bookmark_field: Option<String>,
-    window: Option<chrono::Duration>,
+    window: Option<crate::backfill::plan::WindowStep>,
     tz: chrono_tz::Tz,
 ) -> CliResult<BackfillRange> {
     match (from, to, from_bookmark) {

--- a/cli/src/serve/handlers/backfill.rs
+++ b/cli/src/serve/handlers/backfill.rs
@@ -145,7 +145,7 @@ pub async fn submit_backfill(
         from.to_rfc3339(),
         to.to_rfc3339(),
         window
-            .map(|w| w.num_seconds().to_string())
+            .map(|w| w.to_string())
             .unwrap_or_else(|| "whole".into()),
     );
     let hash = range_hash(&descriptor);

--- a/cli/tests/backfill_end_to_end.rs
+++ b/cli/tests/backfill_end_to_end.rs
@@ -20,7 +20,10 @@ fn time_range(from: &str, to: &str, window_days: i64) -> BackfillRange {
     BackfillRange::Time {
         from: faucet_cli::backfill::plan::parse_boundary(from, utc()).unwrap(),
         to: faucet_cli::backfill::plan::parse_boundary(to, utc()).unwrap(),
-        window: Some(chrono::Duration::days(window_days)),
+        // `Days` (calendar) rather than an absolute 24h step — these ranges are
+        // UTC, where the two coincide, but the calendar form is what `--window 1d`
+        // now parses to (#461).
+        window: Some(faucet_cli::backfill::plan::WindowStep::Days(window_days)),
         tz: utc(),
     }
 }

--- a/crates/core/src/columnar.rs
+++ b/crates/core/src/columnar.rs
@@ -64,7 +64,107 @@ pub fn infer_arrow_schema(records: &[Value]) -> Result<SchemaRef, FaucetError> {
         .map(|v| Ok::<_, arrow::error::ArrowError>(v.clone()));
     let schema = arrow_json::reader::infer_json_schema_from_iterator(iter)
         .map_err(|e| te("schema inference", e))?;
-    Ok(Arc::new(schema))
+    refine_wide_integers(&schema, records).map(Arc::new)
+}
+
+/// Re-type fields that `arrow-json` widened to `Float64` purely because an
+/// integer did not fit `i64`, and refuse the cases that cannot be re-typed.
+///
+/// `arrow-json` infers `Float64` for any integer outside `i64` range, so a `u64`
+/// id such as `18446744073709551615` silently becomes `1.8446744073709552e19` —
+/// exact value gone, `Ok` returned (#460). Where every observed value for such a
+/// field is a non-negative integer, `UInt64` holds it exactly, so use that.
+/// Where no integer type fits (values spanning negative *and* above `i64::MAX`)
+/// or the value sits somewhere this pass does not re-type (inside a list), fail
+/// with a typed error naming the path rather than approximating it.
+///
+/// Fields arrow-json typed `Float64` because a value genuinely *is* fractional
+/// are left alone, as is a field mixing integers and floats — coercing those to
+/// `Float64` is ordinary JSON-number behaviour, not loss of an exact integer.
+fn refine_wide_integers(schema: &Schema, records: &[Value]) -> Result<Schema, FaucetError> {
+    use arrow::datatypes::{DataType, Field};
+
+    /// Values observed at one field across the page (nulls skipped).
+    fn observed<'a>(records: &'a [Value], name: &str) -> Vec<&'a Value> {
+        records
+            .iter()
+            .filter_map(|r| r.get(name))
+            .filter(|v| !v.is_null())
+            .collect()
+    }
+
+    /// Does this number need more than `i64` *and* is it an exact integer?
+    fn is_wide_integer(v: &Value) -> bool {
+        matches!(v, Value::Number(n) if !n.is_i64() && n.is_u64())
+    }
+
+    fn refine_field(field: &Field, values: Vec<&Value>) -> Result<Field, FaucetError> {
+        match field.data_type() {
+            DataType::Float64 if values.iter().any(|v| is_wide_integer(v)) => {
+                // Every value integral and non-negative → UInt64 is exact.
+                if values
+                    .iter()
+                    .all(|v| matches!(v, Value::Number(n) if n.is_u64()))
+                {
+                    Ok(field.clone().with_data_type(DataType::UInt64))
+                } else {
+                    Err(FaucetError::Transform(format!(
+                        "columnar shim: field {:?} mixes an integer above i64::MAX with values \
+                         no unsigned type can hold, so no exact Arrow type fits. Convert it to a \
+                         string first (a `cast` transform) — it is not silently widened to a \
+                         float because that loses the exact value",
+                        field.name()
+                    )))
+                }
+            }
+            DataType::Struct(children) => {
+                let refined = children
+                    .iter()
+                    .map(|child| {
+                        let child_values = values
+                            .iter()
+                            .filter_map(|v| v.get(child.name()))
+                            .filter(|v| !v.is_null())
+                            .collect();
+                        refine_field(child, child_values).map(Arc::new)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(field
+                    .clone()
+                    .with_data_type(DataType::Struct(refined.into())))
+            }
+            // A wide integer inside a list is not re-typed by this pass; refusing
+            // beats writing an approximation nobody asked for.
+            _ if contains_wide_integer_in_container(&values) => {
+                Err(FaucetError::Transform(format!(
+                    "columnar shim: field {:?} contains an integer above i64::MAX inside a list, \
+                     which the columnar path cannot represent exactly. Convert those elements to \
+                     strings first (a `cast` transform)",
+                    field.name()
+                )))
+            }
+            _ => Ok(field.clone()),
+        }
+    }
+
+    /// Any wide integer nested inside an array (at any depth).
+    fn contains_wide_integer_in_container(values: &[&Value]) -> bool {
+        fn walk(v: &Value, in_list: bool) -> bool {
+            match v {
+                Value::Array(items) => items.iter().any(|i| walk(i, true)),
+                Value::Object(map) => map.values().any(|i| walk(i, in_list)),
+                other => in_list && is_wide_integer(other),
+            }
+        }
+        values.iter().any(|v| walk(v, false))
+    }
+
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|f| refine_field(f, observed(records, f.name())).map(Arc::new))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Schema::new(fields).with_metadata(schema.metadata().clone()))
 }
 
 /// Encode a slice of JSON records into a single [`RecordBatch`] against `schema`.
@@ -155,5 +255,91 @@ mod tests {
         let page = ColumnarPage::new(batch, Some(json!({"lsn": 42})));
         assert_eq!(page.num_rows(), 2);
         assert_eq!(page.bookmark, Some(json!({"lsn": 42})));
+    }
+}
+
+#[cfg(test)]
+mod wide_integer_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// #460: arrow-json types an integer above `i64::MAX` as `Float64`, so
+    /// `18446744073709551615` used to come back as `1.8446744073709552e19` with
+    /// `Ok`. It must now round-trip exactly.
+    #[test]
+    fn u64_above_i64_max_round_trips_exactly() {
+        let recs = vec![json!({"id": u64::MAX})];
+        let back =
+            record_batch_to_values(&values_to_record_batch_inferred(&recs).unwrap()).unwrap();
+        assert_eq!(back[0]["id"], json!(u64::MAX), "exact value must survive");
+        assert!(back[0]["id"].is_u64(), "and stay an integer, not a float");
+    }
+
+    #[test]
+    fn mixed_small_and_wide_integers_all_survive() {
+        let recs = vec![
+            json!({"id": 1}),
+            json!({"id": u64::MAX}),
+            json!({"id": null}),
+        ];
+        let back =
+            record_batch_to_values(&values_to_record_batch_inferred(&recs).unwrap()).unwrap();
+        assert_eq!(back[0]["id"], json!(1));
+        assert_eq!(back[1]["id"], json!(u64::MAX));
+        assert_eq!(back[2]["id"], json!(null));
+    }
+
+    #[test]
+    fn wide_integer_nested_in_a_struct_survives() {
+        let recs = vec![json!({"outer": {"id": u64::MAX, "n": 3}})];
+        let back =
+            record_batch_to_values(&values_to_record_batch_inferred(&recs).unwrap()).unwrap();
+        assert_eq!(back[0]["outer"]["id"], json!(u64::MAX));
+        assert_eq!(back[0]["outer"]["n"], json!(3));
+    }
+
+    /// Genuine floats, and integer/float mixes, keep their existing behaviour —
+    /// coercing those to Float64 is ordinary JSON-number semantics, not loss of
+    /// an exact integer.
+    #[test]
+    fn genuine_floats_are_untouched() {
+        let recs = vec![json!({"a": 1.5}), json!({"a": 2})];
+        let back =
+            record_batch_to_values(&values_to_record_batch_inferred(&recs).unwrap()).unwrap();
+        assert_eq!(back[0]["a"], json!(1.5));
+        assert_eq!(back[1]["a"], json!(2.0));
+
+        // i64 range is unaffected (2^53+1 already round-tripped before).
+        let recs = vec![json!({"n": 9007199254740993i64, "m": i64::MIN})];
+        let back =
+            record_batch_to_values(&values_to_record_batch_inferred(&recs).unwrap()).unwrap();
+        assert_eq!(back[0]["n"], json!(9007199254740993i64));
+        assert_eq!(back[0]["m"], json!(i64::MIN));
+    }
+
+    /// No exact type fits a field spanning negatives and above-i64::MAX, so it
+    /// must fail loudly rather than approximate.
+    #[test]
+    fn unrepresentable_mix_is_refused() {
+        let recs = vec![json!({"v": -1}), json!({"v": u64::MAX})];
+        let err = match values_to_record_batch_inferred(&recs) {
+            Err(e) => e.to_string(),
+            Ok(b) => panic!("must refuse; got {:?}", record_batch_to_values(&b).unwrap()),
+        };
+        assert!(err.contains("\"v\""), "{err}");
+        assert!(err.contains("cast"), "points at the workaround: {err}");
+    }
+
+    /// A wide integer inside a list is not re-typed by this pass, so it is
+    /// refused rather than silently written as a float.
+    #[test]
+    fn wide_integer_inside_a_list_is_refused() {
+        let recs = vec![json!({"ids": [1, u64::MAX]})];
+        let err = match values_to_record_batch_inferred(&recs) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("must refuse a wide integer inside a list"),
+        };
+        assert!(err.contains("\"ids\""), "{err}");
+        assert!(err.contains("list"), "{err}");
     }
 }

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -834,3 +834,63 @@ mod tests {
         );
     }
 }
+
+/// Narrow a JSON `u64` to the `i64` a **signed** 64-bit column can hold, or fail.
+///
+/// A `serde_json::Number` that reports `is_u64()` but not `is_i64()` is above
+/// `i64::MAX`. Casting it with `as i64` *wraps* — `9223372036854775808u64`
+/// becomes `-9223372036854775808` — so a large unsigned id would be written, or
+/// compared against, as a large negative number with nothing raised. Two ways
+/// that bites: a sink silently corrupts the value, and a source binding an
+/// incremental-replication bookmark compares against a negative bound, so rows
+/// are re-read or skipped (#462).
+///
+/// Backends with a native unsigned type (MySQL's `UNSIGNED BIGINT`) must **not**
+/// use this — they bind the `u64` directly and round-trip losslessly.
+///
+/// `context` names what is being bound (a column, or `parameter N`) so the error
+/// tells an operator where to look.
+pub fn u64_to_signed(value: u64, context: &str) -> Result<i64, crate::FaucetError> {
+    i64::try_from(value).map_err(|_| {
+        crate::FaucetError::Config(format!(
+            "{context}: {value} exceeds the maximum a signed 64-bit column can hold \
+             ({}). This backend has no unsigned integer type — store the value in a \
+             NUMERIC/TEXT column, or convert it with a `cast` transform. It is not \
+             silently truncated because the wrapped value would be negative",
+            i64::MAX
+        ))
+    })
+}
+
+#[cfg(test)]
+mod u64_to_signed_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_everything_a_signed_column_can_hold() {
+        assert_eq!(u64_to_signed(0, "c").unwrap(), 0);
+        assert_eq!(u64_to_signed(42, "c").unwrap(), 42);
+        assert_eq!(
+            u64_to_signed(i64::MAX as u64, "c").unwrap(),
+            i64::MAX,
+            "the boundary itself fits"
+        );
+    }
+
+    #[test]
+    fn rejects_above_the_boundary_instead_of_wrapping() {
+        // The exact value that `as i64` would turn into i64::MIN.
+        let just_over = i64::MAX as u64 + 1;
+        let err = match u64_to_signed(just_over, "column \"id\"") {
+            Err(e) => e,
+            Ok(v) => panic!("must not accept {just_over} (as i64 would be {})", v),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("column \"id\""), "{msg}");
+        assert!(msg.contains(&just_over.to_string()), "{msg}");
+        // The wrapped form must never appear as if it were the value.
+        assert!(!msg.contains("-9223372036854775808"), "{msg}");
+
+        assert!(u64_to_signed(u64::MAX, "c").is_err());
+    }
+}

--- a/crates/sink/redshift/src/sink.rs
+++ b/crates/sink/redshift/src/sink.rs
@@ -192,7 +192,7 @@ impl RedshiftSink {
                     FaucetError::Sink("redshift: insert requires JSON object records".into())
                 })?;
                 for col in &present {
-                    q = bind_json(q, obj.get(col));
+                    q = bind_json(q, obj.get(col), col)?;
                 }
             }
             q.execute(&self.pool)
@@ -210,8 +210,9 @@ impl RedshiftSink {
 fn bind_json<'q>(
     query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
     v: Option<&Value>,
-) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-    match v {
+    column: &str,
+) -> Result<sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>, FaucetError> {
+    Ok(match v {
         None | Some(Value::Null) => query.bind(None::<String>),
         Some(Value::String(s)) => query.bind(s.clone()),
         Some(Value::Bool(b)) => query.bind(*b),
@@ -219,13 +220,19 @@ fn bind_json<'q>(
             if n.is_i64() {
                 query.bind(n.as_i64().unwrap())
             } else if n.is_u64() {
-                query.bind(n.as_u64().unwrap() as i64)
+                // Above `i64::MAX`. Redshift's BIGINT is signed and `as i64`
+                // would *wrap*, writing the id as a large negative number with
+                // nothing raised. Refuse instead (#462).
+                query.bind(faucet_core::util::u64_to_signed(
+                    n.as_u64().unwrap(),
+                    &format!("column {}", faucet_core::util::quote_ident(column)),
+                )?)
             } else {
                 query.bind(n.as_f64().unwrap_or(0.0))
             }
         }
         Some(other) => query.bind(other.to_string()),
-    }
+    })
 }
 
 #[async_trait]
@@ -448,11 +455,20 @@ mod tests {
         // Smoke: binding must not panic for every JSON scalar kind. The actual
         // wire encoding is exercised by the live integration test.
         let q = sqlx::query("SELECT $1, $2, $3, $4, $5, $6");
-        let q = bind_json(q, Some(&json!("s")));
-        let q = bind_json(q, Some(&json!(7)));
-        let q = bind_json(q, Some(&json!(7.5)));
-        let q = bind_json(q, Some(&json!(true)));
-        let q = bind_json(q, Some(&Value::Null));
-        let _q = bind_json(q, None);
+        let q = bind_json(q, Some(&json!("s")), "c").unwrap();
+        let q = bind_json(q, Some(&json!(7)), "c").unwrap();
+        let q = bind_json(q, Some(&json!(7.5)), "c").unwrap();
+        let q = bind_json(q, Some(&json!(true)), "c").unwrap();
+        let q = bind_json(q, Some(&Value::Null), "c").unwrap();
+        let _q = bind_json(q, None, "c").unwrap();
+
+        // #462: a u64 above i64::MAX must be refused, not wrapped negative.
+        let q = sqlx::query("SELECT 1");
+        let err = match bind_json(q, Some(&json!(u64::MAX)), "big_id") {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("u64::MAX must not bind to a signed BIGINT"),
+        };
+        assert!(err.contains("big_id"), "{err}");
+        assert!(err.contains(&u64::MAX.to_string()), "{err}");
     }
 }

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -179,23 +179,30 @@ fn bind_params<'q>(
     mut query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
     config_params: &'q [Value],
     bind_values: &'q [Value],
-) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+) -> Result<sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>, FaucetError> {
     // Bind the static config params and the per-context values as native
     // scalar types, in positional order ($1, $2, …). Binding a raw
     // `serde_json::Value` encodes it as `jsonb` (sqlx), which breaks comparisons
     // against typed columns — e.g. `WHERE id = $1` against an integer column
     // fails with "operator does not exist: integer = jsonb". config_params
     // previously bound the raw Value and hit exactly this (audit #146 H12).
-    for value in config_params.iter().chain(bind_values) {
+    for (i, value) in config_params.iter().chain(bind_values).enumerate() {
         query = match value {
             Value::String(s) => query.bind(s.clone()),
             Value::Number(n) => match classify_number(n) {
                 // `unwrap()` is sound: the classifier proves the predicate.
                 NumberBind::I64 => query.bind(n.as_i64().unwrap()),
-                // `u64::MAX` has no `i64` representation; reinterpret the bits
-                // so the value round-trips into an `int8`/`bigint` column
-                // without the precision loss an `f64` cast would introduce.
-                NumberBind::U64 => query.bind(n.as_u64().unwrap() as i64),
+                // Above `i64::MAX`. Postgres has no unsigned integer type, and
+                // `as i64` would *wrap* — writing a large id as a large negative
+                // number, or (when this binds an incremental bookmark) comparing
+                // against a negative bound and re-reading or skipping rows. The
+                // original intent here was to avoid an `f64` cast's precision
+                // loss, which is right; bit-reinterpretation is not the way to
+                // get it. Refuse instead (#462).
+                NumberBind::U64 => query.bind(faucet_core::util::u64_to_signed(
+                    n.as_u64().unwrap(),
+                    &format!("bind parameter ${}", i + 1),
+                )?),
                 NumberBind::F64 => query.bind(n.as_f64().unwrap_or(0.0)),
             },
             Value::Bool(b) => query.bind(*b),
@@ -203,7 +210,7 @@ fn bind_params<'q>(
             _ => query.bind(value.to_string()),
         };
     }
-    query
+    Ok(query)
 }
 
 /// One flattened `information_schema.columns` row used by [`discover`].
@@ -284,7 +291,7 @@ impl faucet_core::Source for PostgresSource {
     ) -> Result<Vec<Value>, FaucetError> {
         let (query_str, bind_values) = resolve_query(&self.config, context);
         let query_str = self.shard_wrap(query_str);
-        let query = bind_params(sqlx::query(&query_str), &self.config.params, &bind_values);
+        let query = bind_params(sqlx::query(&query_str), &self.config.params, &bind_values)?;
 
         let rows = query
             .fetch_all(&self.pool)
@@ -322,7 +329,7 @@ impl faucet_core::Source for PostgresSource {
                 sqlx::query(&query_str),
                 &self.config.params,
                 &bind_values,
-            );
+            )?;
 
             let mut rows = query.fetch(&self.pool);
             let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
@@ -434,7 +441,7 @@ impl faucet_core::Source for PostgresSource {
 
         let bounds_sql =
             pk_bounds_query(&self.config.query, &quote_ident(&shard_cfg.key), "BIGINT");
-        let row = bind_params(sqlx::query(&bounds_sql), &self.config.params, &[])
+        let row = bind_params(sqlx::query(&bounds_sql), &self.config.params, &[])?
             .fetch_one(&self.pool)
             .await
             .map_err(|e| {
@@ -928,5 +935,37 @@ mod tests {
             err.to_string().contains("shard bounds"),
             "expected bounds-probe error, got: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod bind_overflow_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// #462: above `i64::MAX` Postgres has no type that fits, and `as i64` would
+    /// wrap to a negative. Refuse loudly instead — silently binding a negative
+    /// bookmark would make `WHERE key > $1` re-read or skip rows.
+    #[test]
+    fn u64_above_i64_max_is_refused_not_wrapped() {
+        let err = match bind_params(sqlx::query("SELECT 1"), &[json!(u64::MAX)], &[]) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("u64::MAX must not bind"),
+        };
+        assert!(err.contains(&u64::MAX.to_string()), "{err}");
+        assert!(
+            !err.contains("-9223372036854775808"),
+            "must not show the wrap: {err}"
+        );
+    }
+
+    #[test]
+    fn values_a_signed_column_can_hold_still_bind() {
+        for v in [json!(0), json!(-1), json!(i64::MAX), json!(i64::MAX as u64)] {
+            assert!(
+                bind_params(sqlx::query("SELECT 1"), &[v.clone()], &[]).is_ok(),
+                "{v} must still bind"
+            );
+        }
     }
 }

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -963,7 +963,7 @@ mod bind_overflow_tests {
     fn values_a_signed_column_can_hold_still_bind() {
         for v in [json!(0), json!(-1), json!(i64::MAX), json!(i64::MAX as u64)] {
             assert!(
-                bind_params(sqlx::query("SELECT 1"), &[v.clone()], &[]).is_ok(),
+                bind_params(sqlx::query("SELECT 1"), std::slice::from_ref(&v), &[]).is_ok(),
                 "{v} must still bind"
             );
         }

--- a/crates/source/redshift/src/convert.rs
+++ b/crates/source/redshift/src/convert.rs
@@ -4,6 +4,7 @@
 //! source: values decode through `sqlx`'s Postgres row API, and JSON bind values
 //! are classified before binding so large integers keep full precision.
 
+use faucet_core::FaucetError;
 use serde_json::Value;
 use sqlx::{Column, Row};
 
@@ -112,13 +113,20 @@ pub(crate) fn classify_number(n: &serde_json::Number) -> NumberBind {
 pub(crate) fn bind_params<'q>(
     mut query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
     binds: &'q [Value],
-) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-    for value in binds {
+) -> Result<sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>, FaucetError> {
+    for (i, value) in binds.iter().enumerate() {
         query = match value {
             Value::String(s) => query.bind(s.clone()),
             Value::Number(n) => match classify_number(n) {
                 NumberBind::I64 => query.bind(n.as_i64().unwrap()),
-                NumberBind::U64 => query.bind(n.as_u64().unwrap() as i64),
+                // Above `i64::MAX`. Redshift's BIGINT is signed, and `as i64`
+                // would *wrap* — writing a large id as a large negative number, or
+                // (when this binds an incremental bookmark) comparing against a
+                // negative bound and re-reading or skipping rows. Refuse (#462).
+                NumberBind::U64 => query.bind(faucet_core::util::u64_to_signed(
+                    n.as_u64().unwrap(),
+                    &format!("bind parameter ${}", i + 1),
+                )?),
                 NumberBind::F64 => query.bind(n.as_f64().unwrap_or(0.0)),
             },
             Value::Bool(b) => query.bind(*b),
@@ -126,7 +134,7 @@ pub(crate) fn bind_params<'q>(
             _ => query.bind(value.to_string()),
         };
     }
-    query
+    Ok(query)
 }
 
 #[cfg(test)]
@@ -162,5 +170,36 @@ mod tests {
     #[test]
     fn classify_float_is_f64() {
         assert_eq!(classify_number(&num(json!(3.5))), NumberBind::F64);
+    }
+}
+
+#[cfg(test)]
+mod bind_overflow_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// #462: Redshift's BIGINT is signed; `as i64` would wrap a large unsigned
+    /// id to a negative, and this same binder carries incremental bookmarks.
+    #[test]
+    fn u64_above_i64_max_is_refused_not_wrapped() {
+        let err = match bind_params(sqlx::query("SELECT 1"), &[json!(u64::MAX)]) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("u64::MAX must not bind"),
+        };
+        assert!(err.contains(&u64::MAX.to_string()), "{err}");
+        assert!(
+            !err.contains("-9223372036854775808"),
+            "must not show the wrap: {err}"
+        );
+    }
+
+    #[test]
+    fn values_a_signed_column_can_hold_still_bind() {
+        for v in [json!(0), json!(-1), json!(i64::MAX), json!(i64::MAX as u64)] {
+            assert!(
+                bind_params(sqlx::query("SELECT 1"), &[v.clone()]).is_ok(),
+                "{v} must still bind"
+            );
+        }
     }
 }

--- a/crates/source/redshift/src/convert.rs
+++ b/crates/source/redshift/src/convert.rs
@@ -197,7 +197,7 @@ mod bind_overflow_tests {
     fn values_a_signed_column_can_hold_still_bind() {
         for v in [json!(0), json!(-1), json!(i64::MAX), json!(i64::MAX as u64)] {
             assert!(
-                bind_params(sqlx::query("SELECT 1"), &[v.clone()]).is_ok(),
+                bind_params(sqlx::query("SELECT 1"), std::slice::from_ref(&v)).is_ok(),
                 "{v} must still bind"
             );
         }

--- a/crates/source/redshift/src/stream.rs
+++ b/crates/source/redshift/src/stream.rs
@@ -197,7 +197,7 @@ impl Source for RedshiftSource {
         Box::pin(async_stream::try_stream! {
             let incr = self.incremental_ctx();
             let (query_str, binds) = self.resolve_query(context, incr.as_ref());
-            let query = bind_params(sqlx::query(&query_str), &binds);
+            let query = bind_params(sqlx::query(&query_str), &binds)?;
 
             let mut rows = query.fetch(&self.pool);
             let chunk = if batch_size == 0 { usize::MAX } else { batch_size };

--- a/crates/source/sqlite/src/stream.rs
+++ b/crates/source/sqlite/src/stream.rs
@@ -961,7 +961,7 @@ mod bind_overflow_tests {
     fn values_a_signed_column_can_hold_still_bind() {
         for v in [json!(0), json!(-1), json!(i64::MAX), json!(i64::MAX as u64)] {
             assert!(
-                bind_params(sqlx::query("SELECT 1"), &[v.clone()]).is_ok(),
+                bind_params(sqlx::query("SELECT 1"), std::slice::from_ref(&v)).is_ok(),
                 "{v} must still bind"
             );
         }

--- a/crates/source/sqlite/src/stream.rs
+++ b/crates/source/sqlite/src/stream.rs
@@ -157,17 +157,23 @@ fn classify_number(n: &serde_json::Number) -> NumberBind {
 fn bind_params<'q>(
     mut query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
     bind_values: &'q [Value],
-) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
-    for value in bind_values {
+) -> Result<sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>, FaucetError> {
+    for (i, value) in bind_values.iter().enumerate() {
         query = match value {
             Value::String(s) => query.bind(s.clone()),
             Value::Number(n) => match classify_number(n) {
                 // `unwrap()` is sound: the classifier proves the predicate.
                 NumberBind::I64 => query.bind(n.as_i64().unwrap()),
-                // SQLite has no unsigned integer type; reinterpret the bits so
-                // the value round-trips through its signed 8-byte INTEGER
-                // without the precision loss an `f64` cast would introduce.
-                NumberBind::U64 => query.bind(n.as_u64().unwrap() as i64),
+                // Above `i64::MAX`. SQLite's INTEGER is a signed 8-byte value, and
+                // `as i64` would *wrap* — storing a large id as a large negative
+                // number, or (when this binds an incremental bookmark) comparing
+                // against a negative bound and re-reading or skipping rows.
+                // Avoiding an `f64` cast's precision loss was the right instinct;
+                // bit-reinterpretation is not the way to get it. Refuse (#462).
+                NumberBind::U64 => query.bind(faucet_core::util::u64_to_signed(
+                    n.as_u64().unwrap(),
+                    &format!("bind parameter {}", i + 1),
+                )?),
                 NumberBind::F64 => query.bind(n.as_f64().unwrap_or(0.0)),
             },
             Value::Bool(b) => query.bind(*b),
@@ -175,7 +181,7 @@ fn bind_params<'q>(
             _ => query.bind(value.to_string()),
         };
     }
-    query
+    Ok(query)
 }
 
 /// One flattened `pragma_table_info` row used by [`discover`].
@@ -248,7 +254,7 @@ impl faucet_core::Source for SqliteSource {
     ) -> Result<Vec<Value>, FaucetError> {
         let (query_str, bind_values) = resolve_query(&self.config, context);
         let query_str = self.shard_wrap(query_str);
-        let query = bind_params(sqlx::query(&query_str), &bind_values);
+        let query = bind_params(sqlx::query(&query_str), &bind_values)?;
 
         let rows = query
             .fetch_all(&self.pool)
@@ -288,7 +294,7 @@ impl faucet_core::Source for SqliteSource {
         Box::pin(async_stream::try_stream! {
             let (query_str, bind_values) = resolve_query(&self.config, context);
             let query_str = self.shard_wrap(query_str);
-            let query = bind_params(sqlx::query(&query_str), &bind_values);
+            let query = bind_params(sqlx::query(&query_str), &bind_values)?;
 
             let mut rows = query.fetch(&self.pool);
             let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
@@ -928,5 +934,36 @@ mod tests {
 
         let bad = faucet_core::ShardSpec::new("0", serde_json::json!({ "key": "k" }));
         assert!(source.apply_shard(&bad).await.is_err());
+    }
+}
+
+#[cfg(test)]
+mod bind_overflow_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// #462: SQLite's INTEGER is signed 8-byte; `as i64` would wrap a large
+    /// unsigned id to a negative. Refuse instead.
+    #[test]
+    fn u64_above_i64_max_is_refused_not_wrapped() {
+        let err = match bind_params(sqlx::query("SELECT 1"), &[json!(u64::MAX)]) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("u64::MAX must not bind"),
+        };
+        assert!(err.contains(&u64::MAX.to_string()), "{err}");
+        assert!(
+            !err.contains("-9223372036854775808"),
+            "must not show the wrap: {err}"
+        );
+    }
+
+    #[test]
+    fn values_a_signed_column_can_hold_still_bind() {
+        for v in [json!(0), json!(-1), json!(i64::MAX), json!(i64::MAX as u64)] {
+            assert!(
+                bind_params(sqlx::query("SELECT 1"), &[v.clone()]).is_ok(),
+                "{v} must still bind"
+            );
+        }
     }
 }

--- a/crates/transform-sql/src/shovel.rs
+++ b/crates/transform-sql/src/shovel.rs
@@ -6,7 +6,6 @@ use arrow::array::RecordBatch;
 use arrow::datatypes::{Schema, SchemaRef};
 use faucet_core::FaucetError;
 use serde_json::{Map, Value};
-use std::sync::Arc;
 
 /// Map any display-able error into a `FaucetError::Transform` with context.
 fn te<E: std::fmt::Display>(ctx: &str, e: E) -> FaucetError {
@@ -17,13 +16,17 @@ fn te<E: std::fmt::Display>(ctx: &str, e: E) -> FaucetError {
 ///
 /// Each element must be a JSON object. Returns the inferred schema wrapped in
 /// an [`Arc`]. On an empty slice the result is a schema with no fields.
+///
+/// Delegates to [`faucet_core::columnar::infer_arrow_schema`] rather than calling
+/// `arrow-json` directly. The two used to be independent copies of the same call,
+/// which is how the wide-integer bug (#460) existed in both: an integer above
+/// `i64::MAX` was inferred as `Float64` and silently lost its exact value. One
+/// implementation means one place to fix.
 pub fn infer_schema(records: &[Value]) -> Result<SchemaRef, FaucetError> {
-    let iter = records
-        .iter()
-        .map(|v| Ok::<_, arrow::error::ArrowError>(v.clone()));
-    let schema = arrow_json::reader::infer_json_schema_from_iterator(iter)
-        .map_err(|e| te("schema inference", e))?;
-    Ok(Arc::new(schema))
+    // Re-wrap so the message still names the thing the operator configured (a
+    // `sql` transform) rather than only the shared shim it delegates to.
+    faucet_core::columnar::infer_arrow_schema(records)
+        .map_err(|e| FaucetError::Transform(format!("sql transform: {e}")))
 }
 
 /// Encode a slice of JSON records into a single [`RecordBatch`] against `schema`.

--- a/docs/book/src/cookbook/backfill.md
+++ b/docs/book/src/cookbook/backfill.md
@@ -74,9 +74,26 @@ back at `faucet backfill`.)
 `backfill.window` default) the whole range runs as a single unit. Windows are
 contiguous half-open slices of `[from, to)` — the last one truncates at `--to`.
 Date boundaries like `--from 2026-06-01` are midnight in `--timezone` (IANA
-name; default UTC), and window arithmetic is absolute, so units never gap or
-overlap — including across DST transitions. A plan above 1,000 units warns;
+name; default UTC). Units never gap or overlap. A plan above 1,000 units warns;
 above 10,000 it is rejected (use a larger window).
+
+**`1d`/`1w` are calendar steps; `24h`/`168h` are elapsed time.** The two are
+identical except across a DST transition, where they deliberately differ:
+
+| window | across US spring-forward (2026-03-08) |
+|---|---|
+| `1d` | every unit starts at **local midnight**; 03-08 is 23 elapsed hours |
+| `24h` | units drift — 03-09 onward start at **01:00** local |
+
+Use `1d` for date-partitioned backfills, so `${backfill.start_date}` always
+names exactly the local day its window covers. Use `24h` when you want a fixed
+amount of elapsed time regardless of the calendar. A fall-back (repeated) hour
+resolves to the earliest instant, matching how `--from`/`--to` dates resolve.
+
+> Changing between `1d` and `24h` changes the unit boundaries, so it also changes
+> the progress-marker hash — an in-flight backfill will not resume across that
+> switch. Absolute windows keep the hash they had before calendar stepping
+> existed, so upgrades do not disturb a running backfill.
 
 ## Progress, resume, restart
 


### PR DESCRIPTION
Second-pass audit of the subsystems the first pass (#456 / #457) left thin, plus fixes for everything it found.

Closes #460
Closes #461
Closes #462

---

## What was audited

The first audit weighted the newest subsystems. This pass covered what it under-examined:

| Area | Verdict |
|---|---|
| `crates/core/src/columnar.rs` + `transform-sql` shovel | **bug — #460** |
| `cli/src/backfill/plan.rs` (window/DST math) | **bug — #461** |
| Numeric bind paths, all SQL backends | **bug — #462** (+ two instances the issue did not name) |
| `crates/core/src/adaptive.rs` | clean |
| `crates/source/singer/src/process.rs` (subprocess lifecycle) | clean |
| `crates/core/src/encryption.rs` (nonce / key handling) | clean |
| Cluster Mode B shard claim / reclaim / finalize fencing | clean |
| `cli/src/select.rs` (row selection) | clean |
| `HashJoin` memory guard | clean |
| Object-store source bookmarks (azure-blob, sftp) | clean |
| Decode paths: clickhouse, databricks, delta | clean |

Notes on the clean ones, since "clean" is a claim too:

- **adaptive** — shrink floors at `min`, grow is `saturating_add().min(max)`, and validation rejects NaN via `!(x > 0.0 && x < 1.0)`.
- **singer** — separate stderr drain task (no pipe deadlock), bounded channel, SIGTERM→grace→SIGKILL, `kill_on_drop`, and — the part that matters — it checks the tap's exit status *before* yielding the trailing page, so a failed tap never commits an un-checkpointed final page.
- **encryption** — fresh random 12-byte nonce per seal (never reused), typed decrypt failures, read-key rotation list.
- **shards** — CAS claim, owner-scoped renew, and the expiry predicate re-checked *in the UPDATE* rather than only the SELECT, so there is no TOCTOU between reclaim's read and write. `finalize_shard` is owner-fenced, so a superseded owner cannot clobber the new one.
- **delta / databricks** — both fall back to a *string* for an integer that does not fit `i64`, preserving the value. That is the contrast that made #462 stand out.

---

## Fixes

### #460 — integers above `i64::MAX` silently became lossy floats `[tier-1]`

`arrow-json` infers `Float64` for any integer outside `i64` range, so:

```
in:  {"id": 18446744073709551615}
out: {"id": 1.8446744073709552e+19}     // Ok(...), exact value gone
```

I verified this by running it rather than reading it — which also told me what *isn't* broken (`i64` values round-trip exactly, including `2^53+1`).

The same inference call was duplicated in `faucet-core`'s columnar shim and `transform-sql`'s shovel, so the bug existed twice — and `transform-sql` is the wider blast radius, since every `sql` transform page goes through it with no Arrow-native connector involved.

- `refine_wide_integers` re-types such a field to `UInt64` when every observed value is a non-negative integer, recursing into structs, so the value round-trips exactly.
- Where no exact type fits — a field spanning negatives *and* above `i64::MAX`, or a wide integer inside a list — it now **fails** with a typed error naming the field and pointing at `cast`. Refusing beats writing an approximation nobody asked for, and it means no silently-lossy path is left behind.
- Genuine floats and int/float mixes keep today's behaviour: coercing those is ordinary JSON-number semantics, not loss of an exact integer.
- `shovel::infer_schema` now delegates to the core helper, so there is one implementation instead of two copies to keep in step. It re-wraps the error so the message still names the `sql` transform the operator configured.

### #462 — `u64 as i64` wrapped to a negative in three backends `[tier-1]`

`9223372036854775808u64 as i64` is `-9223372036854775808`. Two impacts, both silent:

- a **sink** writes a large unsigned id as a large negative number;
- the same binder carries **incremental-replication bookmarks**, so `WHERE key > $1` compares against a negative bound and re-reads or skips rows — data loss/duplication, not just a bad value.

The issue named Redshift. Auditing the class found the identical wrap in **`postgres` and `sqlite` sources** too, both of which also bind bookmarks. `mysql` is the in-tree control: it binds `as_u64()` directly because MySQL has a native `UNSIGNED BIGINT`, with a comment noting the lossless round-trip — same classification, correct handling.

The three signed backends genuinely cannot represent the value, so new `faucet_core::util::u64_to_signed` returns the `i64` when it fits and a typed error naming the column/parameter otherwise. Every value that binds today still binds (`0`, negatives, `i64::MAX`, any `u64` up to `i64::MAX`) — tested alongside the refusals.

The existing comments show the wrap was deliberate: *"reinterpret the bits … without the precision loss an f64 cast would introduce."* Avoiding `f64` loss was the right instinct; bit-reinterpretation is not a way to get it, because the column really does hold a negative afterwards.

### #461 — `--window 1d` drifted off local midnight across DST `[tier-2]`

Absolute stepping meant the unit labelled `2026-03-08` covered **25 local hours** (00:00 → next day 01:00) and every later unit started at 01:00, so `${backfill.start_date}` stopped describing the window it named. Date-partitioned output was misassigned. Coverage was always gapless — which is exactly why the existing DST test passed.

- `parse_window` returns a new `WindowStep`: `d`/`w` are **calendar** steps, everything else absolute. `1d` and `24h` now deliberately differ across a transition.
- Calendar steps advance the *naive* local time (no DST) and re-resolve in the zone: a spring-forward gap nudges forward an hour at a time, a fall-back hour takes the earliest instant, matching how `--from`/`--to` dates already resolve. A non-advancing instant falls back to the nominal duration so the loop always terminates.
- The range-hash descriptor renders an absolute window as its seconds **exactly as before**, so a backfill already in flight keeps resuming. Calendar windows hash differently on purpose — their unit boundaries are not the old plan's, so resuming against an old marker would mix two different unit sets.

---

## Verification

- **`faucet-core`: 952 tests pass** (`quality,contract,masking,transforms,encryption,arrow`).
- **`cargo semver-checks check-release -p faucet-core`: 222 pass, no update required** — `u64_to_signed` is additive and `infer_arrow_schema`'s signature is unchanged.
- Touched connector suites pass; `cargo doc -D warnings` clean; `cargo fmt` clean.
- **clippy `--all-targets --all-features` with fingerprints invalidated** (`touch` on every changed file first). That matters: the naive run passed, and only the forced run surfaced a real lint in one of my new tests. It is the same false-pass that cost an iteration on #457.
- The three exact slim `cargo build --no-default-features` CI commands pass.
- Not run locally: the Docker-gated integration tests (no Docker on this machine — `SocketNotFoundError`), and `--workspace --all-features`, which needs the bundled-DuckDB build this disk cannot hold. Both run in CI.

## Notes for review

- **`faucet-cli`'s lib API changes**: `backfill::plan::parse_window` now returns `WindowStep` instead of `Duration`, and `plan_windows` takes it. This is breaking for anyone depending on `faucet_cli` as a library. It is *inherent* to the fix — a `Duration` cannot express "calendar day vs 24 hours" — but `semver-checks` in CI only gates `faucet-core`, so nothing will catch it automatically. Flagging it so `faucet-cli` gets a deliberate version decision rather than a silent patch bump from the `fix:` prefix.
- `#460`'s refusal paths change behaviour for configs that "worked" before by silently corrupting. That is intended, and the error names the field and the `cast` workaround.
- Areas still unaudited after this pass: the `conformance` crate, `catalog.rs` merge logic, `livemetrics`/`progress`/`tui`, and the remaining per-connector decode paths (nats, pubsub, sqs beyond ack ordering, kinesis beyond #321). #460 came out of exactly this kind of gap-fill, so a third pass over those would likely find more.
