### PR TITLE
feat(topology): exactly-once delivery + per-node SLA/notify/lineage/catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-lineage"
-version = "1.2.3"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ categories = ["database", "asynchronous"]
 # Internal crates
 faucet-core = { path = "crates/core", version = "1.7.1" }
 faucet-auth = { path = "crates/auth", version = "1.0.7" }
-faucet-lineage = { path = "crates/lineage", version = "1.2.3" }
+faucet-lineage = { path = "crates/lineage", version = "2.0.0" }
 faucet-common-bigquery = { path = "crates/common/bigquery", version = "1.0.7" }
 faucet-common-elasticsearch = { path = "crates/common/elasticsearch", version = "1.0.7" }
 faucet-common-gcs = { path = "crates/common/gcs", version = "1.0.7" }

--- a/cli/src/commands/catalog.rs
+++ b/cli/src/commands/catalog.rs
@@ -312,13 +312,13 @@ mod tests {
             pipeline: "p".into(),
             row: "default".into(),
             recorded_at: chrono::Utc::now(),
-            source: DatasetObservation {
+            sources: vec![DatasetObservation {
                 uri: "csv://./in.csv".into(),
                 kind: "csv".into(),
                 role: DatasetRole::Source,
                 schema: None,
                 records: 4,
-            },
+            }],
             sink: DatasetObservation {
                 uri: "jsonl://./out.jsonl".into(),
                 kind: "jsonl".into(),
@@ -328,7 +328,7 @@ mod tests {
             },
             column_lineage: Some(serde_json::json!({"fields": {}})),
         };
-        let edge = apply_edge(None, &update);
+        let edge = apply_edge(None, &update, &update.sources[0]);
         let text = render_edges(&[edge]);
         assert!(
             text.contains("csv://./in.csv  →  jsonl://./out.jsonl"),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1444,13 +1444,16 @@ async fn run_one_invocation(
             pipeline: obs_labels.pipeline.to_string(),
             row: obs_labels.row.to_string(),
             recorded_at: chrono::Utc::now(),
-            source: DatasetObservation {
+            // A matrix invocation is always one source → one sink; the vector
+            // shape exists for topology graphs, where a sink can be fed by several
+            // (#459).
+            sources: vec![DatasetObservation {
                 uri: canonicalize_uri(&source_dataset_uri, &node.source.config, opts.clock),
                 kind: node.source.kind.clone(),
                 role: DatasetRole::Source,
                 schema: source_schema,
                 records: records_read,
-            },
+            }],
             sink: DatasetObservation {
                 uri: canonicalize_uri(&sink_dataset_uri, &node.sink.config, opts.clock),
                 kind: node.sink.kind.clone(),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1173,10 +1173,10 @@ async fn run_one_invocation(
                 job_name,
                 run_id: run_id.clone(),
                 parent: lc.parent_job.clone(),
-                input: faucet_lineage::DatasetRef {
+                inputs: vec![faucet_lineage::DatasetRef {
                     namespace: lc.namespace.clone(),
                     name: source.dataset_uri(),
-                },
+                }],
                 output: faucet_lineage::DatasetRef {
                     namespace: lc.namespace.clone(),
                     name: sink.dataset_uri(),
@@ -1185,7 +1185,7 @@ async fn run_one_invocation(
                 finished_at: None,
                 records: 0,
                 error: None,
-                input_schema: None,
+                input_schemas: Vec::new(),
                 output_schema: None,
                 column_lineage: None,
                 source_code: None,
@@ -1276,7 +1276,7 @@ async fn run_one_invocation(
                 .map(|l| l.include_schema_facet)
                 .unwrap_or(false)
             {
-                ctx.input_schema = Some(in_schema);
+                ctx.input_schemas = vec![Some(in_schema)];
             }
         }
         let ev = match &result {

--- a/cli/src/serve/history/catalog.rs
+++ b/cli/src/serve/history/catalog.rs
@@ -73,7 +73,11 @@ pub struct CatalogUpdate {
     /// Matrix row id (`"default"` for non-matrix runs).
     pub row: String,
     pub recorded_at: DateTime<Utc>,
-    pub source: DatasetObservation,
+    /// Input datasets. A single-source pipeline has one; a topology sink fed by a
+    /// merge or join has one per source that reaches it (#459). Each carries its
+    /// own record count, so per-dataset volume stays accurate instead of the sink
+    /// total being repeated across edges.
+    pub sources: Vec<DatasetObservation>,
     pub sink: DatasetObservation,
     /// Column-lineage facet derived by `faucet-lineage` for the edge, when the
     /// transform chain is expressible (`None` when opaque).
@@ -417,13 +421,14 @@ pub fn apply_observation(
 pub fn apply_edge(
     existing: Option<&CatalogLineageEdge>,
     update: &CatalogUpdate,
+    source: &DatasetObservation,
 ) -> CatalogLineageEdge {
     let mut edge = match existing {
         Some(prev) => prev.clone(),
         None => CatalogLineageEdge {
-            src_id: dataset_id(&update.source.uri),
+            src_id: dataset_id(&source.uri),
             dst_id: dataset_id(&update.sink.uri),
-            src_uri: update.source.uri.clone(),
+            src_uri: source.uri.clone(),
             dst_uri: update.sink.uri.clone(),
             pipeline: update.pipeline.clone(),
             row: update.row.clone(),
@@ -440,7 +445,15 @@ pub fn apply_edge(
     edge.last_seen = update.recorded_at;
     edge.last_run_id = update.run_id.clone();
     edge.runs = edge.runs.saturating_add(1);
-    edge.last_records = update.sink.records;
+    // The records this edge carried. For a single-source pipeline the source read
+    // count and the sink write count coincide; for a merge, attributing the sink
+    // total to every edge would over-count, so each edge reports its own source's
+    // contribution (#459).
+    edge.last_records = if update.sources.len() == 1 {
+        update.sink.records
+    } else {
+        source.records
+    };
     if update.column_lineage.is_some() {
         edge.column_lineage = update.column_lineage.clone();
     }
@@ -691,7 +704,7 @@ mod tests {
             pipeline: "p".into(),
             row: "default".into(),
             recorded_at: Utc::now(),
-            source: obs(src, DatasetRole::Source, None, records),
+            sources: vec![obs(src, DatasetRole::Source, None, records)],
             sink: obs(dst, DatasetRole::Sink, None, records),
             column_lineage: None,
         }
@@ -701,7 +714,7 @@ mod tests {
     fn edge_accumulates_and_keeps_last_column_lineage() {
         let mut u = update("a://1", "b://2", 5);
         u.column_lineage = Some(json!({"fields": {"x": {}}}));
-        let e = apply_edge(None, &u);
+        let e = apply_edge(None, &u, &u.sources[0]);
         assert_eq!(e.runs, 1);
         assert_eq!(e.last_records, 5);
         assert!(e.column_lineage.is_some());
@@ -709,7 +722,7 @@ mod tests {
         // A later opaque run keeps the previous column lineage.
         let mut u2 = update("a://1", "b://2", 9);
         u2.run_id = "r2".into();
-        let e2 = apply_edge(Some(&e), &u2);
+        let e2 = apply_edge(Some(&e), &u2, &u2.sources[0]);
         assert_eq!(e2.runs, 2);
         assert_eq!(e2.last_records, 9);
         assert_eq!(e2.last_run_id, "r2");
@@ -792,7 +805,11 @@ mod tests {
     }
 
     fn edge(src: &str, dst: &str) -> CatalogLineageEdge {
-        apply_edge(None, &update(src, dst, 1))
+        {
+            let u = update(src, dst, 1);
+            let src_obs = u.sources[0].clone();
+            apply_edge(None, &u, &src_obs)
+        }
     }
 
     #[test]
@@ -817,5 +834,66 @@ mod tests {
         assert!(d2.iter().all(|e| e.src_uri != "x"));
         // Unknown root: nothing.
         assert!(lineage_slice(edges, Some("nope"), 3).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod multi_source_tests {
+    use super::*;
+
+    fn obs2(uri: &str, role: DatasetRole, records: u64) -> DatasetObservation {
+        DatasetObservation {
+            uri: uri.into(),
+            kind: "csv".into(),
+            role,
+            schema: None,
+            records,
+        }
+    }
+
+    /// #459: a topology sink fed by a merge has several inputs. Each gets its own
+    /// edge, and each edge reports **its own** source's contribution — repeating
+    /// the sink total across edges would over-count the volume.
+    #[test]
+    fn a_merge_sink_yields_one_edge_per_input_with_its_own_volume() {
+        let update = CatalogUpdate {
+            run_id: "r1".into(),
+            pipeline: "p".into(),
+            row: "w".into(),
+            recorded_at: Utc::now(),
+            sources: vec![
+                obs2("csv://a.csv", DatasetRole::Source, 4),
+                obs2("csv://b.csv", DatasetRole::Source, 3),
+            ],
+            sink: obs2("jsonl://out.jsonl", DatasetRole::Sink, 7),
+            column_lineage: None,
+        };
+
+        let a = apply_edge(None, &update, &update.sources[0]);
+        let b = apply_edge(None, &update, &update.sources[1]);
+        assert_eq!(a.src_uri, "csv://a.csv");
+        assert_eq!(b.src_uri, "csv://b.csv");
+        assert_eq!(a.dst_uri, "jsonl://out.jsonl");
+        assert_eq!(a.dst_id, b.dst_id, "both edges land on the same sink");
+        // Per-source volume, so a.last + b.last == the sink's 7 rather than 7 each.
+        assert_eq!((a.last_records, b.last_records), (4, 3));
+        assert_eq!(a.last_records + b.last_records, update.sink.records);
+    }
+
+    /// The single-source case is unchanged: the edge reports the sink's count,
+    /// which is what every matrix pipeline records.
+    #[test]
+    fn a_single_source_edge_still_reports_the_sink_count() {
+        let update = CatalogUpdate {
+            run_id: "r1".into(),
+            pipeline: "p".into(),
+            row: "default".into(),
+            recorded_at: Utc::now(),
+            sources: vec![obs2("csv://a.csv", DatasetRole::Source, 9)],
+            sink: obs2("jsonl://out.jsonl", DatasetRole::Sink, 9),
+            column_lineage: None,
+        };
+        let e = apply_edge(None, &update, &update.sources[0]);
+        assert_eq!(e.last_records, 9);
     }
 }

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -269,7 +269,7 @@ impl RunHistory for MemoryHistory {
     async fn catalog_record(&self, update: &CatalogUpdate) -> Result<(), HistoryError> {
         let lock_err = |_| HistoryError::Backend("catalog lock poisoned".into());
         let mut cat = self.catalog.lock().map_err(lock_err)?;
-        for obs in [&update.source, &update.sink] {
+        for obs in update.sources.iter().chain(std::iter::once(&update.sink)) {
             let id = catalog::dataset_id(&obs.uri);
             let (ds, new_version) = catalog::apply_observation(
                 cat.datasets.get(&id),
@@ -294,12 +294,15 @@ impl RunHistory for MemoryHistory {
             }
             cat.datasets.insert(id, ds);
         }
-        let key = (
-            catalog::dataset_id(&update.source.uri),
-            catalog::dataset_id(&update.sink.uri),
-        );
-        let edge = catalog::apply_edge(cat.edges.get(&key), update);
-        cat.edges.insert(key, edge);
+        // One edge per input dataset — a merge/join sink has several (#459).
+        for source in &update.sources {
+            let key = (
+                catalog::dataset_id(&source.uri),
+                catalog::dataset_id(&update.sink.uri),
+            );
+            let edge = catalog::apply_edge(cat.edges.get(&key), update, source);
+            cat.edges.insert(key, edge);
+        }
         Ok(())
     }
 
@@ -964,13 +967,13 @@ mod tests {
             pipeline: "p".into(),
             row: "default".into(),
             recorded_at: Utc::now(),
-            source: DatasetObservation {
+            sources: vec![DatasetObservation {
                 uri: src.into(),
                 kind: "csv".into(),
                 role: DatasetRole::Source,
                 schema: schema.clone(),
                 records: 10,
-            },
+            }],
             sink: DatasetObservation {
                 uri: dst.into(),
                 kind: "jsonl".into(),

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -269,6 +269,11 @@ impl RunHistory for MemoryHistory {
     async fn catalog_record(&self, update: &CatalogUpdate) -> Result<(), HistoryError> {
         let lock_err = |_| HistoryError::Backend("catalog lock poisoned".into());
         let mut cat = self.catalog.lock().map_err(lock_err)?;
+        // A dataset id may appear twice in one update — e.g. a source whose URI
+        // canonicalizes to the sink's. The SQL backends dedup a stats point on
+        // its `(dataset_id, recorded_at)` PK, so record each id at most once per
+        // update here too, or the two backends' volume timelines diverge (#466 L2).
+        let mut stat_ids_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         for obs in update.sources.iter().chain(std::iter::once(&update.sink)) {
             let id = catalog::dataset_id(&obs.uri);
             let (ds, new_version) = catalog::apply_observation(
@@ -282,25 +287,32 @@ impl RunHistory for MemoryHistory {
             if let Some(v) = new_version {
                 cat.schema_versions.entry(id.clone()).or_default().push(v);
             }
-            let points = cat.stats.entry(id.clone()).or_default();
-            points.push(CatalogStatsPoint {
-                recorded_at: update.recorded_at,
-                run_id: update.run_id.clone(),
-                records: obs.records,
-            });
-            if points.len() > catalog::STATS_RETAIN {
-                let drop_n = points.len() - catalog::STATS_RETAIN;
-                points.drain(..drop_n);
+            if stat_ids_seen.insert(id.clone()) {
+                let points = cat.stats.entry(id.clone()).or_default();
+                points.push(CatalogStatsPoint {
+                    recorded_at: update.recorded_at,
+                    run_id: update.run_id.clone(),
+                    records: obs.records,
+                });
+                if points.len() > catalog::STATS_RETAIN {
+                    let drop_n = points.len() - catalog::STATS_RETAIN;
+                    points.drain(..drop_n);
+                }
             }
             cat.datasets.insert(id, ds);
         }
-        // One edge per input dataset — a merge/join sink has several (#459).
+        // One edge per input dataset — a merge/join sink has several (#459). Read
+        // every edge's prior state from a pre-loop snapshot, matching the SQL
+        // backends' single `catalog_all_edges()` read: two source nodes sharing a
+        // URI collapse to one edge that must be advanced *once*, not once per node
+        // (#466 L2).
+        let edges_before = cat.edges.clone();
         for source in &update.sources {
             let key = (
                 catalog::dataset_id(&source.uri),
                 catalog::dataset_id(&update.sink.uri),
             );
-            let edge = catalog::apply_edge(cat.edges.get(&key), update, source);
+            let edge = catalog::apply_edge(edges_before.get(&key), update, source);
             cat.edges.insert(key, edge);
         }
         Ok(())
@@ -335,18 +347,21 @@ impl RunHistory for MemoryHistory {
         let mut stats: Vec<CatalogStatsPoint> = cat.stats.get(id).cloned().unwrap_or_default();
         stats.reverse(); // newest first
         stats.truncate(catalog::STATS_DETAIL_LIMIT);
-        let upstream = cat
-            .edges
-            .values()
-            .filter(|e| e.dst_id == id)
-            .cloned()
-            .collect();
-        let downstream = cat
-            .edges
-            .values()
-            .filter(|e| e.src_id == id)
-            .cloned()
-            .collect();
+        // Match the SQL backends exactly: order all edges deterministically
+        // (`last_seen DESC, src_id, dst_id`), then partition by `src_id == id` so
+        // downstream owns any self-loop and upstream is the rest touching `id`.
+        // A `HashMap`-order scan with two independent filters instead put a
+        // self-loop in *both* lists and returned edges in nondeterministic order
+        // (#466 L2).
+        let mut all: Vec<CatalogLineageEdge> = cat.edges.values().cloned().collect();
+        all.sort_by(|a, b| {
+            b.last_seen
+                .cmp(&a.last_seen)
+                .then_with(|| a.src_id.cmp(&b.src_id))
+                .then_with(|| a.dst_id.cmp(&b.dst_id))
+        });
+        let (downstream, rest): (Vec<_>, Vec<_>) = all.into_iter().partition(|e| e.src_id == id);
+        let upstream = rest.into_iter().filter(|e| e.dst_id == id).collect();
         Ok(Some(CatalogDatasetDetail {
             dataset,
             schema_timeline,
@@ -983,6 +998,32 @@ mod tests {
             },
             column_lineage: None,
         }
+    }
+
+    #[tokio::test]
+    async fn catalog_source_equal_sink_dedups_stats_and_self_loop() {
+        // #466 L2: when a source URI canonicalizes to the sink's, the memory
+        // backend must behave like the SQL backends — one stats point per
+        // (id, recorded_at), and the resulting self-loop edge in `downstream`
+        // only, not both lists.
+        let h = MemoryHistory::new(Duration::from_secs(3600));
+        let uri = "file:///same/path.jsonl";
+        h.catalog_record(&catalog_update(uri, uri, None))
+            .await
+            .unwrap();
+
+        let id = crate::serve::history::catalog::dataset_id(uri);
+        let detail = h.catalog_get_dataset(&id).await.unwrap().expect("dataset");
+        assert_eq!(
+            detail.stats.len(),
+            1,
+            "source==sink id must record one stats point, not two"
+        );
+        assert_eq!(detail.downstream.len(), 1, "self-loop edge is downstream");
+        assert!(
+            detail.upstream.is_empty(),
+            "a self-loop must not also appear as upstream"
+        );
     }
 
     #[tokio::test]

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -2150,7 +2150,7 @@ macro_rules! impl_sql_history {
                 let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
                 let now_s = sql::fmt_ts(update.recorded_at);
 
-                for obs in [&update.source, &update.sink] {
+                for obs in update.sources.iter().chain(std::iter::once(&update.sink)) {
                     let id = catalog::dataset_id(&obs.uri);
                     // Read-merge-write; last-write-wins under cluster concurrency
                     // (counters may undercount on a race — acceptable for
@@ -2211,21 +2211,25 @@ macro_rules! impl_sql_history {
                         .map_err(backend)?;
                 }
 
-                let src_id = catalog::dataset_id(&update.source.uri);
+                // One edge per input dataset — a merge/join sink has several
+                // (#459). Fetched once and reused across the inputs.
                 let dst_id = catalog::dataset_id(&update.sink.uri);
                 let existing_edges = self.catalog_all_edges().await?;
-                let existing = existing_edges
-                    .iter()
-                    .find(|e| e.src_id == src_id && e.dst_id == dst_id);
-                let edge = catalog::apply_edge(existing, update);
-                sqlx::query(&self.stmts.catalog_upsert_edge)
-                    .bind(&edge.src_id)
-                    .bind(&edge.dst_id)
-                    .bind(&now_s)
-                    .bind(sql::encode_json(&edge, "catalog edge")?)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(backend)?;
+                for source in &update.sources {
+                    let src_id = catalog::dataset_id(&source.uri);
+                    let existing = existing_edges
+                        .iter()
+                        .find(|e| e.src_id == src_id && e.dst_id == dst_id);
+                    let edge = catalog::apply_edge(existing, update, source);
+                    sqlx::query(&self.stmts.catalog_upsert_edge)
+                        .bind(&edge.src_id)
+                        .bind(&edge.dst_id)
+                        .bind(&now_s)
+                        .bind(sql::encode_json(&edge, "catalog edge")?)
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?;
+                }
                 Ok(())
             }
 

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -350,13 +350,13 @@ mod shard_tests {
             pipeline: "p".into(),
             row: "default".into(),
             recorded_at: chrono::Utc::now(),
-            source: DatasetObservation {
+            sources: vec![DatasetObservation {
                 uri: "csv://./in.csv".into(),
                 kind: "csv".into(),
                 role: DatasetRole::Source,
                 schema: Some(schema.clone()),
                 records,
-            },
+            }],
             sink: DatasetObservation {
                 uri: "jsonl://./out.jsonl".into(),
                 kind: "jsonl".into(),

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -66,12 +66,6 @@ impl TopologyRunOptions {
 /// with the policy doing nothing (#456 M2).
 pub fn inert_blocks(cfg: &PipelineConfig) -> Vec<(&'static str, &'static str)> {
     let mut out = Vec::new();
-    if cfg.resilience.is_some() {
-        out.push((
-            "resilience",
-            "sink writes are not retried and the circuit breaker never trips",
-        ));
-    }
     #[cfg(feature = "notify")]
     if !cfg.notifications.is_empty() {
         out.push((
@@ -112,19 +106,13 @@ pub fn validate_topology_spec(cfg: &PipelineConfig) -> CliResult<()> {
     if !cfg.matrix.is_empty() {
         return Err(CliError::MatrixAndNodesBothPresent);
     }
-    // Exactly-once is not implemented for node graphs: there is no per-sink
-    // commit-token/watermark path here. The matrix path gates this combination in
-    // `expand`, which topology mode never runs — so without this check the run
-    // would silently execute at-least-once and duplicate on retry (#456 H2).
+    // Exactly-once in a node graph (#458). Each sink node commits under its own
+    // scope, so the requirements are the matrix ones applied per node — plus a
+    // single-source restriction, because nothing records which source a given
+    // sink's bookmark came from. Checked here, at config-load time, so an
+    // unsupported combination never runs *as if* it were exactly-once (#456 H2).
     if cfg.delivery == faucet_core::DeliveryMode::ExactlyOnce {
-        return Err(CliError::Config(
-            "`delivery: exactly_once` is not supported in topology mode (`pipeline.nodes`): a \
-             node graph has no atomic commit-token path, so the run would silently be \
-             at-least-once. Use the matrix form (`pipeline.source`/`sink` + `matrix:`) for \
-             exactly-once, or make the sinks idempotent with `write_mode: upsert` and set \
-             `delivery: at_least_once`"
-                .into(),
-        ));
+        validate_exactly_once(cfg)?;
     }
     let spec = &cfg.pipeline;
     let mut known: Vec<String> = spec.nodes.keys().cloned().collect();
@@ -138,6 +126,118 @@ pub fn validate_topology_spec(cfg: &PipelineConfig) -> CliResult<()> {
                 });
             }
         }
+    }
+    Ok(())
+}
+
+/// The connector kind a source/sink node resolves to, without building anything.
+///
+/// Mirrors [`resolve_connector`]'s kind precedence (inline `type` override, else
+/// the referenced template, else the legacy singular block) so the gate below and
+/// the builder can never disagree about what a node *is*.
+fn resolved_node_kind(cfg: &PipelineConfig, node: &NodeSpec) -> Option<String> {
+    let (template, kind, templates, legacy) = match node {
+        NodeSpec::Source { template, kind, .. } => {
+            (template, kind, &cfg.pipeline.sources, &cfg.pipeline.source)
+        }
+        NodeSpec::Sink { template, kind, .. } => {
+            (template, kind, &cfg.pipeline.sinks, &cfg.pipeline.sink)
+        }
+        _ => return None,
+    };
+    if let Some(k) = kind {
+        return Some(k.clone());
+    }
+    let name = template.as_deref().unwrap_or("default");
+    templates
+        .get(name)
+        .or(if name == "default" {
+            legacy.as_ref()
+        } else {
+            None
+        })
+        .map(|t| t.kind.clone())
+}
+
+/// The four atomic-watermark requirements, per node, plus the single-source rule.
+///
+/// Ordered so the message names the *limiting* side, and suggests the keyed-upsert
+/// alternative when the sinks could do it — the same shape as the matrix gate in
+/// `expand`, so an operator moving a pipeline between the two forms reads the same
+/// diagnosis.
+fn validate_exactly_once(cfg: &PipelineConfig) -> CliResult<()> {
+    let nodes = &cfg.pipeline.nodes;
+    let sources: Vec<(&String, String)> = nodes
+        .iter()
+        .filter(|(_, n)| matches!(n, NodeSpec::Source { .. }))
+        .map(|(id, n)| (id, resolved_node_kind(cfg, n).unwrap_or_default()))
+        .collect();
+    let sinks: Vec<(&String, String)> = nodes
+        .iter()
+        .filter(|(_, n)| matches!(n, NodeSpec::Sink { .. }))
+        .map(|(id, n)| (id, resolved_node_kind(cfg, n).unwrap_or_default()))
+        .collect();
+
+    // 1. One source. A sink's bookmark records the position of whichever source
+    //    fed its pages, and the graph does not record which one — so with several
+    //    sources there is no sound resume point to anchor the watermark against.
+    if sources.len() != 1 {
+        return Err(CliError::Config(format!(
+            "`delivery: exactly_once` needs exactly one source node; this graph has {}. A \
+             sink's commit watermark is only meaningful against a known source position, and \
+             nothing records which source fed a given page. Split the graph into one pipeline \
+             per source, or use `write_mode: upsert` + `key` on the sinks for keyed-upsert \
+             effectively-once with any number of sources",
+            sources.len()
+        )));
+    }
+    // 2. The source must replay deterministically.
+    let (src_id, src_kind) = &sources[0];
+    if !crate::registry::source_supports_exactly_once(src_kind) {
+        return Err(CliError::Config(format!(
+            "node '{src_id}': `delivery: exactly_once` is not supported by source '{src_kind}' \
+             (deterministic-replay sources only: {})",
+            crate::registry::EXACTLY_ONCE_SOURCE_KINDS.join(", ")
+        )));
+    }
+    // 3. Every sink must commit data + token atomically.
+    for (id, kind) in &sinks {
+        if !crate::registry::sink_supports_idempotent_writes(kind) {
+            return Err(CliError::Config(format!(
+                "node '{id}': `delivery: exactly_once` is not supported by sink '{kind}' \
+                 (sinks that commit a watermark atomically: {}). Every sink node must qualify — \
+                 each one keeps its own watermark",
+                crate::registry::IDEMPOTENT_SINK_KINDS.join(", ")
+            )));
+        }
+    }
+    // 4. Durable state — the per-node sequence has to survive a restart.
+    match cfg.pipeline.state.as_ref() {
+        None => {
+            return Err(CliError::Config(
+                "`delivery: exactly_once` requires a durable `state:` block: each sink node \
+                 persists its commit sequence there, and without it every restart would \
+                 re-commit from zero"
+                    .into(),
+            ));
+        }
+        Some(state) if state.kind == "memory" => {
+            return Err(CliError::Config(
+                "`delivery: exactly_once` requires a durable `state:` block, and `memory` does \
+                 not survive the process. Use `file`, `redis`, or `postgres`"
+                    .into(),
+            ));
+        }
+        Some(_) => {}
+    }
+    // 5. No DLQ — routing a row aside breaks the all-or-nothing page commit.
+    if cfg.pipeline.dlq.is_some() {
+        return Err(CliError::Config(
+            "`delivery: exactly_once` is incompatible with a `dlq:` block in this version: a \
+             page's rows and its commit token are written as one unit, so a partial page \
+             cannot be split off to a dead-letter queue"
+                .into(),
+        ));
     }
     Ok(())
 }
@@ -357,6 +457,9 @@ fn build_governance(cfg: &PipelineConfig) -> CliResult<TopologyGovernance> {
     if let Some(spec) = &cfg.resilience {
         g.resilience = Some(spec.to_policy()?);
     }
+    // Delivery guarantee (#458). `validate_topology_spec` has already checked the
+    // per-node requirements, so by here `exactly_once` is known to be supportable.
+    g.delivery = cfg.delivery;
 
     #[cfg(feature = "masking")]
     if let Some(spec) = &cfg.pipeline.masking {
@@ -492,7 +595,7 @@ pub async fn run_topology(
         _ => TopologyOnError::Continue,
     };
 
-    let mut opts = TopologyOptions::new(pipeline_name).with_on_error(on_error);
+    let mut opts = TopologyOptions::new(pipeline_name.clone()).with_on_error(on_error);
     opts.run_id = run_id;
 
     if let Some(state) = &cfg.pipeline.state {
@@ -516,30 +619,137 @@ pub async fn run_topology(
         opts = opts.with_cancel(c);
     }
 
-    let result = topo.run_with(opts, build_governance(cfg)?).await?;
+    // `run_reported` rather than `run_with`: the post-run pass below emits one
+    // notification and evaluates one SLA per **sink node**, which needs to know
+    // which node failed (#459).
+    let state_store = opts.state_store.clone();
+    let cancelled = run.cancel.as_ref().is_some_and(|c| c.is_cancelled());
+    let reported = topo.run_reported(opts, build_governance(cfg)?).await?;
 
-    let mut invocations: Vec<InvocationOutcome> = result
+    // Per-sink-node observability. A sink node is a topology's analogue of a
+    // matrix invocation — it owns a state key, a bookmark, and a record count —
+    // so the SLA and notification passes key off it, reusing the same standalone
+    // functions the executor calls rather than a parallel implementation.
+    if !run.is_preview() && !cancelled {
+        post_run_observability(cfg, &pipeline_name, &reported, state_store.as_ref()).await;
+    }
+
+    let mut invocations: Vec<InvocationOutcome> = reported
+        .result
         .per_sink
-        .into_iter()
+        .iter()
         .map(|(node_id, records)| InvocationOutcome {
-            row_id: node_id,
+            row_id: node_id.clone(),
             parent_record_key: None,
-            records_written: records,
+            records_written: *records,
             error: None,
             metrics: None,
         })
         .collect();
     invocations.sort_by(|a, b| a.row_id.cmp(&b.row_id));
 
-    for msg in result.errors {
+    // Failures, attributed to the node that produced them instead of a flat
+    // "topology" row (#459).
+    for n in reported.nodes.iter().filter(|n| n.error.is_some()) {
         invocations.push(InvocationOutcome {
-            row_id: "topology".to_string(),
+            row_id: n.node_id.clone(),
             parent_record_key: None,
             records_written: 0,
-            error: Some(msg),
+            error: n.error.clone(),
             metrics: None,
         });
     }
 
     Ok(RunSummary { invocations })
+}
+
+/// Freshness/volume SLAs and notifications, once per sink node.
+///
+/// Deliberately a thin adapter: `sla::evaluate_post_run` and the `NotifyEvent`
+/// constructors are already standalone, so topology mode calls exactly what the
+/// matrix executor calls. Neither can fail a run — an SLA violation is a signal
+/// and a notification is best-effort — so this returns nothing.
+async fn post_run_observability(
+    cfg: &PipelineConfig,
+    pipeline_name: &str,
+    reported: &faucet_core::topology::TopologyRun,
+    state_store: Option<&std::sync::Arc<dyn faucet_core::StateStore>>,
+) {
+    #[cfg(feature = "notify")]
+    let notifier = match crate::notify::Notifier::from_specs(&cfg.notifications) {
+        Ok(n) => n,
+        Err(e) => {
+            // A malformed block is a config error, but it must not fail a run that
+            // has already written its data.
+            tracing::error!(error = %e, "notifications config invalid; not notifying");
+            None
+        }
+    };
+    let now = chrono::Utc::now().timestamp();
+
+    for node in reported.nodes.iter().filter(|n| n.kind == "sink") {
+        let row = node.node_id.as_str();
+
+        // ── SLA (#202) ───────────────────────────────────────────────────────
+        let violations = match cfg.sla.as_ref() {
+            Some(spec) => {
+                let base_key = format!("{pipeline_name}::{row}");
+                let outcome = match &node.error {
+                    None => crate::sla::RunOutcome::Success {
+                        rows: node.records as u64,
+                    },
+                    Some(_) => crate::sla::RunOutcome::Failure,
+                };
+                let v = crate::sla::evaluate_post_run(
+                    spec,
+                    state_store,
+                    &base_key,
+                    pipeline_name,
+                    row,
+                    outcome,
+                    now,
+                )
+                .await;
+                for violation in &v {
+                    tracing::warn!(node = %row, kind = violation.kind(), "SLA violation: {violation}");
+                }
+                v
+            }
+            None => Vec::new(),
+        };
+
+        // ── Notifications (#280) ─────────────────────────────────────────────
+        #[cfg(feature = "notify")]
+        if let Some(notifier) = &notifier {
+            use crate::notify::NotifyEvent;
+            match &node.error {
+                None => {
+                    notifier
+                        .emit(NotifyEvent::run_success(
+                            pipeline_name,
+                            row,
+                            node.records as u64,
+                        ))
+                        .await;
+                }
+                Some(msg) => {
+                    notifier
+                        .emit(NotifyEvent::run_failure(pipeline_name, row, "sink", msg))
+                        .await;
+                }
+            }
+            for v in &violations {
+                notifier
+                    .emit(NotifyEvent::sla_breach(
+                        pipeline_name,
+                        row,
+                        v.kind(),
+                        v.to_string(),
+                    ))
+                    .await;
+            }
+        }
+        #[cfg(not(feature = "notify"))]
+        let _ = &violations;
+    }
 }

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -58,40 +58,23 @@ impl TopologyRunOptions {
     }
 }
 
-/// Config blocks that topology mode does not (yet) act on.
+/// Top-level blocks that topology mode parses but does **not** act on.
 ///
-/// Returned as `(block, consequence)` pairs so both `faucet validate` and the run
-/// path can say exactly what is inert and why it matters. Silence here was the
-/// original defect: a config could declare a policy, validate as "valid", and run
-/// with the policy doing nothing (#456 M2).
+/// Empty — every top-level block is now applied to a node graph: the per-page
+/// governance passes and `resilience:` per sink node (#456 C3), and `sla:` /
+/// `notifications:` / `lineage:` / `catalog:` per sink node in
+/// [`post_run_observability`] (#459).
+///
+/// The mechanism is kept deliberately. A declared-but-inert block is the worst
+/// kind of silence — the operator believes a guarantee is in force when nothing
+/// is enforcing it — so if a future block lands in matrix mode before topology
+/// mode, list it here and `faucet validate` will say so out loud rather than
+/// printing a clean bill of health.
 pub fn inert_blocks(cfg: &PipelineConfig) -> Vec<(&'static str, &'static str)> {
-    let mut out = Vec::new();
-    #[cfg(feature = "notify")]
-    if !cfg.notifications.is_empty() {
-        out.push((
-            "notifications",
-            "no alert is sent when the run fails or breaches an SLA",
-        ));
-    }
-    #[cfg(feature = "lineage")]
-    if cfg.lineage.is_some() {
-        out.push(("lineage", "no OpenLineage events are emitted"));
-    }
-    #[cfg(feature = "catalog")]
-    if cfg.catalog.is_some() {
-        out.push((
-            "catalog",
-            "no datasets, schemas, or lineage edges are recorded",
-        ));
-    }
-    if cfg.sla.is_some() {
-        out.push((
-            "sla",
-            "freshness and volume are not evaluated after the run",
-        ));
-    }
-    out
+    let _ = cfg;
+    Vec::new()
 }
+
 
 /// Config-level graph validation: the checks that need only the `nodes:` /
 /// `edges:` spec, no connectors. Run as a fail-fast prelude to
@@ -298,6 +281,34 @@ pub async fn build_topology(cfg: &PipelineConfig, auth: &AuthCatalog) -> CliResu
     build_topology_with(cfg, auth, &TopologyRunOptions::default()).await
 }
 
+/// Identity of one source/sink node, captured while the graph is built.
+///
+/// `dataset_uri` is a method on the *built* connector, and the graph is consumed
+/// by the run — so lineage and catalog need this recorded up front (#459).
+#[derive(Debug, Clone)]
+pub struct NodeIdentity {
+    /// Connector kind (`"csv"`, `"postgres"`, …).
+    pub kind: String,
+    /// Raw dataset URI, before canonicalization.
+    pub dataset_uri: String,
+    /// The node's resolved connector config, for `${now.*}` folding.
+    pub config: Value,
+}
+
+/// Per-node identities, keyed by node id. Only source and sink nodes appear.
+pub type NodeIdentities = std::collections::HashMap<String, NodeIdentity>;
+
+/// [`build_topology_with`] that also reports each source/sink node's identity.
+pub async fn build_topology_meta(
+    cfg: &PipelineConfig,
+    auth: &AuthCatalog,
+    opts: &TopologyRunOptions,
+) -> CliResult<(Topology, NodeIdentities)> {
+    let mut ids = NodeIdentities::new();
+    let topo = build_topology_inner(cfg, auth, opts, Some(&mut ids)).await?;
+    Ok((topo, ids))
+}
+
 /// Build a [`faucet_core::Topology`], honouring the run options.
 ///
 /// Two things happen here that the matrix path does per invocation in
@@ -313,6 +324,15 @@ pub async fn build_topology_with(
     cfg: &PipelineConfig,
     auth: &AuthCatalog,
     opts: &TopologyRunOptions,
+) -> CliResult<Topology> {
+    build_topology_inner(cfg, auth, opts, None).await
+}
+
+async fn build_topology_inner(
+    cfg: &PipelineConfig,
+    auth: &AuthCatalog,
+    opts: &TopologyRunOptions,
+    mut identities: Option<&mut NodeIdentities>,
 ) -> CliResult<Topology> {
     // Cheap graph checks first, so a wiring typo never costs a connector build.
     validate_topology_spec(cfg)?;
@@ -585,7 +605,7 @@ pub async fn run_topology(
         );
     }
 
-    let topo = build_topology_with(cfg, auth, &run).await?;
+    let (topo, identities) = build_topology_meta(cfg, auth, &run).await?;
 
     let pipeline_name = cfg.name.clone().unwrap_or_else(|| "unnamed".to_string());
     let run_id = uuid::Uuid::now_v7().to_string();
@@ -596,7 +616,7 @@ pub async fn run_topology(
     };
 
     let mut opts = TopologyOptions::new(pipeline_name.clone()).with_on_error(on_error);
-    opts.run_id = run_id;
+    opts.run_id = run_id.clone();
 
     if let Some(state) = &cfg.pipeline.state {
         let store = crate::state::build_state_store(state).await?;
@@ -619,6 +639,30 @@ pub async fn run_topology(
         opts = opts.with_cancel(c);
     }
 
+    // Lineage START, one per sink node — a topology's analogue of an invocation.
+    // Built before the run so a crash still leaves a START on record.
+    #[cfg(feature = "lineage")]
+    let lineage = crate::lineage_glue::build_emitter(cfg.lineage.as_ref())
+        .map_err(|e| CliError::Config(format!("lineage: {e}")))?;
+    #[cfg(feature = "lineage")]
+    let reaching_for_lineage = reaching_sources(cfg);
+    #[cfg(feature = "lineage")]
+    if let (Some(em), Some(lc)) = (lineage.as_ref(), cfg.lineage.as_ref()) {
+        for (node_id, _) in cfg
+            .pipeline
+            .nodes
+            .iter()
+            .filter(|(_, n)| matches!(n, NodeSpec::Sink { .. }))
+        {
+            if let Some(ctx) = lineage_ctx(
+                cfg, &pipeline_name, &run_id, node_id, &identities,
+                &reaching_for_lineage, lc, 0, None,
+            ) {
+                em.emit(faucet_lineage::EventType::Start, &ctx).await;
+            }
+        }
+    }
+
     // `run_reported` rather than `run_with`: the post-run pass below emits one
     // notification and evaluates one SLA per **sink node**, which needs to know
     // which node failed (#459).
@@ -631,7 +675,19 @@ pub async fn run_topology(
     // so the SLA and notification passes key off it, reusing the same standalone
     // functions the executor calls rather than a parallel implementation.
     if !run.is_preview() && !cancelled {
-        post_run_observability(cfg, &pipeline_name, &reported, state_store.as_ref()).await;
+        post_run_observability(
+            cfg,
+            &pipeline_name,
+            &reported,
+            state_store.as_ref(),
+            &identities,
+            &reaching_sources(cfg),
+            run.clock(),
+            &run_id,
+            #[cfg(feature = "lineage")]
+            lineage.as_ref(),
+        )
+        .await;
     }
 
     let mut invocations: Vec<InvocationOutcome> = reported
@@ -663,7 +719,107 @@ pub async fn run_topology(
     Ok(RunSummary { invocations })
 }
 
-/// Freshness/volume SLAs and notifications, once per sink node.
+
+
+/// Build the lineage context for one sink node: every source that reaches it as
+/// an input, the sink as the output.
+///
+/// `None` when the node has no identity or no reaching source — there is nothing
+/// truthful to emit in that case, and OpenLineage would rather have no event than
+/// one naming a dataset that does not exist.
+#[cfg(feature = "lineage")]
+#[allow(clippy::too_many_arguments)]
+fn lineage_ctx(
+    _cfg: &PipelineConfig,
+    pipeline_name: &str,
+    run_id: &str,
+    node_id: &str,
+    identities: &NodeIdentities,
+    reaching: &std::collections::HashMap<String, Vec<String>>,
+    lc: &faucet_lineage::LineageConfig,
+    records: u64,
+    error: Option<String>,
+) -> Option<faucet_lineage::RunLifecycle> {
+    let sink = identities.get(node_id)?;
+    let inputs: Vec<faucet_lineage::DatasetRef> = reaching
+        .get(node_id)?
+        .iter()
+        .filter_map(|src| {
+            let ident = identities.get(src)?;
+            Some(faucet_lineage::DatasetRef {
+                namespace: lc.namespace.clone(),
+                name: ident.dataset_uri.clone(),
+            })
+        })
+        .collect();
+    if inputs.is_empty() {
+        return None;
+    }
+    Some(faucet_lineage::RunLifecycle {
+        job_namespace: lc.namespace.clone(),
+        // One OpenLineage job per sink node, so a graph shows up as several
+        // related jobs rather than one opaque run.
+        job_name: format!("{pipeline_name}.{node_id}"),
+        run_id: run_id.to_string(),
+        parent: lc.parent_job.clone(),
+        inputs,
+        output: faucet_lineage::DatasetRef {
+            namespace: lc.namespace.clone(),
+            name: sink.dataset_uri.clone(),
+        },
+        started_at: chrono::Utc::now(),
+        finished_at: None,
+        records,
+        error,
+        input_schemas: Vec::new(),
+        output_schema: None,
+        // Derived from a single transform chain, which a graph's per-node chains
+        // are not — omitted rather than fabricated.
+        column_lineage: None,
+        source_code: None,
+    })
+}
+
+/// For each **sink** node, the source nodes that reach it, in deterministic order.
+///
+/// A linear or tee graph gives one source per sink; a merge or join gives several,
+/// which is why lineage and catalog model a list of inputs (#459). Pure reverse
+/// reachability over the declared edges — no connectors involved.
+pub fn reaching_sources(cfg: &PipelineConfig) -> std::collections::HashMap<String, Vec<String>> {
+    use std::collections::{HashMap, HashSet};
+    let mut rev: HashMap<&str, Vec<&str>> = HashMap::new();
+    for e in &cfg.pipeline.edges {
+        rev.entry(e.to.as_str()).or_default().push(e.from.as_str());
+    }
+    let is_source = |id: &str| matches!(cfg.pipeline.nodes.get(id), Some(NodeSpec::Source { .. }));
+
+    let mut out = HashMap::new();
+    for (id, node) in &cfg.pipeline.nodes {
+        if !matches!(node, NodeSpec::Sink { .. }) {
+            continue;
+        }
+        // Walk upstream; a DAG so a seen-set is enough to terminate.
+        let mut found: Vec<String> = Vec::new();
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut stack: Vec<&str> = rev.get(id.as_str()).cloned().unwrap_or_default();
+        while let Some(n) = stack.pop() {
+            if !seen.insert(n) {
+                continue;
+            }
+            if is_source(n) {
+                found.push(n.to_string());
+            }
+            if let Some(ups) = rev.get(n) {
+                stack.extend(ups.iter().copied());
+            }
+        }
+        found.sort();
+        out.insert(id.clone(), found);
+    }
+    out
+}
+
+/// Freshness/volume SLAs, notifications, lineage, and catalog — once per sink node.
 ///
 /// Deliberately a thin adapter: `sla::evaluate_post_run` and the `NotifyEvent`
 /// constructors are already standalone, so topology mode calls exactly what the
@@ -674,7 +830,25 @@ async fn post_run_observability(
     pipeline_name: &str,
     reported: &faucet_core::topology::TopologyRun,
     state_store: Option<&std::sync::Arc<dyn faucet_core::StateStore>>,
+    identities: &NodeIdentities,
+    reaching: &std::collections::HashMap<String, Vec<String>>,
+    clock: DateTime<FixedOffset>,
+    run_id: &str,
+    #[cfg(feature = "lineage")] lineage: Option<&std::sync::Arc<faucet_lineage::LineageEmitter>>,
 ) {
+    #[cfg(feature = "catalog")]
+    let catalog = match cfg.catalog.as_ref() {
+        Some(spec) => match crate::catalog::connect_from_spec(spec).await {
+            Ok(h) => Some(h),
+            Err(e) => {
+                // Recording is best-effort; a bad catalog URL must not retro-fail
+                // a run whose data is already written.
+                tracing::error!(error = %e, "catalog connect failed; not recording");
+                None
+            }
+        },
+        None => None,
+    };
     #[cfg(feature = "notify")]
     let notifier = match crate::notify::Notifier::from_specs(&cfg.notifications) {
         Ok(n) => n,
@@ -751,5 +925,346 @@ async fn post_run_observability(
         }
         #[cfg(not(feature = "notify"))]
         let _ = &violations;
+
+        // ── OpenLineage terminal event (#459) ────────────────────────────────
+        #[cfg(feature = "lineage")]
+        if let (Some(em), Some(lc)) = (lineage, cfg.lineage.as_ref())
+            && let Some(ctx) = lineage_ctx(
+                cfg,
+                pipeline_name,
+                run_id,
+                row,
+                identities,
+                reaching,
+                lc,
+                node.records as u64,
+                node.error.clone(),
+            )
+        {
+            let ev = match node.error {
+                None => faucet_lineage::EventType::Complete,
+                Some(_) => faucet_lineage::EventType::Fail,
+            };
+            em.emit(ev, &ctx).await;
+        }
+
+        // ── Data Movement Catalog (#279 / #459) ──────────────────────────────
+        // One record per sink node: every source that reaches it as an input,
+        // plus the sink itself. A successful node only — a failed one's partial
+        // volume is not a signal, matching the matrix path.
+        #[cfg(feature = "catalog")]
+        if node.error.is_none()
+            && let Some(handle) = catalog.as_ref()
+            && let Some(sink_id) = identities.get(row)
+        {
+            use crate::catalog::model::canonicalize_uri;
+            use crate::serve::history::catalog::{
+                CatalogUpdate, DatasetObservation, DatasetRole,
+            };
+
+            let sources: Vec<DatasetObservation> = reaching
+                .get(row)
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|src| {
+                    let ident = identities.get(src)?;
+                    Some(DatasetObservation {
+                        uri: canonicalize_uri(&ident.dataset_uri, &ident.config, clock),
+                        kind: ident.kind.clone(),
+                        role: DatasetRole::Source,
+                        // Each input reports what *it* read, so a merge's edge
+                        // volumes sum to the sink instead of repeating its total.
+                        records: reported
+                            .nodes
+                            .iter()
+                            .find(|n| &n.node_id == src)
+                            .map(|n| n.records as u64)
+                            .unwrap_or(0),
+                        schema: None,
+                    })
+                })
+                .collect();
+
+            if sources.is_empty() {
+                tracing::debug!(node = %row, "no source reaches this sink; nothing to catalog");
+            } else {
+                let update = CatalogUpdate {
+                    run_id: run_id.to_string(),
+                    pipeline: pipeline_name.to_string(),
+                    row: row.to_string(),
+                    recorded_at: chrono::Utc::now(),
+                    sources,
+                    sink: DatasetObservation {
+                        uri: canonicalize_uri(&sink_id.dataset_uri, &sink_id.config, clock),
+                        kind: sink_id.kind.clone(),
+                        role: DatasetRole::Sink,
+                        schema: None,
+                        records: node.records as u64,
+                    },
+                    // Column lineage is derived from a single transform chain; a
+                    // graph's per-node chains are not that, so it is left absent
+                    // rather than fabricated.
+                    column_lineage: None,
+                };
+                crate::catalog::record(handle, &update).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(yaml: &str) -> PipelineConfig {
+        serde_yaml::from_str(yaml).expect("valid config")
+    }
+
+    #[cfg(feature = "lineage")]
+    fn lineage_cfg() -> faucet_lineage::LineageConfig {
+        serde_json::from_value(serde_json::json!({
+            "namespace": "ns",
+            "transport": { "type": "file", "config": { "path": "/tmp/ol.jsonl" } },
+        }))
+        .expect("valid lineage config")
+    }
+
+    const LINEAR: &str = r#"version: 1
+name: p
+pipeline:
+  sources:
+    a: { type: csv, config: { path: /tmp/a.csv } }
+  sinks:
+    o: { type: jsonl, config: { path: /tmp/o.jsonl } }
+  nodes:
+    s: { kind: source, ref: a }
+    w: { kind: sink, ref: o }
+  edges:
+    - { from: s, to: w }
+"#;
+
+    /// The invariant #459 exists to hold: nothing is parsed-but-ignored, so
+    /// `validate` has nothing to warn about. If this fails because a block was
+    /// added to the list, wire the block instead of updating the assertion.
+    #[test]
+    fn no_block_is_inert() {
+        let mut c = cfg(LINEAR);
+        c.sla = Some(
+            serde_json::from_value(serde_json::json!({ "max_staleness_secs": 60 })).unwrap(),
+        );
+        assert!(inert_blocks(&c).is_empty());
+    }
+
+    /// Kind precedence: an inline `type` on the node wins over its template, so
+    /// the exactly-once gate classifies the connector the run will actually build.
+    #[test]
+    fn resolved_kind_prefers_inline_type_over_template() {
+        let c = cfg(
+            r#"version: 1
+name: p
+pipeline:
+  sinks:
+    o: { type: jsonl, config: { path: /tmp/o.jsonl } }
+  nodes:
+    s: { kind: source, type: csv, config: { path: /tmp/a.csv } }
+    w: { kind: sink, ref: o, type: stdout, config: {} }
+  edges:
+    - { from: s, to: w }
+"#,
+        );
+        assert_eq!(
+            resolved_node_kind(&c, &c.pipeline.nodes["w"]).as_deref(),
+            Some("stdout")
+        );
+        assert_eq!(
+            resolved_node_kind(&c, &c.pipeline.nodes["s"]).as_deref(),
+            Some("csv")
+        );
+    }
+
+    /// A non-connector node has no kind — the gate must skip it rather than
+    /// treating an empty string as an unsupported connector.
+    #[test]
+    fn resolved_kind_is_none_for_a_structural_node() {
+        let c = cfg(
+            r#"version: 1
+name: p
+pipeline:
+  sources:
+    a: { type: csv, config: { path: /tmp/a.csv } }
+  sinks:
+    o: { type: jsonl, config: { path: /tmp/o.jsonl } }
+  nodes:
+    s: { kind: source, ref: a }
+    f: { kind: tee, fanout: 1 }
+    w: { kind: sink, ref: o }
+  edges:
+    - { from: s, to: f }
+    - { from: f, to: w }
+"#,
+        );
+        assert!(resolved_node_kind(&c, &c.pipeline.nodes["f"]).is_none());
+    }
+
+    /// A sink with no reaching source produces no lineage event. Emitting one
+    /// would name an input dataset the run never read.
+    #[cfg(feature = "lineage")]
+    #[test]
+    fn lineage_ctx_is_none_without_a_reaching_source() {
+        let c = cfg(LINEAR);
+        let mut identities = NodeIdentities::new();
+        identities.insert(
+            "w".to_string(),
+            NodeIdentity {
+                kind: "jsonl".into(),
+                dataset_uri: "file:///tmp/o.jsonl".into(),
+                config: Value::Null,
+            },
+        );
+        let lc = lineage_cfg();
+        // `reaching` deliberately empty: the sink is in the graph but no source
+        // reaches it.
+        let ctx = lineage_ctx(
+            &c,
+            "p",
+            "run-1",
+            "w",
+            &identities,
+            &std::collections::HashMap::new(),
+            &lc,
+            0,
+            None,
+        );
+        assert!(ctx.is_none());
+    }
+
+    /// A merge sink's event carries every reaching source as an input, and
+    /// deliberately no column lineage — the per-column derivation is not knowable
+    /// from the graph, so it is omitted rather than guessed.
+    #[cfg(feature = "lineage")]
+    #[test]
+    fn lineage_ctx_carries_all_inputs_and_no_column_lineage() {
+        let c = cfg(LINEAR);
+        let mut identities = NodeIdentities::new();
+        for (id, uri) in [
+            ("sa", "file:///tmp/a.csv"),
+            ("sb", "file:///tmp/b.csv"),
+            ("w", "file:///tmp/o.jsonl"),
+        ] {
+            identities.insert(
+                id.to_string(),
+                NodeIdentity {
+                    kind: "csv".into(),
+                    dataset_uri: uri.into(),
+                    config: Value::Null,
+                },
+            );
+        }
+        let lc = lineage_cfg();
+        let reaching = std::collections::HashMap::from([(
+            "w".to_string(),
+            vec!["sa".to_string(), "sb".to_string()],
+        )]);
+        let ctx = lineage_ctx(&c, "p", "run-1", "w", &identities, &reaching, &lc, 7, None)
+            .expect("both sources known");
+        assert_eq!(ctx.job_name, "p.w");
+        assert_eq!(
+            ctx.inputs.iter().map(|d| d.name.as_str()).collect::<Vec<_>>(),
+            vec!["file:///tmp/a.csv", "file:///tmp/b.csv"]
+        );
+        assert_eq!(ctx.output.name, "file:///tmp/o.jsonl");
+        assert_eq!(ctx.records, 7);
+        assert!(ctx.column_lineage.is_none());
+    }
+
+    /// An input whose identity was never recorded is dropped, not rendered as an
+    /// empty dataset name.
+    #[cfg(feature = "lineage")]
+    #[test]
+    fn lineage_ctx_skips_an_unknown_input() {
+        let c = cfg(LINEAR);
+        let mut identities = NodeIdentities::new();
+        for (id, uri) in [("sa", "file:///tmp/a.csv"), ("w", "file:///tmp/o.jsonl")] {
+            identities.insert(
+                id.to_string(),
+                NodeIdentity {
+                    kind: "csv".into(),
+                    dataset_uri: uri.into(),
+                    config: Value::Null,
+                },
+            );
+        }
+        let lc = lineage_cfg();
+        let reaching = std::collections::HashMap::from([(
+            "w".to_string(),
+            vec!["sa".to_string(), "ghost".to_string()],
+        )]);
+        let ctx = lineage_ctx(&c, "p", "run-1", "w", &identities, &reaching, &lc, 1, None)
+            .expect("one known source is enough");
+        assert_eq!(ctx.inputs.len(), 1);
+    }
+
+    /// `reaching_sources` walks through structural nodes, so a join's two labelled
+    /// inputs both surface on the downstream sink.
+    #[test]
+    fn reaching_sources_traverses_a_join() {
+        let c = cfg(
+            r#"version: 1
+name: p
+pipeline:
+  sources:
+    a: { type: csv, config: { path: /tmp/a.csv } }
+    b: { type: csv, config: { path: /tmp/b.csv } }
+  sinks:
+    o: { type: jsonl, config: { path: /tmp/o.jsonl } }
+  nodes:
+    probe: { kind: source, ref: a }
+    build: { kind: source, ref: b }
+    j:
+      kind: join
+      mode: left
+      build: { edge: build_in, key: id }
+      probe: { edge: probe_in, key: id }
+    w: { kind: sink, ref: o }
+  edges:
+    - { from: probe, to: j, as: probe_in }
+    - { from: build, to: j, as: build_in }
+    - { from: j, to: w }
+"#,
+        );
+        let reaching = reaching_sources(&c);
+        assert_eq!(
+            reaching["w"],
+            vec!["build".to_string(), "probe".to_string()]
+        );
+    }
+
+    /// A cyclic edge set must not hang the traversal. Cycles are rejected by
+    /// graph validation, but this helper also runs from `validate`, so it has to
+    /// terminate on a config that has not been validated yet.
+    #[test]
+    fn reaching_sources_terminates_on_a_cycle() {
+        let c = cfg(
+            r#"version: 1
+name: p
+pipeline:
+  sources:
+    a: { type: csv, config: { path: /tmp/a.csv } }
+  sinks:
+    o: { type: jsonl, config: { path: /tmp/o.jsonl } }
+  nodes:
+    s: { kind: source, ref: a }
+    t1: { kind: transform, transforms: [ { type: flatten, config: {} } ] }
+    t2: { kind: transform, transforms: [ { type: flatten, config: {} } ] }
+    w: { kind: sink, ref: o }
+  edges:
+    - { from: s, to: t1 }
+    - { from: t1, to: t2 }
+    - { from: t2, to: t1 }
+    - { from: t2, to: w }
+"#,
+        );
+        assert_eq!(reaching_sources(&c)["w"], vec!["s".to_string()]);
     }
 }

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -63,7 +63,7 @@ impl TopologyRunOptions {
 /// Empty — every top-level block is now applied to a node graph: the per-page
 /// governance passes and `resilience:` per sink node (#456 C3), and `sla:` /
 /// `notifications:` / `lineage:` / `catalog:` per sink node in
-/// [`post_run_observability`] (#459).
+/// `post_run_observability` (#459).
 ///
 /// The mechanism is kept deliberately. A declared-but-inert block is the worst
 /// kind of silence — the operator believes a guarantee is in force when nothing

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -295,6 +295,41 @@ pub struct NodeIdentity {
     pub config: Value,
 }
 
+/// Record one connector node's identity, when a caller asked for the map.
+///
+/// Skipped when the caller wants no map, or when the connector does not override
+/// `dataset_uri()` — the `<kind>://unknown` default names nothing joinable, and
+/// recording it would put a placeholder dataset in the catalog and in every
+/// OpenLineage event.
+fn record_identity(
+    identities: &mut Option<&mut NodeIdentities>,
+    node_id: &str,
+    kind: &str,
+    config: Value,
+    dataset_uri: String,
+) {
+    let Some(map) = identities.as_mut() else {
+        return;
+    };
+    if dataset_uri.ends_with("://unknown") {
+        tracing::debug!(
+            node = %node_id,
+            kind = %kind,
+            "topology: connector does not expose a dataset_uri; omitted from lineage/catalog"
+        );
+        return;
+    }
+    let uri = dataset_uri;
+    map.insert(
+        node_id.to_string(),
+        NodeIdentity {
+            kind: kind.to_string(),
+            dataset_uri: uri,
+            config,
+        },
+    );
+}
+
 /// Per-node identities, keyed by node id. Only source and sink nodes appear.
 pub type NodeIdentities = std::collections::HashMap<String, NodeIdentity>;
 
@@ -364,7 +399,9 @@ async fn build_topology_inner(
                 )?;
                 crate::executor::resolve_now_inplace(&mut c, clock)?;
                 crate::executor::reject_unresolved_backfill_tokens(&c, "source")?;
-                NodeKind::Source(build_source(&k, c, auth, None).await?)
+                let source = build_source(&k, c.clone(), auth, None).await?;
+                record_identity(&mut identities, id, &k, c, source.dataset_uri());
+                NodeKind::Source(source)
             }
             NodeSpec::Sink {
                 template,
@@ -382,11 +419,19 @@ async fn build_topology_inner(
                 )?;
                 crate::executor::resolve_now_inplace(&mut c, clock)?;
                 crate::executor::reject_unresolved_backfill_tokens(&c, "sink")?;
-                // Preview modes must never reach the real destination.
+                // Preview modes must never reach the real destination. The
+                // identity is still recorded from the *real* config, so a
+                // `--dry-run` report names the destination it would have
+                // written rather than the counting stand-in.
                 let sink: Box<dyn faucet_core::Sink> = if opts.dry_run {
+                    if let Ok(probe) = build_sink(&k, c.clone(), auth).await {
+                        record_identity(&mut identities, id, &k, c.clone(), probe.dataset_uri());
+                    }
                     Box::new(crate::executor::CountingSink::new())
                 } else {
-                    build_sink(&k, c, auth).await?
+                    let sink = build_sink(&k, c.clone(), auth).await?;
+                    record_identity(&mut identities, id, &k, c, sink.dataset_uri());
+                    sink
                 };
                 let sink = match opts.limit {
                     Some(n) => Box::new(crate::executor::LimitedSink::wrap(sink, n)) as Box<_>,
@@ -677,15 +722,17 @@ pub async fn run_topology(
     if !run.is_preview() && !cancelled {
         post_run_observability(
             cfg,
-            &pipeline_name,
-            &reported,
-            state_store.as_ref(),
-            &identities,
-            &reaching_sources(cfg),
-            run.clock(),
-            &run_id,
-            #[cfg(feature = "lineage")]
-            lineage.as_ref(),
+            PostRun {
+                pipeline_name: &pipeline_name,
+                reported: &reported,
+                state_store: state_store.as_ref(),
+                identities: &identities,
+                reaching: &reaching_sources(cfg),
+                clock: run.clock(),
+                run_id: &run_id,
+                #[cfg(feature = "lineage")]
+                lineage: lineage.as_ref(),
+            },
         )
         .await;
     }
@@ -825,17 +872,30 @@ pub fn reaching_sources(cfg: &PipelineConfig) -> std::collections::HashMap<Strin
 /// constructors are already standalone, so topology mode calls exactly what the
 /// matrix executor calls. Neither can fail a run — an SLA violation is a signal
 /// and a notification is best-effort — so this returns nothing.
-async fn post_run_observability(
-    cfg: &PipelineConfig,
-    pipeline_name: &str,
-    reported: &faucet_core::topology::TopologyRun,
-    state_store: Option<&std::sync::Arc<dyn faucet_core::StateStore>>,
-    identities: &NodeIdentities,
-    reaching: &std::collections::HashMap<String, Vec<String>>,
+struct PostRun<'a> {
+    pipeline_name: &'a str,
+    reported: &'a faucet_core::topology::TopologyRun,
+    state_store: Option<&'a std::sync::Arc<dyn faucet_core::StateStore>>,
+    identities: &'a NodeIdentities,
+    reaching: &'a std::collections::HashMap<String, Vec<String>>,
     clock: DateTime<FixedOffset>,
-    run_id: &str,
-    #[cfg(feature = "lineage")] lineage: Option<&std::sync::Arc<faucet_lineage::LineageEmitter>>,
-) {
+    run_id: &'a str,
+    #[cfg(feature = "lineage")]
+    lineage: Option<&'a std::sync::Arc<faucet_lineage::LineageEmitter>>,
+}
+
+async fn post_run_observability(cfg: &PipelineConfig, ctx: PostRun<'_>) {
+    let PostRun {
+        pipeline_name,
+        reported,
+        state_store,
+        identities,
+        reaching,
+        clock,
+        run_id,
+        #[cfg(feature = "lineage")]
+        lineage,
+    } = ctx;
     #[cfg(feature = "catalog")]
     let catalog = match cfg.catalog.as_ref() {
         Some(spec) => match crate::catalog::connect_from_spec(spec).await {

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -75,7 +75,6 @@ pub fn inert_blocks(cfg: &PipelineConfig) -> Vec<(&'static str, &'static str)> {
     Vec::new()
 }
 
-
 /// Config-level graph validation: the checks that need only the `nodes:` /
 /// `edges:` spec, no connectors. Run as a fail-fast prelude to
 /// [`build_topology`] (so a wiring typo is reported before any client is
@@ -700,8 +699,15 @@ pub async fn run_topology(
             .filter(|(_, n)| matches!(n, NodeSpec::Sink { .. }))
         {
             if let Some(ctx) = lineage_ctx(
-                cfg, &pipeline_name, &run_id, node_id, &identities,
-                &reaching_for_lineage, lc, 0, None,
+                cfg,
+                &pipeline_name,
+                &run_id,
+                node_id,
+                &identities,
+                &reaching_for_lineage,
+                lc,
+                0,
+                None,
             ) {
                 em.emit(faucet_lineage::EventType::Start, &ctx).await;
             }
@@ -765,8 +771,6 @@ pub async fn run_topology(
 
     Ok(RunSummary { invocations })
 }
-
-
 
 /// Build the lineage context for one sink node: every source that reaches it as
 /// an input, the sink as the output.
@@ -1018,9 +1022,7 @@ async fn post_run_observability(cfg: &PipelineConfig, ctx: PostRun<'_>) {
             && let Some(sink_id) = identities.get(row)
         {
             use crate::catalog::model::canonicalize_uri;
-            use crate::serve::history::catalog::{
-                CatalogUpdate, DatasetObservation, DatasetRole,
-            };
+            use crate::serve::history::catalog::{CatalogUpdate, DatasetObservation, DatasetRole};
 
             let sources: Vec<DatasetObservation> = reaching
                 .get(row)
@@ -1110,9 +1112,8 @@ pipeline:
     #[test]
     fn no_block_is_inert() {
         let mut c = cfg(LINEAR);
-        c.sla = Some(
-            serde_json::from_value(serde_json::json!({ "max_staleness_secs": 60 })).unwrap(),
-        );
+        c.sla =
+            Some(serde_json::from_value(serde_json::json!({ "max_staleness_secs": 60 })).unwrap());
         assert!(inert_blocks(&c).is_empty());
     }
 
@@ -1120,8 +1121,7 @@ pipeline:
     /// the exactly-once gate classifies the connector the run will actually build.
     #[test]
     fn resolved_kind_prefers_inline_type_over_template() {
-        let c = cfg(
-            r#"version: 1
+        let c = cfg(r#"version: 1
 name: p
 pipeline:
   sinks:
@@ -1131,8 +1131,7 @@ pipeline:
     w: { kind: sink, ref: o, type: stdout, config: {} }
   edges:
     - { from: s, to: w }
-"#,
-        );
+"#);
         assert_eq!(
             resolved_node_kind(&c, &c.pipeline.nodes["w"]).as_deref(),
             Some("stdout")
@@ -1147,8 +1146,7 @@ pipeline:
     /// treating an empty string as an unsupported connector.
     #[test]
     fn resolved_kind_is_none_for_a_structural_node() {
-        let c = cfg(
-            r#"version: 1
+        let c = cfg(r#"version: 1
 name: p
 pipeline:
   sources:
@@ -1162,8 +1160,7 @@ pipeline:
   edges:
     - { from: s, to: f }
     - { from: f, to: w }
-"#,
-        );
+"#);
         assert!(resolved_node_kind(&c, &c.pipeline.nodes["f"]).is_none());
     }
 
@@ -1230,7 +1227,10 @@ pipeline:
             .expect("both sources known");
         assert_eq!(ctx.job_name, "p.w");
         assert_eq!(
-            ctx.inputs.iter().map(|d| d.name.as_str()).collect::<Vec<_>>(),
+            ctx.inputs
+                .iter()
+                .map(|d| d.name.as_str())
+                .collect::<Vec<_>>(),
             vec!["file:///tmp/a.csv", "file:///tmp/b.csv"]
         );
         assert_eq!(ctx.output.name, "file:///tmp/o.jsonl");
@@ -1269,8 +1269,7 @@ pipeline:
     /// inputs both surface on the downstream sink.
     #[test]
     fn reaching_sources_traverses_a_join() {
-        let c = cfg(
-            r#"version: 1
+        let c = cfg(r#"version: 1
 name: p
 pipeline:
   sources:
@@ -1291,8 +1290,7 @@ pipeline:
     - { from: probe, to: j, as: probe_in }
     - { from: build, to: j, as: build_in }
     - { from: j, to: w }
-"#,
-        );
+"#);
         let reaching = reaching_sources(&c);
         assert_eq!(
             reaching["w"],
@@ -1305,8 +1303,7 @@ pipeline:
     /// terminate on a config that has not been validated yet.
     #[test]
     fn reaching_sources_terminates_on_a_cycle() {
-        let c = cfg(
-            r#"version: 1
+        let c = cfg(r#"version: 1
 name: p
 pipeline:
   sources:
@@ -1323,8 +1320,7 @@ pipeline:
     - { from: t1, to: t2 }
     - { from: t2, to: t1 }
     - { from: t2, to: w }
-"#,
-        );
+"#);
         assert_eq!(reaching_sources(&c)["w"], vec!["s".to_string()]);
     }
 }

--- a/cli/tests/topology_end_to_end.rs
+++ b/cli/tests/topology_end_to_end.rs
@@ -845,10 +845,12 @@ pipeline:
     );
 }
 
-/// #456 M2: blocks topology mode does not act on must be called out, not
-/// silently swallowed behind a "valid" line.
+/// #456 M2 + #459: `validate` must never print a clean bill of health for a
+/// block it does not enforce. Every top-level block is applied per sink node
+/// now, so the assertion inverts: none of them may be reported as ignored.
 #[test]
-fn validate_warns_about_blocks_topology_ignores() {
+#[cfg(feature = "lineage")]
+fn validate_reports_no_ignored_blocks() {
     let dir = TempDir::new().unwrap();
     let csv = orders_csv(dir.path());
     let cfg_path = dir.path().join("faucet.yaml");
@@ -859,7 +861,11 @@ fn validate_warns_about_blocks_topology_ignores() {
 name: inert
 sla:
   max_staleness_secs: 3600
+lineage:
+  namespace: test
+  transport: {{ type: file, config: {{ path: {ln} }} }}
 pipeline:
+  state: {{ type: file, config: {{ path: {st} }} }}
   sources:
     o: {{ type: csv, config: {{ path: {csv} }} }}
   sinks:
@@ -870,16 +876,21 @@ pipeline:
   edges:
     - {{ from: s, to: w }}
 "#,
-            csv = csv.display()
+            csv = csv.display(),
+            ln = dir.path().join("lineage.jsonl").display(),
+            st = dir.path().join("state").display()
         ),
     );
-    Command::cargo_bin("faucet")
+    let out = Command::cargo_bin("faucet")
         .unwrap()
         .args(["validate", cfg_path.to_str().unwrap()])
         .assert()
-        .success()
-        .stdout(contains("WARNING"))
-        .stdout(contains("sla"));
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    assert!(
+        !stdout.contains("is ignored"),
+        "no block may be reported inert: {stdout}"
+    );
 }
 
 // ── #458 / #459: exactly-once + per-sink-node observability ─────────────────
@@ -1007,5 +1018,111 @@ pipeline:
     assert!(
         !stdout.contains("`resilience:` is ignored"),
         "resilience is wired; must not be reported as ignored: {stdout}"
+    );
+}
+
+/// #459: a sink's inputs are every source that reaches it — one for a linear or
+/// tee graph, several for a merge/join. This is what lineage and the catalog now
+/// model, so the traversal is asserted directly.
+#[test]
+fn reaching_sources_maps_each_sink_to_its_inputs() {
+    let cfg = parse(
+        r#"version: 1
+name: reach
+pipeline:
+  sources:
+    a: { type: csv, config: { path: /tmp/a.csv } }
+    b: { type: csv, config: { path: /tmp/b.csv } }
+  sinks:
+    one: { type: jsonl, config: { path: /tmp/1.jsonl } }
+    two: { type: jsonl, config: { path: /tmp/2.jsonl } }
+  nodes:
+    sa: { kind: source, ref: a }
+    sb: { kind: source, ref: b }
+    m: { kind: merge }
+    fan: { kind: tee, fanout: 2 }
+    w1: { kind: sink, ref: one }
+    w2: { kind: sink, ref: two }
+  edges:
+    - { from: sa, to: m }
+    - { from: sb, to: m }
+    - { from: m, to: fan }
+    - { from: fan, to: w1 }
+    - { from: fan, to: w2 }
+"#,
+    );
+    let reaching = faucet_cli::topology::reaching_sources(&cfg);
+    // Both sinks sit downstream of the merge, so both have two inputs.
+    assert_eq!(reaching["w1"], vec!["sa".to_string(), "sb".to_string()]);
+    assert_eq!(reaching["w2"], vec!["sa".to_string(), "sb".to_string()]);
+    // Only sink nodes are keyed.
+    assert!(!reaching.contains_key("m"));
+    assert!(!reaching.contains_key("sa"));
+}
+
+/// A linear graph gives exactly one input per sink — the shape every matrix
+/// pipeline has, and the one where column lineage stays expressible.
+#[test]
+fn reaching_sources_is_one_input_for_a_linear_graph() {
+    let cfg = parse(
+        r#"version: 1
+name: linear
+pipeline:
+  sources:
+    a: { type: csv, config: { path: /tmp/a.csv } }
+  sinks:
+    one: { type: jsonl, config: { path: /tmp/1.jsonl } }
+  nodes:
+    s: { kind: source, ref: a }
+    t: { kind: transform, transforms: [ { type: keys_case, config: { mode: snake } } ] }
+    w: { kind: sink, ref: one }
+  edges:
+    - { from: s, to: t }
+    - { from: t, to: w }
+"#,
+    );
+    let reaching = faucet_cli::topology::reaching_sources(&cfg);
+    assert_eq!(reaching["w"], vec!["s".to_string()]);
+}
+
+/// #459: with catalog and SLA wired, `validate` must no longer report them as
+/// ignored — only genuinely-unwired blocks may appear.
+#[test]
+fn validate_no_longer_claims_sla_is_ignored() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: inert2
+sla:
+  max_staleness_secs: 3600
+pipeline:
+  state: {{ type: file, config: {{ path: {st} }} }}
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: stdout, config: {{}} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            st = dir.path().join("state").display()
+        ),
+    );
+    let out = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate", cfg_path.to_str().unwrap()])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    assert!(
+        !stdout.contains("`sla:` is ignored"),
+        "sla is wired per sink node now: {stdout}"
     );
 }

--- a/cli/tests/topology_end_to_end.rs
+++ b/cli/tests/topology_end_to_end.rs
@@ -764,8 +764,10 @@ pipeline:
     );
 }
 
-/// #456 H2: `delivery: exactly_once` has no watermark path in a node graph, so
-/// it must be rejected rather than silently downgraded to at-least-once.
+/// #456 H2: an exactly-once config that cannot be honoured must be rejected
+/// rather than silently downgraded to at-least-once. (Since #458 topology mode
+/// *does* support exactly-once — this asserts the refusal path still holds when a
+/// requirement is unmet.)
 #[tokio::test]
 async fn rejects_exactly_once_in_topology_mode() {
     let cfg = parse(
@@ -787,8 +789,12 @@ pipeline:
     let auth = build_auth_catalog(None).unwrap();
     let err = build_topology(&cfg, &auth).await.unwrap_err();
     let msg = err.to_string();
+    // The invariant #456 H2 is about: an unsupportable exactly-once config is
+    // *refused*, never silently downgraded to at-least-once. Since #458 the
+    // refusal is per-node and names the limiting side (here the csv source)
+    // instead of rejecting topology mode wholesale.
     assert!(msg.contains("exactly_once"), "{msg}");
-    assert!(msg.contains("topology mode"), "{msg}");
+    assert!(msg.contains("csv"), "names what is limiting: {msg}");
 }
 
 /// #456 H4: `${now.*}` was never resolved in topology mode, so the literal token
@@ -874,4 +880,132 @@ pipeline:
         .success()
         .stdout(contains("WARNING"))
         .stdout(contains("sla"));
+}
+
+// ── #458 / #459: exactly-once + per-sink-node observability ─────────────────
+
+/// #458: the four atomic-watermark requirements are checked per node at
+/// config-load time. The message must name the *limiting* side.
+#[tokio::test]
+async fn exactly_once_gate_names_the_limiting_side() {
+    // A non-deterministic source: csv cannot replay positionally.
+    let cfg = parse(
+        r#"version: 1
+name: eo
+delivery: exactly_once
+pipeline:
+  state: { type: file, config: { path: ./st } }
+  sources:
+    o: { type: csv, config: { path: /tmp/x.csv } }
+  sinks:
+    out: { type: sqlite, config: { connection_url: "sqlite::memory:", table: t } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err().to_string();
+    assert!(err.contains("csv"), "names the source: {err}");
+    assert!(err.contains("deterministic-replay"), "{err}");
+}
+
+/// A memory state store cannot carry a commit sequence across a restart.
+#[tokio::test]
+async fn exactly_once_requires_durable_state() {
+    let cfg = parse(
+        r#"version: 1
+name: eo
+delivery: exactly_once
+pipeline:
+  state: { type: memory, config: {} }
+  sources:
+    o: { type: postgres-cdc, config: { connection_url: "postgres://x/y", slot: s, publication: p } }
+  sinks:
+    out: { type: sqlite, config: { connection_url: "sqlite::memory:", table: t } }
+  nodes:
+    s: { kind: source, ref: o }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: s, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err().to_string();
+    assert!(err.contains("memory"), "{err}");
+    assert!(err.contains("durable"), "{err}");
+}
+
+/// Several sources means no sound resume anchor for a watermark, so the gate
+/// refuses and points at the keyed-upsert alternative.
+#[tokio::test]
+async fn exactly_once_refuses_a_multi_source_graph() {
+    let cfg = parse(
+        r#"version: 1
+name: eo
+delivery: exactly_once
+pipeline:
+  state: { type: file, config: { path: ./st } }
+  sources:
+    a: { type: postgres-cdc, config: { connection_url: "postgres://x/y", slot: s1, publication: p } }
+    b: { type: postgres-cdc, config: { connection_url: "postgres://x/y", slot: s2, publication: p } }
+  sinks:
+    out: { type: sqlite, config: { connection_url: "sqlite::memory:", table: t } }
+  nodes:
+    sa: { kind: source, ref: a }
+    sb: { kind: source, ref: b }
+    m: { kind: merge }
+    w: { kind: sink, ref: out }
+  edges:
+    - { from: sa, to: m }
+    - { from: sb, to: m }
+    - { from: m, to: w }
+"#,
+    );
+    let auth = build_auth_catalog(None).unwrap();
+    let err = build_topology(&cfg, &auth).await.unwrap_err().to_string();
+    assert!(err.contains("exactly one source node"), "{err}");
+    assert!(err.contains("upsert"), "offers the alternative: {err}");
+}
+
+/// #459: `resilience:` IS applied in topology mode (it rides the governance set),
+/// so it must not be listed as ignored — the earlier warning was wrong.
+#[test]
+fn validate_does_not_claim_resilience_is_ignored() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: resil
+resilience:
+  retry: {{ max_attempts: 3 }}
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: stdout, config: {{}} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display()
+        ),
+    );
+    let out = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate", cfg_path.to_str().unwrap()])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&out.get_output().stdout).to_string();
+    assert!(
+        !stdout.contains("`resilience:` is ignored"),
+        "resilience is wired; must not be reported as ignored: {stdout}"
+    );
 }

--- a/cli/tests/topology_end_to_end.rs
+++ b/cli/tests/topology_end_to_end.rs
@@ -1378,7 +1378,10 @@ pipeline:
     assert_eq!(edges.len(), 2, "one edge per contributing source: {detail}");
     for e in edges {
         assert!(
-            e["dst_uri"].as_str().unwrap_or_default().ends_with("out.jsonl"),
+            e["dst_uri"]
+                .as_str()
+                .unwrap_or_default()
+                .ends_with("out.jsonl"),
             "both edges land on the sink: {e}"
         );
     }

--- a/cli/tests/topology_end_to_end.rs
+++ b/cli/tests/topology_end_to_end.rs
@@ -1126,3 +1126,270 @@ pipeline:
         "sla is wired per sink node now: {stdout}"
     );
 }
+
+/// #459: a merge sink's OpenLineage job must name **both** sources as inputs.
+///
+/// This is the end-to-end proof, not a unit check of the context builder: it runs
+/// a real two-source graph with a file transport and reads the emitted events
+/// back. An earlier revision threaded node identities through the builder but
+/// never populated them, so every event was silently suppressed — a test that
+/// only asserted "the run succeeded" could not tell the difference.
+#[test]
+#[cfg(feature = "lineage")]
+fn lineage_emits_a_job_per_sink_node_with_every_reaching_source() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.csv");
+    let b = dir.path().join("b.csv");
+    write(&a, "id,v\n1,x\n2,y\n");
+    write(&b, "id,v\n3,z\n");
+    let out = dir.path().join("out.jsonl");
+    let events = dir.path().join("lineage.jsonl");
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: merged
+lineage:
+  namespace: test-ns
+  transport: {{ type: file, config: {{ path: {ev} }} }}
+pipeline:
+  sources:
+    a: {{ type: csv, config: {{ path: {a} }} }}
+    b: {{ type: csv, config: {{ path: {b} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    sa: {{ kind: source, ref: a }}
+    sb: {{ kind: source, ref: b }}
+    m: {{ kind: merge }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: sa, to: m }}
+    - {{ from: sb, to: m }}
+    - {{ from: m, to: w }}
+"#,
+            a = a.display(),
+            b = b.display(),
+            out = out.display(),
+            ev = events.display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", cfg_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let body = fs::read_to_string(&events).expect("lineage transport wrote events");
+    let evs: Vec<serde_json::Value> = body
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each line is one RunEvent"))
+        .collect();
+    assert!(!evs.is_empty(), "at least one event: {body}");
+
+    // One job per sink node, named `{pipeline}.{node_id}`.
+    for e in &evs {
+        assert_eq!(e["job"]["name"], "merged.w", "job per sink node: {e}");
+        assert_eq!(e["job"]["namespace"], "test-ns");
+    }
+    let kinds: Vec<&str> = evs
+        .iter()
+        .map(|e| e["eventType"].as_str().unwrap_or_default())
+        .collect();
+    assert!(kinds.contains(&"START"), "START emitted: {kinds:?}");
+    assert!(kinds.contains(&"COMPLETE"), "COMPLETE emitted: {kinds:?}");
+
+    // The terminal event names both sources as inputs and carries no column
+    // lineage (not derivable across a merge).
+    let done = evs
+        .iter()
+        .find(|e| e["eventType"] == "COMPLETE")
+        .expect("terminal event");
+    let inputs = done["inputs"].as_array().expect("inputs array");
+    assert_eq!(inputs.len(), 2, "both sources are inputs: {done}");
+    let mut names: Vec<String> = inputs
+        .iter()
+        .map(|d| d["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    names.sort();
+    assert!(
+        names[0].ends_with("a.csv") && names[1].ends_with("b.csv"),
+        "inputs name the real files: {names:?}"
+    );
+    assert_eq!(done["outputs"].as_array().map(Vec::len), Some(1));
+    let facets = &done["outputs"][0]["facets"];
+    assert!(
+        facets.get("columnLineage").is_none(),
+        "column lineage is not fabricated for a multi-input sink: {facets}"
+    );
+}
+
+/// A single-source graph is the shape where column lineage stays expressible, so
+/// the linear case must keep exactly one input — the check that the N-input
+/// change did not turn every job into a fan-in.
+#[test]
+#[cfg(feature = "lineage")]
+fn lineage_keeps_one_input_for_a_linear_graph() {
+    let dir = TempDir::new().unwrap();
+    let csv = orders_csv(dir.path());
+    let out = dir.path().join("out.jsonl");
+    let events = dir.path().join("lineage.jsonl");
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: linear
+lineage:
+  namespace: ns
+  transport: {{ type: file, config: {{ path: {ev} }} }}
+pipeline:
+  sources:
+    o: {{ type: csv, config: {{ path: {csv} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    s: {{ kind: source, ref: o }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: s, to: w }}
+"#,
+            csv = csv.display(),
+            out = out.display(),
+            ev = events.display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", cfg_path.to_str().unwrap()])
+        .assert()
+        .success();
+    let body = fs::read_to_string(&events).unwrap();
+    let done: serde_json::Value = body
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).unwrap())
+        .find(|e| e["eventType"] == "COMPLETE")
+        .expect("terminal event");
+    assert_eq!(done["inputs"].as_array().map(Vec::len), Some(1));
+    assert_eq!(done["job"]["name"], "linear.w");
+}
+
+/// #459: the catalog records a dataset per source and per sink, plus one edge per
+/// (source, sink) pair the graph actually connects — so a merge produces two
+/// edges into the same sink, each carrying its own source's volume.
+///
+/// Read back through `faucet catalog`, which is the surface an operator uses, so
+/// the test fails if either the write path or the read path regresses.
+#[test]
+#[cfg(all(feature = "catalog", feature = "serve-history-sqlite"))]
+fn catalog_records_a_dataset_per_node_and_an_edge_per_pair() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.csv");
+    let b = dir.path().join("b.csv");
+    write(&a, "id,v\n1,x\n2,y\n");
+    write(&b, "id,v\n3,z\n");
+    let out = dir.path().join("out.jsonl");
+    let store = dir.path().join("catalog.db");
+    let cfg_path = dir.path().join("faucet.yaml");
+    write(
+        &cfg_path,
+        &format!(
+            r#"version: 1
+name: cat-merge
+catalog:
+  url: sqlite:{store}
+pipeline:
+  sources:
+    a: {{ type: csv, config: {{ path: {a} }} }}
+    b: {{ type: csv, config: {{ path: {b} }} }}
+  sinks:
+    out: {{ type: jsonl, config: {{ path: {out} }} }}
+  nodes:
+    sa: {{ kind: source, ref: a }}
+    sb: {{ kind: source, ref: b }}
+    m: {{ kind: merge }}
+    w: {{ kind: sink, ref: out }}
+  edges:
+    - {{ from: sa, to: m }}
+    - {{ from: sb, to: m }}
+    - {{ from: m, to: w }}
+"#,
+            a = a.display(),
+            b = b.display(),
+            out = out.display(),
+            store = store.display()
+        ),
+    );
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", cfg_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let listed = Command::cargo_bin("faucet")
+        .unwrap()
+        .args([
+            "catalog",
+            "datasets",
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--json",
+        ])
+        .assert()
+        .success();
+    let body = String::from_utf8_lossy(&listed.get_output().stdout).to_string();
+    let json: serde_json::Value = serde_json::from_str(&body).expect("--json emits JSON");
+    let rows = json
+        .get("datasets")
+        .and_then(|d| d.as_array())
+        .or_else(|| json.as_array())
+        .expect("a dataset list");
+    let uris: Vec<String> = rows
+        .iter()
+        .map(|d| d["uri"].as_str().unwrap_or_default().to_string())
+        .collect();
+    // Both sources and the sink, not just the sink.
+    for want in ["a.csv", "b.csv", "out.jsonl"] {
+        assert!(
+            uris.iter().any(|u| u.ends_with(want)),
+            "{want} recorded: {uris:?}"
+        );
+    }
+
+    // The lineage graph carries one edge per contributing source, and the volumes
+    // are per-source (2 + 1) rather than the sink total repeated.
+    let shown = Command::cargo_bin("faucet")
+        .unwrap()
+        .args([
+            "catalog",
+            "lineage",
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--json",
+        ])
+        .assert()
+        .success();
+    let detail: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&shown.get_output().stdout)).unwrap();
+    let edges = detail["edges"].as_array().expect("edges array");
+    assert_eq!(edges.len(), 2, "one edge per contributing source: {detail}");
+    for e in edges {
+        assert!(
+            e["dst_uri"].as_str().unwrap_or_default().ends_with("out.jsonl"),
+            "both edges land on the sink: {e}"
+        );
+    }
+    let mut vols: Vec<u64> = edges
+        .iter()
+        .map(|e| e["last_records"].as_u64().unwrap_or_default())
+        .collect();
+    vols.sort_unstable();
+    assert_eq!(
+        vols,
+        vec![1, 2],
+        "per-source volume, not the sink total: {edges:?}"
+    );
+}

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -319,6 +319,7 @@ impl TopologyOptions {
 /// notifications and evaluates SLAs per **sink node**, which needs to know which
 /// node failed — [`TopologyResult::errors`] is a flat list of messages).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct NodeReport {
     /// Node id.
     pub node_id: String,
@@ -333,12 +334,20 @@ pub struct NodeReport {
 }
 
 /// A topology run with per-node attribution.
+///
+/// `#[non_exhaustive]`: this is an output callers read, never construct, so
+/// keeping it open means a future per-node field is a minor release rather than
+/// a breaking one — the mistake [`TopologyResult`] cannot now undo.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct TopologyRun {
     /// The aggregate result, identical to what [`Topology::run`] returns.
     pub result: TopologyResult,
     /// One entry per node, in the graph's deterministic (sorted-id) order.
     pub nodes: Vec<NodeReport>,
+    /// Records emitted per **source** node, keyed by node id (#459). Lives here
+    /// rather than on [`TopologyResult`] so adding it stays a minor change.
+    pub per_source: HashMap<String, usize>,
 }
 
 /// Outcome of a topology run.
@@ -350,8 +359,6 @@ pub struct TopologyResult {
     pub per_sink: HashMap<String, usize>,
     /// Per-sink-node final bookmark, keyed by node id.
     pub bookmarks: HashMap<String, Option<Value>>,
-    /// Records emitted per **source** node, keyed by node id (#459).
-    pub per_source: HashMap<String, usize>,
     /// Node failures observed under [`TopologyOnError::Continue`] (empty under
     /// `Propagate`, which returns `Err` on the first failure instead).
     pub errors: Vec<String>,
@@ -880,10 +887,14 @@ impl Topology {
                 if let Some(e) = first_err.lock().unwrap_or_else(|p| p.into_inner()).take() {
                     return Err(e);
                 }
-                let result = aggregate(outcomes.into_iter().flatten().collect());
+                let (result, per_source) = aggregate(outcomes.into_iter().flatten().collect());
                 let failed = failures.lock().unwrap_or_else(|p| p.into_inner()).clone();
-                let nodes = reports(&order, &result, &failed);
-                Ok(TopologyRun { result, nodes })
+                let nodes = reports(&order, &result, &per_source, &failed);
+                Ok(TopologyRun {
+                    result,
+                    nodes,
+                    per_source,
+                })
             }
             TopologyOnError::Continue => {
                 let results = futures::future::join_all(joined).await;
@@ -904,10 +915,14 @@ impl Topology {
                         }
                     }
                 }
-                let mut result = aggregate(ok);
+                let (mut result, per_source) = aggregate(ok);
                 result.errors = errs;
-                let nodes = reports(&order, &result, &failed);
-                Ok(TopologyRun { result, nodes })
+                let nodes = reports(&order, &result, &per_source, &failed);
+                Ok(TopologyRun {
+                    result,
+                    nodes,
+                    per_source,
+                })
             }
         }
     }
@@ -917,6 +932,7 @@ impl Topology {
 fn reports(
     order: &[(String, &'static str)],
     sinks: &TopologyResult,
+    per_source: &HashMap<String, usize>,
     errors: &[(String, String)],
 ) -> Vec<NodeReport> {
     order
@@ -927,7 +943,7 @@ fn reports(
             records: sinks
                 .per_sink
                 .get(id)
-                .or_else(|| sinks.per_source.get(id))
+                .or_else(|| per_source.get(id))
                 .copied()
                 .unwrap_or(0),
             bookmark: sinks.bookmarks.get(id).cloned().flatten(),
@@ -939,9 +955,11 @@ fn reports(
         .collect()
 }
 
-/// Aggregate node outcomes into a [`TopologyResult`].
-fn aggregate(outcomes: Vec<NodeOutcome>) -> TopologyResult {
+/// Aggregate node outcomes into a [`TopologyResult`] plus the per-source counts
+/// (which live on [`TopologyRun`], not the result).
+fn aggregate(outcomes: Vec<NodeOutcome>) -> (TopologyResult, HashMap<String, usize>) {
     let mut result = TopologyResult::default();
+    let mut per_source = HashMap::new();
     for o in outcomes {
         match o {
             NodeOutcome::Sink {
@@ -954,12 +972,12 @@ fn aggregate(outcomes: Vec<NodeOutcome>) -> TopologyResult {
                 result.bookmarks.insert(node_id, bookmark);
             }
             NodeOutcome::Source { node_id, records } => {
-                result.per_source.insert(node_id, records);
+                per_source.insert(node_id, records);
             }
             NodeOutcome::Other => {}
         }
     }
-    result
+    (result, per_source)
 }
 
 fn cfg(msg: impl Into<String>) -> FaucetError {

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -350,6 +350,8 @@ pub struct TopologyResult {
     pub per_sink: HashMap<String, usize>,
     /// Per-sink-node final bookmark, keyed by node id.
     pub bookmarks: HashMap<String, Option<Value>>,
+    /// Records emitted per **source** node, keyed by node id (#459).
+    pub per_source: HashMap<String, usize>,
     /// Node failures observed under [`TopologyOnError::Continue`] (empty under
     /// `Propagate`, which returns `Err` on the first failure instead).
     pub errors: Vec<String>,
@@ -380,6 +382,13 @@ enum NodeOutcome {
         node_id: String,
         records: usize,
         bookmark: Option<Value>,
+    },
+    /// A source node and how many records it emitted. Needed so a lineage /
+    /// catalog edge can report the volume *that input* contributed rather than
+    /// the sink's total, which would over-count a merge (#459).
+    Source {
+        node_id: String,
+        records: usize,
     },
     Other,
 }
@@ -710,7 +719,7 @@ impl Topology {
                 NodeKind::Source(source) => {
                     let sb = start_bookmark.clone();
                     let bs = opts.batch_size;
-                    Box::pin(run_source_node(source, sb, bs, node_outs, cancel))
+                    Box::pin(run_source_node(id, source, sb, bs, node_outs, cancel))
                 }
                 NodeKind::Transform(stages) => {
                     let rx = take_single(node_ins)
@@ -915,7 +924,12 @@ fn reports(
         .map(|(id, kind)| NodeReport {
             node_id: id.clone(),
             kind,
-            records: sinks.per_sink.get(id).copied().unwrap_or(0),
+            records: sinks
+                .per_sink
+                .get(id)
+                .or_else(|| sinks.per_source.get(id))
+                .copied()
+                .unwrap_or(0),
             bookmark: sinks.bookmarks.get(id).cloned().flatten(),
             error: errors
                 .iter()
@@ -929,15 +943,20 @@ fn reports(
 fn aggregate(outcomes: Vec<NodeOutcome>) -> TopologyResult {
     let mut result = TopologyResult::default();
     for o in outcomes {
-        if let NodeOutcome::Sink {
-            node_id,
-            records,
-            bookmark,
-        } = o
-        {
-            result.records_written += records;
-            result.per_sink.insert(node_id.clone(), records);
-            result.bookmarks.insert(node_id, bookmark);
+        match o {
+            NodeOutcome::Sink {
+                node_id,
+                records,
+                bookmark,
+            } => {
+                result.records_written += records;
+                result.per_sink.insert(node_id.clone(), records);
+                result.bookmarks.insert(node_id, bookmark);
+            }
+            NodeOutcome::Source { node_id, records } => {
+                result.per_source.insert(node_id, records);
+            }
+            NodeOutcome::Other => {}
         }
     }
     result
@@ -1116,6 +1135,7 @@ fn cancelled(cancel: &Option<CancellationToken>) -> bool {
 }
 
 async fn run_source_node(
+    node_id: String,
     source: Box<dyn Source>,
     start_bookmark: Option<Value>,
     batch_size: usize,
@@ -1127,16 +1147,18 @@ async fn run_source_node(
     }
     let ctx = std::collections::HashMap::new();
     let mut pages = source.stream_pages(&ctx, batch_size);
+    let mut records = 0usize;
     while let Some(item) = pages.next().await {
         if cancelled(&cancel) {
             break;
         }
         let page = item?;
+        records += page.records.len();
         if !broadcast(page, &mut outs).await {
             break;
         }
     }
-    Ok(NodeOutcome::Other)
+    Ok(NodeOutcome::Source { node_id, records })
 }
 
 async fn run_transform_node(

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -208,6 +208,19 @@ pub struct TopologyGovernance {
     /// Resilience policy (retry / circuit breaker / poison) for sink-side
     /// writes, flushes, and state puts.
     pub resilience: Option<crate::resilience::ResiliencePolicy>,
+    /// Delivery guarantee for every sink node (#458).
+    ///
+    /// `ExactlyOnce` gives each sink node its own commit-token scope — its state
+    /// key, `{pipeline}::{node_id}` — so a sink that durably committed a page
+    /// skips it on resume independently of its siblings. Lives here rather than on
+    /// [`TopologyOptions`] because that struct is exhaustively constructible
+    /// through the public API, so a new field there is a major break; this one is
+    /// `#[non_exhaustive]`. It is a per-sink write policy either way.
+    ///
+    /// The caller is responsible for the gate (deterministic-replay source,
+    /// idempotent sinks, durable state, no DLQ) — `run_stream` re-checks the sink
+    /// side and downgrades with a warning rather than pretending.
+    pub delivery: crate::idempotency::DeliveryMode,
 }
 
 impl TopologyGovernance {
@@ -300,6 +313,32 @@ impl TopologyOptions {
         self.batch_size = batch_size;
         self
     }
+}
+
+/// What one node did, for callers that need per-node attribution (the CLI emits
+/// notifications and evaluates SLAs per **sink node**, which needs to know which
+/// node failed — [`TopologyResult::errors`] is a flat list of messages).
+#[derive(Debug, Clone)]
+pub struct NodeReport {
+    /// Node id.
+    pub node_id: String,
+    /// Node kind (`"source"`, `"sink"`, …).
+    pub kind: &'static str,
+    /// Records written (sink nodes only; 0 elsewhere).
+    pub records: usize,
+    /// Final bookmark (sink nodes only).
+    pub bookmark: Option<Value>,
+    /// The node's failure, if it failed.
+    pub error: Option<String>,
+}
+
+/// A topology run with per-node attribution.
+#[derive(Debug, Clone, Default)]
+pub struct TopologyRun {
+    /// The aggregate result, identical to what [`Topology::run`] returns.
+    pub result: TopologyResult,
+    /// One entry per node, in the graph's deterministic (sorted-id) order.
+    pub nodes: Vec<NodeReport>,
 }
 
 /// Outcome of a topology run.
@@ -586,6 +625,20 @@ impl Topology {
         opts: TopologyOptions,
         governance: TopologyGovernance,
     ) -> Result<TopologyResult, FaucetError> {
+        self.run_reported(opts, governance).await.map(|r| r.result)
+    }
+
+    /// [`Topology::run_with`] with **per-node attribution**.
+    ///
+    /// The CLI emits notifications and evaluates SLAs per *sink node*, which needs
+    /// to know which node failed; [`TopologyResult::errors`] is only a flat list
+    /// of messages. Additive rather than a change to `run_with`'s return type,
+    /// which would break every caller (#459).
+    pub async fn run_reported(
+        self,
+        opts: TopologyOptions,
+        governance: TopologyGovernance,
+    ) -> Result<TopologyRun, FaucetError> {
         self.validate()?;
         let Topology { nodes, edges } = self;
 
@@ -607,7 +660,19 @@ impl Topology {
             .map(|n| n.id.clone())
             .collect();
         let source_count = nodes.iter().filter(|n| n.kind.is_source()).count();
-        let start_bookmark = compute_start_bookmark(&opts, &sink_ids, source_count).await;
+        // The graph's source replay capability, captured before the sources are
+        // moved into their futures. Only meaningful with exactly one source —
+        // which is also the only shape exactly-once is allowed in (#458).
+        let source_replay = if source_count == 1 {
+            nodes.iter().find_map(|n| match &n.kind {
+                NodeKind::Source(src) => Some(src.replay_guarantee()),
+                _ => None,
+            })
+        } else {
+            None
+        };
+        let start_bookmark =
+            compute_start_bookmark(&opts, &sink_ids, source_count, governance.delivery).await;
 
         // Build channels.
         let mut outs: HashMap<String, Vec<mpsc::Sender<StreamPage>>> = HashMap::new();
@@ -630,6 +695,8 @@ impl Topology {
         // task (see the spawn below).
         type NodeFut = Pin<Box<dyn Future<Output = Result<NodeOutcome, FaucetError>> + Send>>;
         let mut futs: Vec<NodeFut> = Vec::with_capacity(nodes.len());
+        // Parallel to `futs`, so a failure can be attributed to its node.
+        let mut order: Vec<(String, &'static str)> = Vec::with_capacity(nodes.len());
 
         for node in nodes {
             let node_outs = outs.remove(&node.id).unwrap_or_default();
@@ -637,6 +704,7 @@ impl Topology {
             let pipeline = opts.pipeline_name.clone();
             let cancel = opts.cancel.clone();
             let Node { id, kind } = node;
+            order.push((id.clone(), kind.kind_str()));
 
             let fut: NodeFut = match kind {
                 NodeKind::Source(source) => {
@@ -694,6 +762,8 @@ impl Topology {
                         contract: governance.contract.clone(),
                         schema_drift: governance.schema_drift,
                         resilience: governance.resilience.clone(),
+                        delivery: governance.delivery,
+                        replay: source_replay,
                     };
                     Box::pin(run_sink_node(id, sink, rx, sopts))
                 }
@@ -746,13 +816,20 @@ impl Topology {
                 let coop = opts.cancel.clone().unwrap_or_default().child_token();
                 let first_err: Arc<std::sync::Mutex<Option<FaucetError>>> =
                     Arc::new(std::sync::Mutex::new(None));
-                let wrapped = joined.map(|f| {
+                let failures: Arc<std::sync::Mutex<Vec<(String, String)>>> =
+                    Arc::new(std::sync::Mutex::new(Vec::new()));
+                let wrapped = joined.zip(order.clone()).map(|(f, (node_id, _))| {
                     let coop = coop.clone();
                     let slot = Arc::clone(&first_err);
+                    let failed = Arc::clone(&failures);
                     async move {
                         match f.await {
                             Ok(o) => Some(o),
                             Err(e) => {
+                                failed
+                                    .lock()
+                                    .unwrap_or_else(|p| p.into_inner())
+                                    .push((node_id, e.to_string()));
                                 tracing::error!(
                                     error = %e,
                                     "topology node failed; cancelling siblings so they flush"
@@ -794,27 +871,58 @@ impl Topology {
                 if let Some(e) = first_err.lock().unwrap_or_else(|p| p.into_inner()).take() {
                     return Err(e);
                 }
-                Ok(aggregate(outcomes.into_iter().flatten().collect()))
+                let result = aggregate(outcomes.into_iter().flatten().collect());
+                let failed = failures.lock().unwrap_or_else(|p| p.into_inner()).clone();
+                let nodes = reports(&order, &result, &failed);
+                Ok(TopologyRun { result, nodes })
             }
             TopologyOnError::Continue => {
                 let results = futures::future::join_all(joined).await;
                 let mut ok = Vec::new();
                 let mut errs = Vec::new();
-                for r in results {
+                let mut failed: Vec<(String, String)> = Vec::new();
+                for (r, (node_id, _)) in results.into_iter().zip(order.clone()) {
                     match r {
                         Ok(o) => ok.push(o),
                         Err(e) => {
-                            tracing::error!(error = %e, "topology node failed (on_error: continue)");
+                            tracing::error!(
+                                node = %node_id,
+                                error = %e,
+                                "topology node failed (on_error: continue)"
+                            );
                             errs.push(e.to_string());
+                            failed.push((node_id, e.to_string()));
                         }
                     }
                 }
                 let mut result = aggregate(ok);
                 result.errors = errs;
-                Ok(result)
+                let nodes = reports(&order, &result, &failed);
+                Ok(TopologyRun { result, nodes })
             }
         }
     }
+}
+
+/// Build the per-node report list from the node ids/kinds and their outcomes.
+fn reports(
+    order: &[(String, &'static str)],
+    sinks: &TopologyResult,
+    errors: &[(String, String)],
+) -> Vec<NodeReport> {
+    order
+        .iter()
+        .map(|(id, kind)| NodeReport {
+            node_id: id.clone(),
+            kind,
+            records: sinks.per_sink.get(id).copied().unwrap_or(0),
+            bookmark: sinks.bookmarks.get(id).cloned().flatten(),
+            error: errors
+                .iter()
+                .find(|(nid, _)| nid == id)
+                .map(|(_, e)| e.clone()),
+        })
+        .collect()
 }
 
 /// Aggregate node outcomes into a [`TopologyResult`].
@@ -881,6 +989,7 @@ async fn compute_start_bookmark(
     opts: &TopologyOptions,
     sink_ids: &[String],
     source_count: usize,
+    delivery: crate::idempotency::DeliveryMode,
 ) -> Option<Value> {
     let store = opts.state_store.as_ref()?;
     if sink_ids.is_empty() {
@@ -894,7 +1003,48 @@ async fn compute_start_bookmark(
             _ => return None, // a sink with no bookmark → full replay.
         }
     }
+    if delivery == crate::idempotency::DeliveryMode::ExactlyOnce {
+        // Exactly-once stores `(bookmark, seq)`, and `seq` is a monotonic page
+        // counter — a real total order, so the sinks can be ranked exactly
+        // instead of guessed at. Resume from the *furthest behind* sink; every
+        // sink ahead of it skips the pages it already committed, which is
+        // precisely what the commit token is for. (#458)
+        let ranked: Vec<(u64, Option<Value>)> = values
+            .iter()
+            .map(|v| {
+                let (bm, seq) = crate::idempotency::unwrap_state(v);
+                (seq, bm)
+            })
+            .collect();
+        return eo_start_bookmark(&ranked, source_count);
+    }
     start_bookmark(&values, source_count)
+}
+
+/// Exactly-once resume point: the bookmark of the lowest-`seq` sink.
+///
+/// Unlike the at-least-once path this *can* order the sinks, because `seq` is a
+/// monotonic counter rather than an opaque position — so a diverged set resumes
+/// from the laggard instead of replaying from scratch, and the sinks that are
+/// ahead skip their already-committed pages via their commit tokens.
+///
+/// The single-source restriction still applies: nothing records which source a
+/// sink's bookmark came from.
+pub fn eo_start_bookmark(ranked: &[(u64, Option<Value>)], source_count: usize) -> Option<Value> {
+    if ranked.is_empty() || source_count != 1 {
+        if source_count > 1 && !ranked.is_empty() {
+            tracing::warn!(
+                sources = source_count,
+                "topology: multi-source graph cannot attribute a sink bookmark to a source; \
+                 replaying every source in full"
+            );
+        }
+        return None;
+    }
+    ranked
+        .iter()
+        .min_by_key(|(seq, _)| *seq)
+        .and_then(|(_, bm)| bm.clone())
 }
 
 /// Pure resume-point decision: the bookmark every source node is started from,
@@ -1138,6 +1288,12 @@ struct SinkNodeOpts {
     contract: Option<Arc<crate::contract::CompiledContract>>,
     schema_drift: Option<crate::drift::SchemaDriftPolicy>,
     resilience: Option<crate::resilience::ResiliencePolicy>,
+    /// Delivery guarantee for this sink node.
+    delivery: crate::idempotency::DeliveryMode,
+    /// The replay capability of the graph's source, so `run_stream` can tell an
+    /// atomic-watermark run from a keyed-upsert one. `None` when there is not
+    /// exactly one source (in which case exactly-once is gated off anyway).
+    replay: Option<crate::idempotency::ReplayGuarantee>,
 }
 
 async fn run_sink_node(
@@ -1158,6 +1314,20 @@ async fn run_sink_node(
         .with_run_id(opts.run_id.clone());
     if let Some(store) = opts.state_store {
         let key = format!("{}::{}", opts.pipeline_name, node_id);
+        // Exactly-once: this node's state holds `(bookmark, seq)`, and `seq` is
+        // where its commit-token sequence resumes. Read it before handing the
+        // store to `run_stream`, which owns the writes from here (#458).
+        if opts.delivery == crate::idempotency::DeliveryMode::ExactlyOnce {
+            let seq = match store.get(&key).await {
+                Ok(Some(prior)) => crate::idempotency::unwrap_state(&prior).1,
+                Ok(None) => 0,
+                Err(e) => return Err(e),
+            };
+            run_opts = run_opts.with_delivery(opts.delivery).with_start_seq(seq);
+            if let Some(replay) = opts.replay {
+                run_opts = run_opts.with_replay_guarantee(replay);
+            }
+        }
         run_opts = run_opts.with_state(store, key);
     }
     if let Some(dlq) = opts.dlq {
@@ -1292,12 +1462,12 @@ mod tests {
 
     // ── Mock connectors ───────────────────────────────────────────────────────
 
-    struct VecSource {
+    pub(super) struct VecSource {
         records: Vec<Value>,
         bookmark: Option<Value>,
     }
     impl VecSource {
-        fn boxed(records: Vec<Value>) -> Box<dyn Source> {
+        pub(super) fn boxed(records: Vec<Value>) -> Box<dyn Source> {
             Box::new(VecSource {
                 records,
                 bookmark: None,
@@ -1357,11 +1527,11 @@ mod tests {
     }
 
     #[derive(Clone)]
-    struct CollectSink {
+    pub(super) struct CollectSink {
         store: Arc<Mutex<Vec<Value>>>,
     }
     impl CollectSink {
-        fn new() -> (Self, Arc<Mutex<Vec<Value>>>) {
+        pub(super) fn new() -> (Self, Arc<Mutex<Vec<Value>>>) {
             let store = Arc::new(Mutex::new(Vec::new()));
             (
                 Self {
@@ -1379,7 +1549,7 @@ mod tests {
         }
     }
 
-    struct FailingSink;
+    pub(super) struct FailingSink;
     #[async_trait]
     impl Sink for FailingSink {
         async fn write_batch(&self, _records: &[Value]) -> Result<usize, FaucetError> {
@@ -1403,7 +1573,7 @@ mod tests {
         }
     }
 
-    fn recs(n: usize) -> Vec<Value> {
+    pub(super) fn recs(n: usize) -> Vec<Value> {
         (0..n).map(|i| json!({ "i": i })).collect()
     }
 
@@ -2075,5 +2245,179 @@ mod tests {
         topo.run(TopologyOptions::new("p")).await.unwrap();
         let w = store.lock().unwrap();
         assert!(w[0].get("foo_bar").is_some());
+    }
+}
+
+#[cfg(test)]
+mod delivery_and_report_tests {
+    use super::tests::{CollectSink, FailingSink, VecSource, recs};
+    use super::*;
+    use crate::Stream;
+    use crate::idempotency::{DeliveryMode, format_token_with_bookmark, wrap_state};
+    use crate::state::{MemoryStateStore, StateStore};
+    use async_trait::async_trait;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// A sink that records a commit token per scope, like the SQL sinks do.
+    struct TokenSink {
+        rows: Arc<Mutex<Vec<Value>>>,
+        tokens: Arc<Mutex<std::collections::HashMap<String, String>>>,
+    }
+    #[async_trait]
+    impl Sink for TokenSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            self.rows.lock().unwrap().extend_from_slice(records);
+            Ok(records.len())
+        }
+        fn supports_idempotent_writes(&self) -> bool {
+            true
+        }
+        async fn write_batch_idempotent(
+            &self,
+            records: &[Value],
+            scope: &str,
+            token: &str,
+        ) -> Result<usize, FaucetError> {
+            self.rows.lock().unwrap().extend_from_slice(records);
+            self.tokens
+                .lock()
+                .unwrap()
+                .insert(scope.to_string(), token.to_string());
+            Ok(records.len())
+        }
+        async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+            Ok(self.tokens.lock().unwrap().get(scope).cloned())
+        }
+    }
+
+    /// #458: a sink node under `delivery: exactly_once` must commit through the
+    /// idempotent write path, under **its own** scope (its state key), so each
+    /// sink's watermark is independent of its siblings'.
+    #[tokio::test]
+    async fn exactly_once_commits_a_token_per_sink_node_scope() {
+        let rows = Arc::new(Mutex::new(Vec::new()));
+        let tokens = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let sink = TokenSink {
+            rows: rows.clone(),
+            tokens: tokens.clone(),
+        };
+        let store = Arc::new(MemoryStateStore::new());
+        let topo = Topology::builder()
+            .source("s", Box::new(EoSource(recs(3))))
+            .sink("k", Box::new(sink))
+            .edge("s", "k")
+            .build()
+            .unwrap();
+
+        let mut gov = TopologyGovernance::new();
+        gov.delivery = DeliveryMode::ExactlyOnce;
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        topo.run_with(opts, gov).await.unwrap();
+
+        assert_eq!(rows.lock().unwrap().len(), 3);
+        let committed = tokens.lock().unwrap();
+        assert!(
+            committed.contains_key("p::k"),
+            "token must be scoped to the sink node's own state key, got {:?}",
+            committed.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// A source that reports deterministic replay and emits a bookmark per page,
+    /// which is what the atomic-watermark mechanism requires.
+    struct EoSource(Vec<Value>);
+    #[async_trait]
+    impl Source for EoSource {
+        async fn fetch_with_context(
+            &self,
+            _ctx: &std::collections::HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.0.clone())
+        }
+        fn stream_pages<'a>(
+            &'a self,
+            _ctx: &'a std::collections::HashMap<String, Value>,
+            _batch: usize,
+        ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+            let rows = self.0.clone();
+            Box::pin(async_stream::try_stream! {
+                yield StreamPage { records: rows, bookmark: Some(json!({"pos": 1})) };
+            })
+        }
+        fn replay_guarantee(&self) -> crate::idempotency::ReplayGuarantee {
+            crate::idempotency::ReplayGuarantee::Deterministic
+        }
+        fn supports_exactly_once(&self) -> bool {
+            true
+        }
+    }
+
+    /// #458: exactly-once *can* order sinks, because `seq` is a monotonic counter.
+    /// Resume from the furthest-behind sink; the ones ahead skip via their tokens.
+    #[test]
+    fn eo_resume_picks_the_lowest_sequence() {
+        let a = (7u64, Some(json!({"pos": 7})));
+        let b = (4u64, Some(json!({"pos": 4})));
+        let c = (9u64, Some(json!({"pos": 9})));
+        assert_eq!(
+            eo_start_bookmark(&[a.clone(), b.clone(), c.clone()], 1),
+            Some(json!({"pos": 4})),
+            "resume from the laggard, not the leader"
+        );
+        // Still never cross-applies in a multi-source graph.
+        assert_eq!(eo_start_bookmark(&[a, b, c], 2), None);
+        assert_eq!(eo_start_bookmark(&[], 1), None);
+    }
+
+    /// The EO envelope must be unwrapped on read — a raw `get` would hand the
+    /// source `{"__faucet_eo": …}` instead of its bookmark.
+    #[tokio::test]
+    async fn eo_resume_unwraps_the_state_envelope() {
+        let store = Arc::new(MemoryStateStore::new());
+        store
+            .put("p::k", &wrap_state(Some(&json!({"pos": 5})), 5))
+            .await
+            .unwrap();
+        let opts = TopologyOptions::new("p").with_state_store(store.clone());
+        let bm =
+            compute_start_bookmark(&opts, &["k".to_string()], 1, DeliveryMode::ExactlyOnce).await;
+        assert_eq!(bm, Some(json!({"pos": 5})), "envelope must be unwrapped");
+        // A bare token round-trips through parse_token_parts the same way.
+        let t = format_token_with_bookmark(5, Some(&json!({"pos": 5})));
+        assert!(t.contains('#'), "token embeds the bookmark: {t}");
+    }
+
+    /// #459: the CLI needs to know *which* sink node failed to notify per node.
+    #[tokio::test]
+    async fn run_reported_attributes_failures_to_their_node() {
+        let (good, _) = CollectSink::new();
+        let topo = Topology::builder()
+            .source("s", VecSource::boxed(recs(4)))
+            .tee("t", 4, Some(2))
+            .sink("bad", Box::new(FailingSink))
+            .sink("good", Box::new(good))
+            .edge("s", "t")
+            .edge("t", "bad")
+            .edge("t", "good")
+            .build()
+            .unwrap();
+        let run = topo
+            .run_reported(
+                TopologyOptions::new("p").with_on_error(TopologyOnError::Continue),
+                TopologyGovernance::new(),
+            )
+            .await
+            .unwrap();
+
+        let bad = run.nodes.iter().find(|n| n.node_id == "bad").unwrap();
+        assert!(bad.error.is_some(), "the failing sink is attributed");
+        let good = run.nodes.iter().find(|n| n.node_id == "good").unwrap();
+        assert!(good.error.is_none(), "the healthy sink is not");
+        assert_eq!(good.records, 4);
+        // Every node appears, with its kind.
+        assert_eq!(run.nodes.len(), 4);
+        assert!(run.nodes.iter().any(|n| n.kind == "source"));
+        assert!(run.nodes.iter().any(|n| n.kind == "tee"));
     }
 }

--- a/crates/lineage/Cargo.toml
+++ b/crates/lineage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-lineage"
-version = "1.2.3"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/lineage/src/emitter.rs
+++ b/crates/lineage/src/emitter.rs
@@ -121,14 +121,24 @@ impl LineageEmitter {
             source_code: src.clone(),
         });
 
-        // Input dataset (+ schema on terminal events).
-        let mut input = Dataset::new(ctx.input.namespace.clone(), ctx.input.name.clone());
-        if terminal
-            && self.cfg.include_schema_facet
-            && let Some(s) = &ctx.input_schema
-        {
-            input.facets.schema = Some(schema_facet(s));
-        }
+        // Input datasets (+ schema on terminal events). Several when a topology
+        // sink is fed by a merge or join (#459); `input_schemas` aligns
+        // positionally and may be shorter than `inputs`.
+        let inputs: Vec<Dataset> = ctx
+            .inputs
+            .iter()
+            .enumerate()
+            .map(|(i, r)| {
+                let mut ds = Dataset::new(r.namespace.clone(), r.name.clone());
+                if terminal
+                    && self.cfg.include_schema_facet
+                    && let Some(Some(s)) = ctx.input_schemas.get(i)
+                {
+                    ds.facets.schema = Some(schema_facet(s));
+                }
+                ds
+            })
+            .collect();
 
         // Output dataset (+ schema + column lineage on terminal events).
         let mut output = Dataset::new(ctx.output.namespace.clone(), ctx.output.name.clone());
@@ -138,12 +148,17 @@ impl LineageEmitter {
         {
             output.facets.schema = Some(schema_facet(s));
         }
+        // Column lineage references a single input's fields, and the derivation
+        // models one transform chain — so emit it only when there is exactly one
+        // input. A merge/join is opaque to it, and inventing an input to point at
+        // would be worse than omitting the facet (the same "never fabricate"
+        // rule the opaque-transform list follows).
         if terminal
             && self.cfg.include_column_lineage
             && let Some(cl) = &ctx.column_lineage
+            && let [only] = ctx.inputs.as_slice()
         {
-            output.facets.column_lineage =
-                Some(column_facet(cl, &ctx.input.namespace, &ctx.input.name));
+            output.facets.column_lineage = Some(column_facet(cl, &only.namespace, &only.name));
         }
 
         RunEvent {
@@ -161,7 +176,7 @@ impl LineageEmitter {
                 name: ctx.job_name.clone(),
                 facets: JobFacets { source_code },
             },
-            inputs: vec![input],
+            inputs,
             outputs: vec![output],
             producer: PRODUCER.into(),
             schema_url: OL_SCHEMA_URL.into(),
@@ -249,10 +264,10 @@ mod tests {
             job_name: "j".into(),
             run_id: "r1".into(),
             parent: None,
-            input: DatasetRef {
+            inputs: vec![DatasetRef {
                 namespace: "ns".into(),
                 name: "postgres://h/db".into(),
-            },
+            }],
             output: DatasetRef {
                 namespace: "ns".into(),
                 name: "bigquery://p.d.t".into(),
@@ -261,7 +276,7 @@ mod tests {
             finished_at: None,
             records: 0,
             error: None,
-            input_schema: None,
+            input_schemas: Vec::new(),
             output_schema: None,
             column_lineage: None,
             source_code: None,

--- a/crates/lineage/src/lifecycle.rs
+++ b/crates/lineage/src/lifecycle.rs
@@ -24,13 +24,19 @@ pub struct RunLifecycle {
     pub job_name: String,
     pub run_id: String,
     pub parent: Option<ParentJob>,
-    pub input: DatasetRef,
+    /// Input datasets. One for a single-source pipeline; one per source that
+    /// reaches the sink for a topology merge/join node (#459). OpenLineage models
+    /// `inputs` as a list, so this maps straight onto the wire format.
+    pub inputs: Vec<DatasetRef>,
     pub output: DatasetRef,
     pub started_at: DateTime<Utc>,
     pub finished_at: Option<DateTime<Utc>>,
     pub records: u64,
     pub error: Option<String>,
-    pub input_schema: Option<InferredSchema>,
+    /// Observed schema per input, positionally aligned with [`Self::inputs`].
+    /// A shorter vector simply means the remaining inputs contribute no schema
+    /// facet, so callers that only sample one input need not pad it.
+    pub input_schemas: Vec<Option<InferredSchema>>,
     pub output_schema: Option<InferredSchema>,
     pub column_lineage: Option<ColumnLineage>,
     pub source_code: Option<String>,

--- a/crates/lineage/tests/emitter_events.rs
+++ b/crates/lineage/tests/emitter_events.rs
@@ -32,10 +32,10 @@ fn lifecycle() -> RunLifecycle {
         job_name: "j".into(),
         run_id: "r1".into(),
         parent: None,
-        input: DatasetRef {
+        inputs: vec![DatasetRef {
             namespace: "ns".into(),
             name: "postgres://h/db".into(),
-        },
+        }],
         output: DatasetRef {
             namespace: "ns".into(),
             name: "bigquery://p.d.t".into(),
@@ -44,7 +44,7 @@ fn lifecycle() -> RunLifecycle {
         finished_at: None,
         records: 0,
         error: None,
-        input_schema: None,
+        input_schemas: Vec::new(),
         output_schema: None,
         column_lineage: None,
         source_code: None,
@@ -121,12 +121,12 @@ async fn schema_facet_emitted_on_terminal_event_when_enabled() {
     let em = LineageEmitter::new(cfg).unwrap();
     let mut done = lifecycle();
     done.finished_at = Some(chrono::Utc::now());
-    done.input_schema = Some(InferredSchema {
+    done.input_schemas = vec![Some(InferredSchema {
         fields: vec![
             ("id".into(), "integer".into()),
             ("name".into(), "string".into()),
         ],
-    });
+    })];
     done.output_schema = Some(InferredSchema {
         fields: vec![("id".into(), "integer".into())],
     });
@@ -150,9 +150,9 @@ async fn schema_facet_suppressed_on_start_even_when_enabled() {
     cfg.include_schema_facet = true;
     let em = LineageEmitter::new(cfg).unwrap();
     let mut start = lifecycle();
-    start.input_schema = Some(InferredSchema {
+    start.input_schemas = vec![Some(InferredSchema {
         fields: vec![("id".into(), "integer".into())],
-    });
+    })];
     em.emit(EventType::Start, &start).await;
     let events = read_lines(&path);
     assert_eq!(events[0]["eventType"], "START");

--- a/crates/lineage/tests/marquez_integration.rs
+++ b/crates/lineage/tests/marquez_integration.rs
@@ -32,10 +32,10 @@ async fn emits_to_marquez() {
         job_name: "it-job".into(),
         run_id: uuid::Uuid::now_v7().to_string(),
         parent: None,
-        input: DatasetRef {
+        inputs: vec![DatasetRef {
             namespace: "faucet-it".into(),
             name: "postgres://h/db?table=t".into(),
-        },
+        }],
         output: DatasetRef {
             namespace: "faucet-it".into(),
             name: "bigquery://p.d.t".into(),
@@ -44,7 +44,7 @@ async fn emits_to_marquez() {
         finished_at: None,
         records: 0,
         error: None,
-        input_schema: None,
+        input_schemas: Vec::new(),
         output_schema: None,
         column_lineage: None,
         source_code: None,

--- a/docs/book/src/cookbook/topology.md
+++ b/docs/book/src/cookbook/topology.md
@@ -121,7 +121,59 @@ serialized text, which is unrelated to replication progress — an ordered "mini
 can sit *ahead* of the true minimum and skip the lagging sink's records.
 
 Replaying costs duplicates; skipping loses data. So when a graph is resumed
-routinely, make the sinks idempotent (`write_mode: upsert` with a `key`).
+routinely, make the sinks idempotent (`write_mode: upsert` with a `key`) or turn
+on [exactly-once delivery](#exactly-once-delivery), which replaces both rules
+above with a real ordering.
+
+## Exactly-once delivery
+
+`delivery: exactly_once` works in topology mode. Each sink node keeps its own
+commit watermark, so a restart resumes from the **lowest** committed sequence
+across the sinks — the one that is furthest behind — and every sink that is
+already ahead of that point skips the pages it has committed. Unlike the
+at-least-once rules above this is a genuine total order (the sequence is a
+monotonic counter the pipeline assigns, not an opaque bookmark), so no sink is
+ever resumed past its own progress and no sink re-writes a page it already has.
+
+Five requirements are checked at config-load time, so `faucet validate` catches
+a violation before anything runs:
+
+1. exactly **one** source node — with several, one source's position would be
+   applied to another;
+2. that source must support replay from a bookmark (`postgres-cdc`, `mysql-cdc`,
+   `mongodb-cdc`, `kafka`);
+3. **every** sink node must support idempotent writes (`postgres`, `mysql`,
+   `mssql`, `sqlite`, `snowflake`, `bigquery`, `redis`, `mongodb`, `kafka`,
+   `spanner`, `iceberg`) — one non-idempotent sink is enough to lose the
+   guarantee for the whole graph;
+4. a durable `state:` block (not `memory`);
+5. no `dlq:` block — a quarantined row is by definition not committed with the
+   page, so the two cannot both hold.
+
+The error message names which side is the limiting one, and suggests the
+keyed-upsert alternative when the sink supports it:
+
+```yaml
+version: 1
+name: cdc-mirror
+delivery: exactly_once
+state: { type: file, config: { path: ./state } }
+pipeline:
+  sources:
+    changes: { type: postgres-cdc, config: { ... } }
+  sinks:
+    warm: { type: postgres, config: { ..., write_mode: upsert, key: [id] } }
+    cold: { type: sqlite,   config: { ..., write_mode: upsert, key: [id] } }
+  nodes:
+    src:  { kind: source, ref: changes }
+    fan:  { kind: tee, fanout: 2 }
+    w1:   { kind: sink, ref: warm }
+    w2:   { kind: sink, ref: cold }
+  edges:
+    - { from: src, to: fan }
+    - { from: fan, to: w1 }
+    - { from: fan, to: w2 }
+```
 
 `execution.on_error: stop` aborts the whole topology on the first failure —
 signalling the other nodes so they stop at a page boundary and **flush** (a
@@ -139,6 +191,21 @@ Topology runs emit the standard sink/transform/state metrics plus
 `faucet_join_*` family (`build_records`, `probe_records`, `matches`, `misses`,
 `duplicates`, `build_nulls`, `project_misses`, `build_duration_seconds`),
 labelled `pipeline` + `node`.
+
+Every top-level governance and reporting block applies, each scoped to the node
+where it makes sense:
+
+| Block | How it applies to a graph |
+|---|---|
+| `masking:` / `contract:` / `quality:` / `schema:` | per sink node, on the records that reach it — `masking`'s `applies_to` matches the sink's template name or kind, exactly as in matrix mode |
+| `resilience:` | per sink node (retry / circuit breaker / poison-pill on its writes) |
+| `sla:` | per sink node, with its own history under `{name}::{node_id}` — so a slow branch of a tee is reported on its own, not averaged away |
+| `notify:` | per sink node: `run_success` / `run_failure` / `sla_breach`, with the node id in the event |
+| `lineage:` | one OpenLineage job per sink node, named `{pipeline}.{node_id}`. Its **inputs are every source that reaches that sink**, so a merge emits a job with several inputs. Column lineage is emitted only for a single-input sink — with several inputs the per-column derivation is not knowable from the graph alone, and it is left out rather than guessed |
+| `catalog:` | one dataset per source and per sink, plus one edge per (source, sink) pair that the graph actually connects; a merge sink's per-edge volume is the contributing source's own record count |
+
+A sink whose branch produced no records still reports — an empty branch is a
+result, not a missing one.
 
 ## Runnable examples
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -322,32 +322,39 @@ with `matrix:` — both non-empty is a load-time error. `faucet run` / `validate
 [Topology mode](../cookbook/topology.md) for the full grammar, the `join:`
 node, state semantics, and runnable examples.
 
-**What applies in topology mode.** The per-page governance passes behave exactly
-as they do for a matrix pipeline — `pipeline.masking`, `pipeline.quality`,
-`pipeline.contract`, and `schema:` are enforced per sink node, and `resilience:`
-applies to sink-side writes. So do `--dry-run` / `--limit`, `${now.*}` /
-`--clock`, `state:`, and `dlq:`.
+**What applies in topology mode.** Every top-level block does, each scoped to the
+node where it makes sense. The per-page governance passes — `pipeline.masking`,
+`pipeline.quality`, `pipeline.contract`, `schema:` — are enforced per sink node,
+and `resilience:` applies to its writes. `sla:` keeps per-sink-node history under
+`{pipeline}::{node_id}`; `notifications:` reports per sink node; `lineage:` emits
+one job per sink node (`{pipeline}.{node_id}`) whose inputs are every source that
+reaches it; `catalog:` records a dataset per source and per sink plus an edge for
+each pair the graph connects. So do `--dry-run` / `--limit`, `${now.*}` /
+`--clock`, `state:`, and `dlq:`. See the
+[applies-per-node table](../cookbook/topology.md#observability) for the detail.
 
-Two things differ, and both are reported rather than silent:
+Column lineage is the one thing deliberately withheld: with several inputs
+feeding a sink, the per-column derivation is not knowable from the graph, so the
+facet is omitted for a multi-input sink rather than guessed. Single-input sinks
+emit it as usual.
 
-- **`delivery: exactly_once` is rejected.** A node graph has no per-sink
-  atomic commit-token path, so the config is refused at load time instead of
-  running at-least-once under an exactly-once label. Use the matrix form, or make
-  the sinks idempotent with `write_mode: upsert`.
-- **`notifications:`, `lineage:`, `catalog:`, and `sla:` are not applied.**
-  `faucet validate` prints a `WARNING:` line naming each one it finds, and the run
-  logs the same, so a declared-but-inert block is never silent.
+**`delivery: exactly_once` is supported**, with five requirements checked at load
+time: exactly one source node, a replayable source, **every** sink idempotent, a
+durable `state:`, and no `dlq:`. Each sink node carries its own commit watermark
+and a restart resumes from the lowest committed sequence, so no sink is resumed
+past its own progress. See
+[Exactly-once delivery](../cookbook/topology.md#exactly-once-delivery).
 
-**Resume semantics are deliberately conservative.** Each sink node owns a
-bookmark under `{pipeline}::{node_id}`. The source resumes from a stored position
-only when the graph has **exactly one source node** and **every sink's bookmark is
-identical**; otherwise it replays in full (with a warning). Bookmarks are compared
-for equality, never ordered — a resume position is often structured (a CDC LSN
-map, a Kafka offset map), and an ordered "minimum" over those can sit *ahead* of
-the true minimum and skip the lagging sink's records. Replaying costs duplicates
-on a non-idempotent sink; skipping would lose data, so the trade is made in that
-direction. Use `write_mode: upsert` on the sinks when a graph is resumed
-routinely.
+**At-least-once resume is deliberately conservative.** Each sink node owns a
+bookmark under `{pipeline}::{node_id}`. Without exactly-once the source resumes
+from a stored position only when the graph has **exactly one source node** and
+**every sink's bookmark is identical**; otherwise it replays in full (with a
+warning). Bookmarks are compared for equality, never ordered — a resume position
+is often structured (a CDC LSN map, a Kafka offset map), and an ordered "minimum"
+over those can sit *ahead* of the true minimum and skip the lagging sink's
+records. Replaying costs duplicates on a non-idempotent sink; skipping would lose
+data, so the trade is made in that direction. Use `write_mode: upsert` on the
+sinks — or `delivery: exactly_once` — when a graph is resumed routinely.
 
 ## Row selection
 


### PR DESCRIPTION
Topology mode reached feature parity with matrix mode: exactly-once delivery, and every governance / reporting block applied per node.

Closes #458
Closes #459

---

## #458 — exactly-once delivery in a node graph `[tier-2]`

Topology mode refused `delivery: exactly_once` outright. It now supports it, with each **sink node** keeping its own commit watermark.

The interesting part is resume. At-least-once resume in a graph is deliberately conservative — it requires *all* sink bookmarks to be equal, because bookmarks are compared for equality, never ordered (an ordered "minimum" over an LSN/offset map compares serialized text and can sit *ahead* of the true minimum, skipping the lagging sink's records — #456 H1). Exactly-once gives a way out: the commit sequence is a monotonic counter the pipeline assigns, so `eo_start_bookmark` resumes from the **lowest committed `seq`** — a genuine total order. A sink already ahead of that point skips the pages it has committed via the existing `last_committed_token` path. No sink is resumed past its own progress; no sink rewrites a page it already has.

Five requirements, checked at config-load time by `faucet validate` so an unsupported combination never runs *as if* it were exactly-once:

1. exactly one source node — a sink's watermark is only meaningful against a known source position, and nothing records which source fed a given page;
2. a replayable source (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`, `kafka`);
3. **every** sink idempotent — one non-idempotent sink loses the guarantee for the whole graph, so a partial pass is not a pass;
4. a durable non-`memory` `state:`;
5. no `dlq:` — a quarantined row is by definition not committed with its page.

Errors name the limiting side and suggest keyed-upsert when the sink supports it, matching the matrix gate's wording so moving a pipeline between the two forms reads the same diagnosis.

## #459 — SLA, notifications, lineage and catalog, per sink node `[tier-2]`

These four blocks parsed but did nothing. Each is now applied where it is meaningful, which for a graph is **per sink node**, not per run:

- **`sla:`** keeps its own history under `{pipeline}::{node_id}`. A slow branch of a tee is flagged on its own rather than averaged away behind a fast sibling.
- **`notifications:`** fires `run_success` / `run_failure` / `sla_breach` per sink node, naming the node.
- **`lineage:`** emits one OpenLineage job per sink node (`{pipeline}.{node_id}`) with **every source that reaches it** as an input.
- **`catalog:`** records a dataset per source and per sink, plus one edge per (source, sink) pair the graph connects.

### The API change, and why

`RunLifecycle` carried a single `input: DatasetRef`. A merge sink genuinely has several, and a job claiming one input would name *the wrong dataset* — so it becomes `inputs: Vec<DatasetRef>` (`input_schemas` likewise). `CatalogUpdate.source` becomes `sources: Vec<_>` for the same reason. Both are breaking; both are inherent to modelling a fan-in truthfully rather than approximately.

Per-edge volume follows from this: a merge edge carries the **contributing source's** own record count, not the sink total repeated per edge. A single-source edge keeps the sink's count, so linear pipelines are byte-identical to before.

**Column lineage is deliberately withheld for a multi-input sink.** With several inputs the per-column derivation is not knowable from the graph, so the facet is omitted rather than guessed — a fabricated lineage edge is worse than a missing one, because downstream tooling trusts it. Single-input sinks emit it as usual.

Core gained `run_reported` → `NodeReport` per terminal node plus `TopologyRun.per_source`, because attributing any of the above needs per-node records, not a run total. `run_with` delegates to it, so the existing entry point is unchanged.

`inert_blocks()` is now **empty** and stays as the mechanism. A declared-but-inert block is the worst kind of silence — the operator believes a guarantee is in force when nothing enforces it — so if a future block lands in matrix mode first, listing it there makes `faucet validate` say so out loud.

## A bug this PR found in its own first draft

Worth calling out, because it is the failure mode reporting features have. `build_topology_inner` took an identities map and never wrote to it: `lineage_ctx` found no dataset for any node, returned `None`, and **every event was silently suppressed**. The catalog recorded nothing. Nothing failed; output was simply absent. Clippy's `unused variable: identities` was the only signal.

So the tests for both surfaces run a **real** graph — file transport, sqlite catalog — and read the output back: the merge job names both sources with no column-lineage facet, and the catalog gets one edge per source carrying that source's own volume (2 and 1, not 3 twice). A test asserting only "the run succeeded" cannot distinguish working emission from none at all.

A connector that does not override `dataset_uri()` (the `<kind>://unknown` default) is skipped rather than recorded under a placeholder nothing can join on. Under `--dry-run` the identity comes from the real config, not the counting stand-in, so a preview names the destination it *would* have written to.

## Versioning — read before merging

**`faucet-lineage` is bumped to 2.0.0 in this PR, by hand.** `cargo semver-checks -p faucet-lineage` reports 2 major failures (the two removed `RunLifecycle` fields), but `release-plz.toml` sets `semver_check = false` workspace-wide, so release-plz would derive a *minor* bump from the `feat:` prefix and publish a breaking change as 1.3.0. release-plz takes the local `Cargo.toml` version as its base, so 2.0.0 is what ships.

Scoped deliberately to that one crate: `faucet-core` is API-clean (**222 semver checks pass, no update required** — the new `TopologyRun` / `NodeReport` are `#[non_exhaustive]`, and `per_source` was moved off the exhaustively-constructible `TopologyResult` for exactly this reason). A `!` on the squash subject would have bumped core major too, and ~60 dependents would have had to chase it for nothing.

**`faucet-cli`'s lib API also changed** (`CatalogUpdate.sources`), which CI cannot catch — `semver-checks` gates `faucet-core` only. Flagging it so `faucet-cli` gets a deliberate version decision rather than a silent patch bump, same as `parse_window` in the previous PR.

## Verification

- **`faucet-core`: 944 + 12 tests pass**; `cargo semver-checks -p faucet-core` → 222 pass, no update required.
- **`faucet-lineage`: 44 tests pass** across its suites.
- **`faucet-cli`: 999 lib + 33 topology + 30 CLI e2e tests pass.** Remaining local failures are all missing-connector-feature artifacts of the near-full set this machine can link (`unknown sink 'postgres'` / `'bigquery'`, `source-rest` absent from the completions assertion) — not regressions; CI's `--all-features` run covers them.
- **clippy `--all-targets -D warnings` with fingerprints invalidated first** (`touch` on every changed file — the naive run reuses cached analysis and false-passes). Clean apart from three pre-existing `unused variable` lints in files this PR does not touch (`registry.rs`, `commands/run.rs`), which are artifacts of the same narrowed feature set.
- `RUSTDOCFLAGS="-D warnings" cargo doc` clean; `cargo fmt --all --check` clean; the three exact slim `--no-default-features` CI builds pass; `mdbook build docs/book` clean.
- Not run locally: Docker-gated integration tests (no Docker on this machine) and `--workspace --all-features`, which needs the bundled-DuckDB build this disk cannot hold. Both run in CI.

## Docs

`cookbook/topology.md` gains an **Exactly-once delivery** section (the five requirements + a runnable tee example) and an applies-per-node table under Observability; `reference/config.md` replaces the two "does not apply" bullets with what each block now does. `.claude/rules/architecture.md` documents both the core and CLI sides.
