### PR TITLE
fix: third-pass audit — contract DLQ index, GraphQL cycle guard, redshift null-row, spanner NUMERIC cursor

### DIFF
--- a/crates/common/spanner/src/decode.rs
+++ b/crates/common/spanner/src/decode.rs
@@ -49,6 +49,22 @@ fn type_code(ty: Option<&Type>) -> TypeCode {
         .unwrap_or(TypeCode::Unspecified)
 }
 
+/// Whether the named column in a result's metadata is Spanner `NUMERIC`.
+///
+/// The source uses this to reject an incremental-replication cursor on a NUMERIC
+/// column: NUMERIC decodes to a JSON *string* (to preserve precision), so the
+/// generic replication comparison orders it lexicographically (`"9" > "10"`),
+/// which would advance the bookmark incorrectly and skip or re-read rows. INT64
+/// (JSON number) and TIMESTAMP/DATE (RFC-3339 string, lexicographic == chrono)
+/// cursors are unaffected. Checked once the first page's metadata is known.
+pub fn column_is_numeric(fields: &[Field], name: &str) -> bool {
+    fields
+        .iter()
+        .find(|f| f.name == name)
+        .map(|f| type_code(f.r#type.as_ref()) == TypeCode::Numeric)
+        .unwrap_or(false)
+}
+
 /// Decode one protobuf value with its (possibly absent) Spanner type.
 pub fn decode_value(
     value: &prost_types::Value,
@@ -166,6 +182,25 @@ mod tests {
             struct_type: None,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn column_is_numeric_only_flags_numeric_columns() {
+        let field = |name: &str, code: TypeCode| Field {
+            name: name.to_string(),
+            r#type: Some(ty(code)),
+        };
+        let fields = vec![
+            field("id", TypeCode::Int64),
+            field("amount", TypeCode::Numeric),
+            field("updated_at", TypeCode::Timestamp),
+        ];
+        // Only the NUMERIC column is flagged (the #466 L3 cursor guard).
+        assert!(column_is_numeric(&fields, "amount"));
+        assert!(!column_is_numeric(&fields, "id"));
+        assert!(!column_is_numeric(&fields, "updated_at"));
+        // An unknown column is not numeric (and must not panic).
+        assert!(!column_is_numeric(&fields, "nope"));
     }
 
     #[test]

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -311,19 +311,19 @@ where
     );
 
     // Crash-replay of page 1: the pipeline compares the page token against the
-    // committed token and skips when already committed. Mimic that guard; the
-    // destination must not grow.
-    if faucet_core::parse_token(committed.as_deref().unwrap_or_default())
-        .is_some_and(|c| c >= faucet_core::parse_token(&t1).unwrap_or(0))
-    {
-        // committed >= page token ⇒ skip (no re-write), exactly as run_stream does.
-    } else {
-        panic!("[{label}] committed token did not advance to the written page's token");
-    }
-    let after_replay = count().await;
-    assert_eq!(
-        after_replay, after_first,
-        "[{label}] a guarded replay changed the destination — watermark is not honoured"
+    // committed token and *skips* the page when already committed. Assert that
+    // decision resolves to "skip" — i.e. the sink's recorded token parses and is
+    // ≥ the page token. (We deliberately do NOT re-invoke the sink and assert the
+    // row count is unchanged: the no-duplication guarantee lives in the pipeline's
+    // skip, not in the sink, so an append-mode idempotent sink re-delivered the
+    // same committed page legitimately *would* grow. Testing that here would fail
+    // correct sinks. This is the vacuous assertion #466 L4 removed.)
+    let committed_seq = faucet_core::parse_token(committed.as_deref().unwrap_or_default())
+        .unwrap_or_else(|| panic!("[{label}] committed token {committed:?} does not parse"));
+    assert!(
+        committed_seq >= faucet_core::parse_token(&t1).unwrap_or(0),
+        "[{label}] committed token did not reach the written page's token — \
+         run_stream could not skip the replay and would re-write the page"
     );
 
     // Forward progress with a new token still writes.

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -996,8 +996,19 @@ where
                                         version: c.version.clone(),
                                         message: vr.violation.describe(),
                                     };
-                                    // `record_index` is the position within the PAGE
-                                    // (the frozen envelope contract).
+                                    // `record_index` must be the position within the
+                                    // original PAGE (the frozen envelope contract).
+                                    // `vr.violation.page_index` is the position within
+                                    // *this pass's input* — the quality survivors —
+                                    // which is aligned with `page_indices`, so translate
+                                    // through it. Without this, an earlier quality
+                                    // quarantine on the same page shifts every contract
+                                    // envelope's index by the count of quality-removed
+                                    // rows (#466 M1).
+                                    let page_index = page_indices
+                                        .get(vr.violation.page_index)
+                                        .copied()
+                                        .unwrap_or(vr.violation.page_index);
                                     build_envelope(
                                         &vr.record,
                                         &err,
@@ -1005,7 +1016,7 @@ where
                                         sink_name,
                                         &pipeline_name,
                                         &row,
-                                        vr.violation.page_index,
+                                        page_index,
                                     )
                                 })
                                 .collect();
@@ -4125,6 +4136,28 @@ mod tests {
         assert!(kinds.contains(&"QualityFailure"), "kinds: {kinds:?}");
         assert!(kinds.contains(&"ContractViolation"), "kinds: {kinds:?}");
         assert_eq!(result.dlq.unwrap().records_dlq, 2);
+
+        // #466 M1: the contract envelope's `record_index` must be the position in
+        // the ORIGINAL page (1 — the `"bad"` record), not its position within the
+        // quality-survivor slice (0, after the null id at page-index 0 was
+        // removed). Before the fix this reported 0, silently pointing DLQ readers
+        // at the wrong original row whenever quality also quarantined earlier.
+        let contract_env = dlq
+            .iter()
+            .find(|e| e["error"]["kind"] == "ContractViolation")
+            .expect("a contract envelope");
+        assert_eq!(
+            contract_env["record_index"], 1,
+            "contract record_index must be the original page position: {contract_env}"
+        );
+        let quality_env = dlq
+            .iter()
+            .find(|e| e["error"]["kind"] == "QualityFailure")
+            .expect("a quality envelope");
+        assert_eq!(
+            quality_env["record_index"], 0,
+            "null id was at page index 0"
+        );
     }
 
     /// Sink whose write_batch_partial fails every Nth record; drives the

--- a/crates/sink/redshift/README.md
+++ b/crates/sink/redshift/README.md
@@ -12,7 +12,9 @@ Redshift speaks the PostgreSQL wire protocol, so the sink connects through
   path.
 - **`insert`** — multi-row `INSERT INTO … VALUES (…), (…)`. Portable and needs
   no S3, but slower for bulk data. Sub-chunked to respect Redshift's bind-param
-  limit.
+  limit. Columns are the union of table columns present across the page; a
+  record that shares *no* column with the table is skipped (with a warning)
+  rather than inserted as an all-NULL row.
 
 Append-only: Redshift has no `ON CONFLICT`, and `COPY` cannot upsert, so
 `supported_write_modes()` is `[Append]`.

--- a/crates/sink/redshift/src/copy.rs
+++ b/crates/sink/redshift/src/copy.rs
@@ -112,6 +112,16 @@ pub(crate) fn columns_present<'a>(
         .collect()
 }
 
+/// Whether `record` (a JSON object) has at least one key matching a column in
+/// `present`. A record that shares no column with the table carries nothing for
+/// this destination; binding it would emit an all-NULL row, so the INSERT path
+/// skips it (#466 L1). A non-object never shares a column.
+pub(crate) fn shares_a_column(record: &Value, present: &[String]) -> bool {
+    record
+        .as_object()
+        .is_some_and(|o| present.iter().any(|c| o.contains_key(c.as_str())))
+}
+
 /// Serialize records as newline-delimited JSON (JSONL) bytes for `FORMAT AS
 /// JSON 'auto'`.
 pub(crate) fn serialize_jsonl(records: &[Value]) -> Result<Vec<u8>, FaucetError> {
@@ -269,6 +279,19 @@ mod tests {
             present.into_iter().cloned().collect::<Vec<_>>(),
             vec!["id".to_string(), "name".to_string(), "email".to_string()]
         );
+    }
+
+    #[test]
+    fn shares_a_column_detects_overlap_and_its_absence() {
+        let cols = vec!["id".to_string(), "name".to_string()];
+        assert!(shares_a_column(&json!({"id": 1}), &cols));
+        assert!(shares_a_column(&json!({"name": "x", "extra": 9}), &cols));
+        // No overlap → skipped (would otherwise be an all-NULL row, #466 L1).
+        assert!(!shares_a_column(&json!({"unrelated": 1}), &cols));
+        assert!(!shares_a_column(&json!({}), &cols));
+        // A non-object never shares a column.
+        assert!(!shares_a_column(&json!(42), &cols));
+        assert!(!shares_a_column(&json!(null), &cols));
     }
 
     #[test]

--- a/crates/sink/redshift/src/sink.rs
+++ b/crates/sink/redshift/src/sink.rs
@@ -180,11 +180,33 @@ impl RedshiftSink {
             return Ok(0);
         }
 
+        // Drop records that share *no* column with the table. `present` is the
+        // union of table columns across the page, so binding such a record would
+        // emit an all-NULL row rather than the data the caller sent — the DuckDB
+        // and SQLite sinks skip it, and so do we (#466 L1). A record with at
+        // least one matching column is still inserted (missing columns → NULL).
+        let insertable: Vec<&Value> = records
+            .iter()
+            .filter(|r| crate::copy::shares_a_column(r, &present))
+            .collect();
+        let skipped = records.len() - insertable.len();
+        if skipped > 0 {
+            tracing::warn!(
+                table = %self.config.table_name,
+                skipped,
+                "redshift: skipped record(s) with no column matching the table \
+                 (would have inserted an all-NULL row)"
+            );
+        }
+        if insertable.is_empty() {
+            return Ok(0);
+        }
+
         let num_cols = present.len();
         let max_rows = (MAX_REDSHIFT_PARAMS / num_cols).max(1);
         let mut total = 0usize;
 
-        for sub in records.chunks(max_rows) {
+        for sub in insertable.chunks(max_rows) {
             let sql = insert_statement(&self.table_ref(), &present, sub.len());
             let mut q = sqlx::query(&sql);
             for record in sub {

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -110,6 +110,7 @@ impl GraphqlStream {
         let mut cursor: Option<String> = None;
         let mut pages_fetched = 0usize;
         let mut warned_unresolved_has_next = false;
+        let mut cursor_guard = CursorGuard::new();
 
         loop {
             if let Some(max) = self.config.max_pages
@@ -142,7 +143,15 @@ impl GraphqlStream {
                             tracing::warn!("cursor loop detected, stopping pagination");
                             break;
                         }
-                        PageStep::Advance(next) => cursor = Some(next),
+                        PageStep::Advance(next) => {
+                            if cursor_guard.is_repeat(&next) {
+                                tracing::warn!(
+                                    "cursor cycle detected (cursor already seen), stopping pagination"
+                                );
+                                break;
+                            }
+                            cursor = Some(next);
+                        }
                     }
                 }
                 None => break,
@@ -344,6 +353,7 @@ impl GraphqlStream {
 
         Box::pin(async_stream::try_stream! {
             let mut cursor: Option<String> = None;
+            let mut cursor_guard = CursorGuard::new();
             let mut pages_fetched = 0usize;
             let mut warned_unresolved_has_next = false;
             // No incremental replication today — `running_max` stays `None`.
@@ -386,8 +396,15 @@ impl GraphqlStream {
                                 false
                             }
                             PageStep::Advance(next) => {
-                                cursor = Some(next);
-                                true
+                                if cursor_guard.is_repeat(&next) {
+                                    tracing::warn!(
+                                        "cursor cycle detected (cursor already seen), stopping pagination"
+                                    );
+                                    false
+                                } else {
+                                    cursor = Some(next);
+                                    true
+                                }
                             }
                         }
                     }
@@ -515,6 +532,49 @@ fn decide_next_page(
         None => (PageStep::Stop, unresolved),
         Some(next) if Some(next.as_str()) == prev_cursor => (PageStep::StopLoop, unresolved),
         Some(next) => (PageStep::Advance(next), unresolved),
+    }
+}
+
+/// Bounded record of recently-advanced pagination cursors.
+///
+/// [`decide_next_page`] only compares against the *immediately previous* cursor,
+/// so a server that returns `hasNextPage: true` while cycling its cursor across
+/// two or more values (`c1→c2→c1→c2…`) would never trip that guard and — with
+/// `max_pages` unset — paginate forever, re-emitting the same pages (#466 M2).
+/// This catches any such cycle by remembering the cursors already seen.
+///
+/// Bounded to [`Self::CAP`] entries so the streaming path keeps its O(page)
+/// memory guarantee on a legitimately large result set (whose cursors are all
+/// distinct, so eviction never causes a false positive). A cycle length beyond
+/// the cap is not realistic for a real endpoint.
+struct CursorGuard {
+    seen: HashMap<String, ()>,
+    order: std::collections::VecDeque<String>,
+}
+
+impl CursorGuard {
+    const CAP: usize = 4096;
+
+    fn new() -> Self {
+        Self {
+            seen: HashMap::new(),
+            order: std::collections::VecDeque::new(),
+        }
+    }
+
+    /// Record `cursor`; return `true` if it had already been seen (a cycle).
+    fn is_repeat(&mut self, cursor: &str) -> bool {
+        if self.seen.contains_key(cursor) {
+            return true;
+        }
+        if self.order.len() >= Self::CAP
+            && let Some(old) = self.order.pop_front()
+        {
+            self.seen.remove(&old);
+        }
+        self.seen.insert(cursor.to_string(), ());
+        self.order.push_back(cursor.to_string());
+        false
     }
 }
 
@@ -694,5 +754,28 @@ mod tests {
         .with_retry_policy(policy);
         assert_eq!(stream.retry_policy.max_attempts, 9);
         assert_eq!(stream.retry_policy.base, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn cursor_guard_detects_repeats_and_bounds_memory() {
+        let mut g = CursorGuard::new();
+        assert!(!g.is_repeat("a"));
+        assert!(!g.is_repeat("b"));
+        // Any earlier cursor repeating is a cycle, not just the adjacent one.
+        assert!(g.is_repeat("a"));
+        assert!(g.is_repeat("b"));
+
+        // Bounded: after CAP distinct cursors, the oldest is evicted, so the
+        // set never grows without bound on a legitimately large pagination.
+        let mut g = CursorGuard::new();
+        for i in 0..CursorGuard::CAP {
+            assert!(!g.is_repeat(&format!("c{i}")));
+        }
+        assert_eq!(g.order.len(), CursorGuard::CAP);
+        // One more distinct cursor evicts the oldest ("c0").
+        assert!(!g.is_repeat("overflow"));
+        assert_eq!(g.order.len(), CursorGuard::CAP);
+        assert!(!g.seen.contains_key("c0"), "oldest cursor evicted");
+        assert!(g.seen.contains_key("overflow"));
     }
 }

--- a/crates/source/graphql/tests/streaming.rs
+++ b/crates/source/graphql/tests/streaming.rs
@@ -469,3 +469,45 @@ async fn stuck_cursor_stops_without_extra_duplicate_page() {
     assert_eq!(hits.load(Ordering::SeqCst), 2, "must stop after 2 requests");
     assert_eq!(records.len(), 2);
 }
+
+/// #466 M2: a server that cycles its cursor across *two* values
+/// (`c1→c2→c1→c2…`) while always claiming `hasNextPage: true` must still
+/// terminate. The old guard compared only against the immediately-previous
+/// cursor, so this cycle evaded it and — with `max_pages` unset — looped
+/// forever, re-emitting the same pages. Wrapped in a timeout so a regression
+/// fails the test instead of hanging it.
+#[tokio::test]
+async fn multi_cursor_cycle_terminates() {
+    let server = MockServer::start().await;
+    let hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let hits_resp = hits.clone();
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(move |req: &Request| {
+            hits_resp.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // None→c1, c1→c2, c2→c1, … always hasNextPage:true.
+            let next = match request_cursor(req).as_deref() {
+                None | Some("c2") => "c1",
+                Some("c1") => "c2",
+                other => panic!("unexpected cursor {other:?}"),
+            };
+            ResponseTemplate::new(200).set_body_json(make_page(0, 1, Some(next)))
+        })
+        .mount(&server)
+        .await;
+
+    let source = GraphqlStream::new(relay_config(&server, 10));
+    let records = tokio::time::timeout(std::time::Duration::from_secs(10), source.fetch_all())
+        .await
+        .expect("must terminate, not loop forever")
+        .expect("fetch_all ok");
+
+    // Pages: None→c1 (record 1), c1→c2 (record 2), c2→c1 — c1 already seen ⇒
+    // stop. Three requests, two records; never unbounded.
+    assert_eq!(
+        hits.load(std::sync::atomic::Ordering::SeqCst),
+        3,
+        "stops when a cursor repeats"
+    );
+    assert_eq!(records.len(), 3);
+}

--- a/crates/source/spanner/README.md
+++ b/crates/source/spanner/README.md
@@ -82,6 +82,12 @@ bookmark compared against a `TIMESTAMP` column needs an explicit cast in the
 query — `updated_at > TIMESTAMP(@bookmark)` — and likewise `DATE(@bookmark)`
 for `DATE` columns. Integer bookmarks bind as `INT64` and compare directly.
 
+**Cursor column type:** the cursor `column` must be `INT64`, `TIMESTAMP`, or
+`DATE`. `NUMERIC` is **rejected** — it decodes to a string to preserve
+precision, so the bookmark comparison would order it lexicographically (`"9" >
+"10"`) and skip or re-read rows. The source fails fast with a clear error rather
+than advancing an incorrect bookmark.
+
 ## Stale reads
 
 Set `exact_staleness_secs: 15` to read at a bounded-staleness timestamp.

--- a/crates/source/spanner/src/stream.rs
+++ b/crates/source/spanner/src/stream.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use faucet_common_spanner::decode::row_to_json;
+use faucet_common_spanner::decode::{column_is_numeric, row_to_json};
 use faucet_common_spanner::quote_ident_spanner;
 use faucet_common_spanner::types::{parse_spanner_type, spanner_type_to_json_schema};
 use faucet_core::replication::{filter_incremental, max_replication_value, max_value};
@@ -317,7 +317,24 @@ impl Source for SpannerSource {
                 .await
                 .map_err(|e| FaucetError::Source(format!("spanner: row stream failed: {e}")))?
             {
+                let first_page = fields.is_none();
                 let fields = fields.get_or_insert_with(|| iter.columns_metadata().clone());
+                // Fail loud on a NUMERIC incremental cursor rather than advancing
+                // a lexicographically-ordered bookmark and silently skipping or
+                // re-reading rows (#466 L3). Checked once, when the metadata
+                // first arrives.
+                if first_page
+                    && let Some(ctx) = incr.as_ref()
+                    && column_is_numeric(fields, &ctx.column)
+                {
+                    Err(FaucetError::Config(format!(
+                        "spanner: incremental cursor column `{}` is NUMERIC, which decodes to a \
+                         string and orders lexicographically (\"9\" > \"10\"), producing an \
+                         incorrect bookmark that skips or re-reads rows. Use an INT64 or \
+                         TIMESTAMP/DATE cursor column instead.",
+                        ctx.column
+                    )))?;
+                }
                 let record = row_to_json(&row, fields)
                     .map_err(|e| FaucetError::Source(format!("spanner: row decode failed: {e}")))?;
                 buffer.push(record);


### PR DESCRIPTION
Fixes the findings that survived verification in the third-pass audit (#466). The full audit — including the verified-clean appendix (exactly-once atomicity, CDC durability, masking ordering) — is in that issue.

**Addresses #466** (partial — the low catalog-backend-parity finding #466 L2 is handled on the `feat/topology-parity` branch / #464, which owns the catalog code it touches; not `Closes` because two PRs share the issue).

## Fixes

**M1 (medium) — contract DLQ `record_index` was survivor-relative.** `apply_contract` runs over the quality *survivors*, so its `page_index` is a position within that slice. The DLQ envelope reported it raw, while the correct `page_indices` remap sat right below (used only for the drift pass). With an earlier quality quarantine on the same page, every contract envelope's index was off by the count of quality-removed rows — a DLQ reader pointed at the wrong original row. Metadata-only (payload correct, routed once, replays fine); uncaught because no test combined the two quarantine passes. The existing quality+contract test now asserts `record_index`.

**M2 (medium) — GraphQL cursor cycle looped forever.** The guard compared only against the *immediately previous* cursor, so a server cycling its cursor across ≥2 values (`c1→c2→c1…`) with `hasNextPage: true` and `max_pages` unset paginated forever, re-emitting the same pages. Added a bounded `CursorGuard` (capped seen-set, so the streaming path keeps O(page) memory) that stops on any repeat — the robustness the REST source already has. A wiremock test proves a 2-cycle terminates under a timeout.

**L1 (low) — redshift inserted an all-NULL row** for a record sharing no column with the table (it bound across the union of page columns). The DuckDB/SQLite sinks skip such a record; redshift now does too (with a warning), via the pure, unit-tested `shares_a_column`.

**L3 (low) — Spanner NUMERIC cursor silently mis-ordered.** A `NUMERIC` incremental cursor decodes to a string to preserve precision, so the comparison ordered `"9" > "10"` and advanced the bookmark incorrectly (skip/re-read). There is no correct client-side comparison, so the source now rejects it fast (use INT64 / TIMESTAMP / DATE) once the column metadata is known.

**L4 (low, conformance) — removed a vacuous watermark sub-assertion** that claimed to verify a crash-replay but never re-invoked the sink. Replaced with a real assertion on the pipeline's skip *decision* — deliberately not a re-delivery + no-growth check, which would overreach the contract (an append-mode idempotent sink re-delivered a committed page legitimately *would* grow; the pipeline, not the sink, guarantees no re-delivery).

## Notes

- **`faucet-common-spanner` gains one `pub fn`** (`column_is_numeric`, needed cross-crate by the source) — additive/non-breaking. CI semver-checks gates only `faucet-core` (222 checks pass, no update required — M1 is internal to `run_stream`), so flagging it for a deliberate version decision.
- Every fix ships with a test that would have caught the bug.

## Verification

`faucet-core` full suite + `faucet-source-graphql` / `faucet-sink-redshift` / `faucet-common-spanner` / `faucet-source-spanner` / `faucet-conformance` tests pass; clippy `--all-targets -D warnings` (fingerprints invalidated first) clean on the touched crates; `cargo semver-checks -p faucet-core` clean; `cargo doc` clean (with the transform features that define the pre-existing feature-gated intra-doc links); `cargo fmt --check` clean; the three slim CLI builds pass. Docker-gated and `--all-features` runs are CI-only on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
