### PR TITLE
test(conformance): adopt the new capability checks across all connectors

### DIFF
--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -638,7 +638,9 @@ pub async fn assert_schema_evolution_effective<S: Sink + ?Sized>(sink: &S) {
             )
         });
 
-    let new_col = "__conformance_evolved__";
+    // Must be a valid identifier on every evolvable backend: Spanner rejects a
+    // leading underscore ("Column name not valid"), so no `__…__` fencing here.
+    let new_col = "faucet_conformance_evolved";
     let already = before
         .get("properties")
         .and_then(|p| p.as_object())

--- a/crates/sink/azure-blob/tests/conformance.rs
+++ b/crates/sink/azure-blob/tests/conformance.rs
@@ -109,6 +109,27 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "azure-blob");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+/// The `object_store` Azure builder is lazy, so this runs unconditionally with
+/// no container.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let config = AzureBlobSinkConfig::new(CONTAINER)
+        .account(AZURITE_ACCOUNT)
+        .auth(AzureCredentials::AccountKey {
+            account_key: AZURITE_KEY.into(),
+        })
+        .endpoint("http://127.0.0.1:1")
+        .allow_http(true);
+    let sink = AzureBlobSink::new(config)
+        .await
+        .expect("sink builds lazily");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
 // ── Check 5: capabilities are truthful (Azurite, skip if no Docker) ──────────
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_capabilities_truthful() {

--- a/crates/sink/clickhouse/tests/conformance.rs
+++ b/crates/sink/clickhouse/tests/conformance.rs
@@ -8,7 +8,10 @@
 //! honest-`false` branch: Append works and no phantom commit token is recorded.
 //! Passing this battery in CI is the Tier-1 (supported) criterion.
 
-use faucet_conformance::{assert_capabilities_truthful, assert_config_schema_valid_value};
+use faucet_conformance::{
+    assert_capabilities_truthful, assert_config_schema_valid_value,
+    assert_connector_name_nonempty_value,
+};
 use faucet_core::Sink as _;
 use faucet_sink_clickhouse::{ClickHouseSink, ClickHouseSinkConfig};
 use serde_json::Value;
@@ -67,6 +70,14 @@ async fn count_rows(base: &str) -> usize {
 fn conformance_config_schema_valid() {
     let schema = serde_json::to_value(schemars::schema_for!(ClickHouseSinkConfig)).unwrap();
     assert_config_schema_valid_value(&schema, "clickhouse");
+}
+
+// ── Check 10: connector_name is non-empty (offline, lazy sink) ───────────────
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink =
+        ClickHouseSink::new(ClickHouseSinkConfig::new("http://127.0.0.1:1", "t")).expect("sink");
+    assert_connector_name_nonempty_value(sink.connector_name(), sink.connector_name());
 }
 
 // ── Check 5: capabilities are truthful (real backend, skip if no Docker) ─────

--- a/crates/sink/csv/tests/conformance.rs
+++ b/crates/sink/csv/tests/conformance.rs
@@ -26,6 +26,31 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "csv");
 }
 
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink = CsvSink::new(CsvSinkConfig::new("/tmp/does-not-matter.csv"));
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // A writable parent directory makes the filesystem probe pass; the check
+    // must return Ok(report) with a well-formed probe.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.csv");
+    let sink = CsvSink::new(CsvSinkConfig::new(path.to_str().unwrap()));
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn conformance_capabilities_truthful() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/sink/delta/tests/conformance.rs
+++ b/crates/sink/delta/tests/conformance.rs
@@ -5,10 +5,12 @@
 //! [`DeltaSource`]. Passing this battery in CI is the Tier-1 (supported)
 //! criterion — see the connector catalog's "Support tiers" note.
 //!
-//! Checks exercised: 1 (config schema, offline) and 5 (capabilities truthful).
-//! The Delta sink is append-only (no idempotent-watermark / keyed-upsert
-//! mechanism), so check 5 takes the honest-`false` branch: Append is advertised
-//! and works, and no phantom commit token is recorded.
+//! Checks exercised: 1 (config schema, offline), 5 (capabilities truthful), 10
+//! (`connector_name()` non-empty), and 11 (`check()` well-formed). The Delta
+//! sink is append-only (no idempotent-watermark / keyed-upsert mechanism), so
+//! check 5 takes the honest-`false` branch: Append is advertised and works, and
+//! no phantom commit token is recorded. Checks 7/8 (upsert/evolution) do not
+//! apply — it advertises neither.
 
 use faucet_conformance::{assert_capabilities_truthful, assert_config_schema_valid_value};
 use faucet_core::{Sink as _, Source as _};
@@ -32,6 +34,38 @@ async fn count_committed(uri: &str) -> usize {
 fn conformance_config_schema_valid() {
     let schema = serde_json::to_value(schemars::schema_for!(DeltaSinkConfig)).unwrap();
     assert_config_schema_valid_value(&schema, "delta");
+}
+
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "name");
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri))
+        .await
+        .expect("sink");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+/// A reachable local warehouse makes the metadata-open probe pass (the table
+/// need not exist yet); the check must return Ok(report) with a well-formed
+/// probe.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_preflight_check_wellformed() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "preflight");
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri))
+        .await
+        .expect("sink");
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }
 
 // ── Check 5: capabilities are truthful ───────────────────────────────────────

--- a/crates/sink/duckdb/tests/conformance.rs
+++ b/crates/sink/duckdb/tests/conformance.rs
@@ -28,6 +28,12 @@ async fn conformance_capabilities_truthful() {
     .await
     .expect("sink");
 
+    // Check 10: connector_name() is non-empty (reuses this offline instance).
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+
     // The battery writes {id: i64, v: string}; seed the matching table on the
     // sink's own connection.
     sink.run_sql("CREATE TABLE t (id BIGINT, v TEXT)")

--- a/crates/sink/elasticsearch/tests/conformance.rs
+++ b/crates/sink/elasticsearch/tests/conformance.rs
@@ -1,6 +1,35 @@
-//! `faucet-conformance` battery — Check 1 (config schema validity).
+//! `faucet-conformance` battery for the Elasticsearch sink.
 //! Passing this battery in CI is the Tier-1 (supported) criterion.
-use faucet_conformance::assert_config_schema_valid_value;
+//!
+//! - check 1  `assert_config_schema_valid_value` — the config schema is valid.
+//! - check 7  `assert_write_modes_truthful` — an upsert/delete-capable sink
+//!   genuinely converges by key and removes on delete (driven against a
+//!   stateful `_bulk` mock that maintains a `_id`-keyed doc store).
+//! - check 8  `assert_schema_evolution_effective` — `evolve_schema` makes the
+//!   added column appear in a fresh `current_schema()` (stateful `_mapping`
+//!   GET/PUT mock).
+//! - check 10 `assert_connector_name_nonempty_value` — the connector label is
+//!   non-empty (offline).
+//! - check 11 `assert_sink_preflight_check_wellformed` — `check()` returns a
+//!   well-formed `Ok(report)` (health + index probes against a mock).
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use faucet_conformance::doubles::{DELETE_MARKER_FIELD, DELETE_MARKER_VALUE};
+use faucet_conformance::{
+    assert_config_schema_valid_value, assert_connector_name_nonempty_value,
+    assert_schema_evolution_effective, assert_sink_preflight_check_wellformed,
+    assert_write_modes_truthful,
+};
+use faucet_core::check::CheckContext;
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
+use faucet_sink_elasticsearch::{ElasticsearchSink, ElasticsearchSinkConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+// ── Check 1: config schema validity ───────────────────────────────────────────
 
 #[test]
 fn conformance_config_schema_valid() {
@@ -9,4 +38,167 @@ fn conformance_config_schema_valid() {
     ))
     .unwrap();
     assert_config_schema_valid_value(&schema, "elasticsearch");
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink =
+        ElasticsearchSink::new(ElasticsearchSinkConfig::new("http://127.0.0.1:1", "idx")).unwrap();
+    assert_connector_name_nonempty_value(sink.connector_name(), sink.connector_name());
+}
+
+// ── Check 7: write modes are truthful (stateful `_bulk` doc store) ────────────
+
+/// A `_bulk` responder that maintains a `_id`-keyed doc store: it applies the
+/// `index`/`delete` action lines from each NDJSON body so the destination's
+/// distinct-row count reflects real upsert/delete convergence.
+#[derive(Clone)]
+struct BulkDocStore {
+    ids: Arc<Mutex<HashSet<String>>>,
+}
+
+impl BulkDocStore {
+    fn new() -> Self {
+        Self {
+            ids: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.ids.lock().unwrap().len()
+    }
+}
+
+impl Respond for BulkDocStore {
+    fn respond(&self, req: &Request) -> ResponseTemplate {
+        let body = std::str::from_utf8(&req.body).unwrap_or("");
+        let mut ids = self.ids.lock().unwrap();
+        let mut items = 0usize;
+        for line in body.lines().filter(|l| !l.trim().is_empty()) {
+            let v: Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if let Some(action) = v.get("index").and_then(|a| a.get("_id")) {
+                if let Some(id) = action.as_str() {
+                    ids.insert(id.to_string());
+                }
+                items += 1;
+            } else if let Some(action) = v.get("delete").and_then(|a| a.get("_id")) {
+                if let Some(id) = action.as_str() {
+                    ids.remove(id);
+                }
+                items += 1;
+            }
+            // Doc lines (no `index`/`delete` action key) are skipped.
+        }
+        let items: Vec<Value> = (0..items)
+            .map(|_| json!({ "index": { "status": 200 } }))
+            .collect();
+        ResponseTemplate::new(200).set_body_json(json!({ "errors": false, "items": items }))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_write_modes_truthful() {
+    let server = MockServer::start().await;
+    let store = BulkDocStore::new();
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        .respond_with(store.clone())
+        .mount(&server)
+        .await;
+
+    // The sink under test is configured for keyed writes so the upsert/delete
+    // modes it advertises can be exercised through the trait.
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: Some(DeleteMarker {
+                field: DELETE_MARKER_FIELD.to_string(),
+                values: vec![DELETE_MARKER_VALUE.to_string()],
+            }),
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    let store_ref = store.clone();
+    assert_write_modes_truthful(&sink, || {
+        let store = store_ref.clone();
+        async move { store.count() }
+    })
+    .await;
+}
+
+// ── Check 8: schema evolution is effective (stateful `_mapping` mock) ─────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_schema_evolution_effective() {
+    // A shared property map: `GET /idx/_mapping` returns it; `PUT /idx/_mapping`
+    // merges its `properties` body into it — so a fresh `current_schema()` after
+    // `evolve_schema` genuinely reflects the added column.
+    let props: Arc<Mutex<serde_json::Map<String, Value>>> = Arc::new(Mutex::new({
+        let mut m = serde_json::Map::new();
+        m.insert("id".to_string(), json!({ "type": "long" }));
+        m
+    }));
+
+    let server = MockServer::start().await;
+
+    let get_props = props.clone();
+    Mock::given(method("GET"))
+        .and(path("/idx/_mapping"))
+        .respond_with(move |_req: &Request| {
+            let props = Value::Object(get_props.lock().unwrap().clone());
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "idx": { "mappings": { "properties": props } } }))
+        })
+        .mount(&server)
+        .await;
+
+    let put_props = props.clone();
+    Mock::given(method("PUT"))
+        .and(path("/idx/_mapping"))
+        .respond_with(move |req: &Request| {
+            if let Ok(body) = serde_json::from_slice::<Value>(&req.body)
+                && let Some(new_props) = body.get("properties").and_then(|p| p.as_object())
+            {
+                let mut props = put_props.lock().unwrap();
+                for (k, v) in new_props {
+                    props.insert(k.clone(), v.clone());
+                }
+            }
+            ResponseTemplate::new(200).set_body_json(json!({ "acknowledged": true }))
+        })
+        .mount(&server)
+        .await;
+
+    let sink = ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "idx")).unwrap();
+    assert_schema_evolution_effective(&sink).await;
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_preflight_check_wellformed() {
+    let server = MockServer::start().await;
+    // Health probe: a healthy cluster.
+    Mock::given(method("GET"))
+        .and(path("/_cluster/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
+        .mount(&server)
+        .await;
+    // Index HEAD probe: index exists.
+    Mock::given(method("HEAD"))
+        .and(path("/idx"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let sink = ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "idx")).unwrap();
+    assert_sink_preflight_check_wellformed(&sink, &CheckContext::default()).await;
 }

--- a/crates/sink/gcs/tests/conformance.rs
+++ b/crates/sink/gcs/tests/conformance.rs
@@ -1,10 +1,28 @@
-//! `faucet-conformance` battery — Check 1 (config schema validity).
-//! Passing this battery in CI is the Tier-1 (supported) criterion.
+//! `faucet-conformance` battery — Check 1 (config schema validity) and
+//! Check 10 (connector_name non-empty). Passing this battery in CI is the
+//! Tier-1 (supported) criterion.
 use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::Sink as _;
+use faucet_sink_gcs::{GcsCredentials, GcsSink, GcsSinkConfig};
 
 #[test]
 fn conformance_config_schema_valid() {
     let schema =
         serde_json::to_value(schemars::schema_for!(faucet_sink_gcs::GcsSinkConfig)).unwrap();
     assert_config_schema_valid_value(&schema, "gcs");
+}
+
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+/// Building the GCS storage client with `Anonymous` creds + an endpoint
+/// override performs no I/O, so this runs unconditionally (no emulator needed).
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let config = GcsSinkConfig::new("does-not-exist")
+        .auth(GcsCredentials::Anonymous)
+        .storage_host("http://127.0.0.1:1");
+    let sink = GcsSink::new(config).await.expect("sink builds lazily");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
 }

--- a/crates/sink/http/tests/conformance.rs
+++ b/crates/sink/http/tests/conformance.rs
@@ -19,6 +19,17 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "http");
 }
 
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink = HttpSink::new(HttpSinkConfig::new("http://127.0.0.1:1/ingest"));
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
 #[tokio::test]
 async fn conformance_capabilities_truthful() {
     // A mock server that records every POST it receives. In Individual batch

--- a/crates/sink/iceberg/tests/conformance.rs
+++ b/crates/sink/iceberg/tests/conformance.rs
@@ -1,6 +1,7 @@
 //! `faucet-conformance` battery for the Iceberg sink.
 //!
-//! Only **check 1** (`assert_config_schema_valid_value`) runs here, so the
+//! **Check 1** (`assert_config_schema_valid_value`) and **check 10**
+//! (`connector_name()` non-empty, gated on `catalog-sql`) run here, so the
 //! Iceberg sink stays **Tier-2** for now. The effectively-once check (check 4)
 //! does not fit this sink cleanly on `iceberg-rust` 0.9.1: the sink is
 //! append-only and only materialises rows on `flush()` (it buffers in
@@ -20,4 +21,37 @@ fn conformance_config_schema_valid() {
     ))
     .unwrap();
     assert_config_schema_valid_value(&schema, "iceberg");
+}
+
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+/// Builds the sink fully offline against a SQLite catalog + local-FS warehouse
+/// (no Docker), so this runs under `--all-features` in CI. Gated on
+/// `catalog-sql` (the same feature the offline `integration.rs` uses).
+#[cfg(feature = "catalog-sql")]
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    use faucet_core::Sink as _;
+    use faucet_sink_iceberg::{IcebergSink, IcebergSinkConfig};
+
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("catalog.db");
+    let warehouse_path = dir.path().join("warehouse");
+    std::fs::create_dir_all(&warehouse_path).expect("create warehouse dir");
+    let sqlite_uri = format!("sqlite:{}?mode=rwc", db_path.display());
+    let warehouse_uri = format!("file://{}", warehouse_path.display());
+
+    let cfg: IcebergSinkConfig = serde_json::from_value(serde_json::json!({
+        "catalog": { "type": "sql", "uri": sqlite_uri, "warehouse": warehouse_uri },
+        "namespace": ["db"],
+        "table": "conformance_name",
+        "create_if_missing": true,
+        "batch_size": 0
+    }))
+    .expect("sink config parse");
+
+    let sink = IcebergSink::new(cfg).await.expect("IcebergSink::new");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
 }

--- a/crates/sink/jsonl/tests/conformance.rs
+++ b/crates/sink/jsonl/tests/conformance.rs
@@ -28,6 +28,31 @@ fn conformance_config_schema_valid() {
     );
 }
 
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink = JsonlSink::new(JsonlSinkConfig::new("/tmp/does-not-matter.jsonl"));
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // A writable parent directory makes the filesystem probe pass; the check
+    // must return Ok(report) with a well-formed probe.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.jsonl");
+    let sink = JsonlSink::new(JsonlSinkConfig::new(&path));
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn conformance_capabilities_truthful() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/sink/kafka/tests/conformance.rs
+++ b/crates/sink/kafka/tests/conformance.rs
@@ -23,6 +23,7 @@ fn conformance_config_schema_valid() {
 mod idempotent {
     use faucet_common_kafka::{CompressionType, KafkaAuth, KafkaValueFormat, OnKeyError};
     use faucet_core::DEFAULT_BATCH_SIZE;
+    use faucet_core::Sink as _;
     use faucet_sink_kafka::{Acks, KafkaSink, KafkaSinkConfig, KafkaSinkTopic};
     use rdkafka::ClientConfig;
     use rdkafka::Message;
@@ -141,6 +142,18 @@ mod idempotent {
     #[tokio::test(flavor = "multi_thread")]
     async fn conformance_capabilities_truthful() {
         let (_container, brokers, sink) = fresh_sink().await;
+        // Check 10: connector_name is non-empty (metric-cardinality contract).
+        faucet_conformance::assert_connector_name_nonempty_value(
+            sink.connector_name(),
+            sink.connector_name(),
+        );
+        // Check 11: preflight check() is well-formed against the live broker
+        // (`fetch_metadata` → a Pass probe inside Ok(report); nothing produced).
+        faucet_conformance::assert_sink_preflight_check_wellformed(
+            &sink,
+            &faucet_core::check::CheckContext::default(),
+        )
+        .await;
         faucet_conformance::assert_capabilities_truthful(&sink, || {
             let brokers = brokers.clone();
             async move { distinct_ids(&brokers, "conformance_dest").await }

--- a/crates/sink/kinesis/tests/conformance.rs
+++ b/crates/sink/kinesis/tests/conformance.rs
@@ -147,6 +147,20 @@ async fn conformance_capabilities_truthful() {
     cfg.credentials = test_credentials();
     let sink = KinesisSink::new(cfg).await.expect("sink");
 
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+    // Check 11: preflight check() is well-formed against the live stream
+    // (`DescribeStreamSummary` → a Pass probe inside Ok(report); nothing
+    // written).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
     let client_ref = &client;
     faucet_conformance::assert_capabilities_truthful(&sink, || async move {
         // PutRecords completes synchronously within write_batch; the records

--- a/crates/sink/mongodb/tests/conformance.rs
+++ b/crates/sink/mongodb/tests/conformance.rs
@@ -20,6 +20,27 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "mongodb");
 }
 
+// ── Check 10: connector_name is non-empty (offline) ──────────────────────────
+//
+// `MongoSink::new` only parses the URI (it spawns the driver's background
+// topology monitor, no blocking connect), so a sink builds offline and its
+// pure `connector_name()` can be asserted without Docker.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    use faucet_core::Sink;
+    let sink = faucet_sink_mongodb::MongoSink::new(faucet_sink_mongodb::MongoSinkConfig::new(
+        "mongodb://127.0.0.1:27017",
+        "testdb",
+        "events",
+    ))
+    .await
+    .expect("sink builds lazily");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
 mod idempotent {
     use faucet_sink_mongodb::{MongoSink, MongoSinkConfig};
     use mongodb::Client;
@@ -58,6 +79,24 @@ mod idempotent {
         (container, uri, sink)
     }
 
+    /// A fresh replica-set container + a **keyed upsert-mode** sink, so the
+    /// advertised `Upsert`/`Delete` write modes can be exercised through the
+    /// trait. Keyed on `["id"]` (the field the battery writes), with the
+    /// conformance delete marker (`__op` = `"d"`) so a delete-marked record
+    /// removes its row.
+    async fn keyed_sink() -> (ContainerAsync<Mongo>, String, MongoSink) {
+        let (container, uri) = start_mongo_repl_set().await;
+        let mut config = MongoSinkConfig::new(&uri, DB, COLLECTION);
+        config.write.write_mode = faucet_core::WriteMode::Upsert;
+        config.write.key = vec!["id".to_string()];
+        config.write.delete_marker = Some(faucet_core::DeleteMarker {
+            field: faucet_conformance::doubles::DELETE_MARKER_FIELD.to_string(),
+            values: vec![faucet_conformance::doubles::DELETE_MARKER_VALUE.to_string()],
+        });
+        let sink = MongoSink::new(config).await.expect("keyed sink new");
+        (container, uri, sink)
+    }
+
     async fn count_docs(uri: &str) -> usize {
         let client = Client::with_uri_str(uri).await.expect("client");
         client
@@ -82,6 +121,20 @@ mod idempotent {
     async fn conformance_capabilities_truthful() {
         let (_container, uri, sink) = fresh_sink().await;
         faucet_conformance::assert_capabilities_truthful(&sink, || {
+            let uri = uri.clone();
+            async move { count_docs(&uri).await }
+        })
+        .await;
+    }
+
+    /// Check 7: the advertised `Upsert`/`Delete` write modes are truthful — a
+    /// re-written key converges (no duplicate), a delete-marked record removes
+    /// its row, and missing/null-key rows are reported as failed. Uses a keyed
+    /// sink so `dedups_by_key()` is true and the modes can be exercised.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn conformance_write_modes_truthful() {
+        let (_container, uri, sink) = keyed_sink().await;
+        faucet_conformance::assert_write_modes_truthful(&sink, || {
             let uri = uri.clone();
             async move { count_docs(&uri).await }
         })

--- a/crates/sink/mssql/tests/conformance.rs
+++ b/crates/sink/mssql/tests/conformance.rs
@@ -15,7 +15,7 @@
 
 use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
 use faucet_conformance::assert_config_schema_valid_value;
-use faucet_core::{WriteMode, WriteSpec};
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
 use faucet_sink_mssql::{MssqlColumnMapping, MssqlSink, MssqlSinkConfig, OnUnknownField};
 use testcontainers_modules::mssql_server::MssqlServer;
 use testcontainers_modules::testcontainers::ContainerAsync;
@@ -77,7 +77,10 @@ async fn fresh_sink() -> (ContainerAsync<MssqlServer>, MssqlPool, MssqlSink) {
     scfg.write = WriteSpec {
         write_mode: WriteMode::Upsert,
         key: vec!["id".to_string()],
-        delete_marker: None,
+        delete_marker: Some(DeleteMarker {
+            field: "__op".to_string(),
+            values: vec!["d".to_string()],
+        }),
     };
     let sink = MssqlSink::new(scfg).await.expect("sink");
     (container, pool, sink)
@@ -95,22 +98,51 @@ async fn count_rows(pool: &MssqlPool) -> usize {
     rows[0].get::<i32, _>("c").expect("count value") as usize
 }
 
+/// Empty the data table so a following check starts from a known-clean state.
+async fn reset_rows(pool: &MssqlPool) {
+    exec(pool, "DELETE FROM dbo.t").await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_idempotent_replay() {
     let _serial = SERIAL.lock().await;
     let (_container, pool, sink) = fresh_sink().await;
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let pool = pool.clone();
         async move { count_rows(&pool).await }
     })
     .await;
+    // Check 8: schema evolution is effective (add-column surfaces in a fresh
+    // current_schema()). Independent of row state, so it can follow the replay.
+    faucet_conformance::assert_schema_evolution_effective(&sink).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_capabilities_truthful() {
     let _serial = SERIAL.lock().await;
     let (_container, pool, sink) = fresh_sink().await;
+    // Check 11: the sink's preflight check() returns Ok(report) with well-formed
+    // probes (non-mutating).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
     faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let pool = pool.clone();
+        async move { count_rows(&pool).await }
+    })
+    .await;
+    // Check 7: write modes are truthful (upsert converges, delete removes,
+    // missing/null keys are reported failed). Needs a clean table because the
+    // capabilities check above wrote rows.
+    reset_rows(&pool).await;
+    faucet_conformance::assert_write_modes_truthful(&sink, || {
         let pool = pool.clone();
         async move { count_rows(&pool).await }
     })

--- a/crates/sink/mysql/tests/conformance.rs
+++ b/crates/sink/mysql/tests/conformance.rs
@@ -11,7 +11,7 @@
 //! they require Docker.
 
 use faucet_conformance::assert_config_schema_valid_value;
-use faucet_core::{WriteMode, WriteSpec};
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
 use faucet_sink_mysql::{MysqlColumnMapping, MysqlSink, MysqlSinkConfig};
 use std::sync::OnceLock;
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
@@ -63,7 +63,10 @@ async fn fresh_sink() -> (
     cfg.write = WriteSpec {
         write_mode: WriteMode::Upsert,
         key: vec!["id".to_string()],
-        delete_marker: None,
+        delete_marker: Some(DeleteMarker {
+            field: "__op".to_string(),
+            values: vec!["d".to_string()],
+        }),
     };
     let sink = MysqlSink::new(cfg).await.expect("sink");
     (container, permit, url, sink)
@@ -81,20 +84,54 @@ async fn count_rows(url: &str) -> usize {
     n as usize
 }
 
+/// Empty the data table so a following check starts from a known-clean state.
+async fn reset_rows(url: &str) {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    sqlx::query("DELETE FROM t")
+        .execute(&pool)
+        .await
+        .expect("reset rows");
+    pool.close().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_idempotent_replay() {
     let (_container, _permit, url, sink) = fresh_sink().await;
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }
     })
     .await;
+    // Check 8: schema evolution is effective (add-column surfaces in a fresh
+    // current_schema()). Independent of row state, so it can follow the replay.
+    faucet_conformance::assert_schema_evolution_effective(&sink).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_capabilities_truthful() {
     let (_container, _permit, url, sink) = fresh_sink().await;
+    // Check 11: the sink's preflight check() returns Ok(report) with well-formed
+    // probes (non-mutating).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
     faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let url = url.clone();
+        async move { count_rows(&url).await }
+    })
+    .await;
+    // Check 7: write modes are truthful (upsert converges, delete removes,
+    // missing/null keys are reported failed). Needs a clean table because the
+    // capabilities check above wrote rows.
+    reset_rows(&url).await;
+    faucet_conformance::assert_write_modes_truthful(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }
     })

--- a/crates/sink/nats/tests/conformance.rs
+++ b/crates/sink/nats/tests/conformance.rs
@@ -25,6 +25,7 @@ fn conformance_config_schema_valid() {
 #[cfg(test)]
 mod docker {
     use super::*;
+    use faucet_core::Sink as _;
     use faucet_sink_nats::NatsSink;
     use futures::StreamExt;
     use std::sync::Arc;
@@ -62,6 +63,20 @@ mod docker {
         let mut cfg = NatsSinkConfig::new(subject);
         cfg.connection.servers = vec![server.clone()];
         let sink = NatsSink::new(cfg).await.expect("sink new");
+
+        // Check 10: connector_name is non-empty (metric-cardinality contract).
+        faucet_conformance::assert_connector_name_nonempty_value(
+            sink.connector_name(),
+            sink.connector_name(),
+        );
+        // Check 11: the append-only NATS sink implements no custom check(), so
+        // the core default returns a well-formed single Skip probe inside
+        // Ok(report) — never an Err.
+        faucet_conformance::assert_sink_preflight_check_wellformed(
+            &sink,
+            &faucet_core::check::CheckContext::default(),
+        )
+        .await;
 
         let counter_cl = counter.clone();
         faucet_conformance::assert_capabilities_truthful(&sink, move || {

--- a/crates/sink/parquet/tests/conformance.rs
+++ b/crates/sink/parquet/tests/conformance.rs
@@ -48,6 +48,39 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "parquet");
 }
 
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[tokio::test]
+async fn conformance_connector_name_nonempty() {
+    let dir = tempfile::tempdir().unwrap();
+    let sink = ParquetSink::new(ParquetSinkConfig::local(
+        dir.path().to_string_lossy().to_string(),
+    ))
+    .await
+    .unwrap();
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // A writable local target dir makes the filesystem probe pass; the check
+    // must return Ok(report) with a well-formed probe.
+    let dir = tempfile::tempdir().unwrap();
+    let sink = ParquetSink::new(ParquetSinkConfig::local(
+        dir.path().to_string_lossy().to_string(),
+    ))
+    .await
+    .unwrap();
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn conformance_capabilities_truthful() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/sink/postgres/tests/conformance.rs
+++ b/crates/sink/postgres/tests/conformance.rs
@@ -12,7 +12,7 @@
 //! they require Docker.
 
 use faucet_conformance::assert_config_schema_valid_value;
-use faucet_core::{WriteMode, WriteSpec};
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
 use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
 use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
 use testcontainers_modules::postgres::Postgres;
@@ -51,7 +51,10 @@ async fn fresh_sink() -> (ContainerAsync<Postgres>, String, PostgresSink) {
     cfg.write = WriteSpec {
         write_mode: WriteMode::Upsert,
         key: vec!["id".to_string()],
-        delete_marker: None,
+        delete_marker: Some(DeleteMarker {
+            field: "__op".to_string(),
+            values: vec!["d".to_string()],
+        }),
     };
     let sink = PostgresSink::new(cfg).await.expect("sink");
     (container, url, sink)
@@ -67,20 +70,54 @@ async fn count_rows(url: &str) -> usize {
     count as usize
 }
 
+/// Empty the data table so a following check starts from a known-clean state.
+async fn reset_rows(url: &str) {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    sqlx::query("DELETE FROM t")
+        .execute(&pool)
+        .await
+        .expect("reset rows");
+    pool.close().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_idempotent_replay() {
     let (_container, url, sink) = fresh_sink().await;
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }
     })
     .await;
+    // Check 8: schema evolution is effective (add-column surfaces in a fresh
+    // current_schema()). Independent of row state, so it can follow the replay.
+    faucet_conformance::assert_schema_evolution_effective(&sink).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_capabilities_truthful() {
     let (_container, url, sink) = fresh_sink().await;
+    // Check 11: the sink's preflight check() returns Ok(report) with well-formed
+    // probes (non-mutating).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
     faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let url = url.clone();
+        async move { count_rows(&url).await }
+    })
+    .await;
+    // Check 7: write modes are truthful (upsert converges, delete removes,
+    // missing/null keys are reported failed). Needs a clean table because the
+    // capabilities check above wrote rows.
+    reset_rows(&url).await;
+    faucet_conformance::assert_write_modes_truthful(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }
     })

--- a/crates/sink/pubsub/tests/conformance.rs
+++ b/crates/sink/pubsub/tests/conformance.rs
@@ -110,6 +110,19 @@ async fn conformance_capabilities_truthful() {
     cfg.value_format = ValueFormat::Json;
     let sink = PubsubSink::new(cfg).await.expect("sink builds");
 
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+    // Check 11: preflight check() is well-formed against the emulator (the
+    // topic created above exists → a Pass probe inside Ok(report)).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
     let seen = Arc::new(AtomicUsize::new(0));
     let sub = Arc::new(sub);
     assert_capabilities_truthful_count(&sink, seen, sub).await;

--- a/crates/sink/redis/tests/conformance.rs
+++ b/crates/sink/redis/tests/conformance.rs
@@ -20,6 +20,7 @@ fn conformance_config_schema_valid() {
 }
 
 mod idempotent {
+    use faucet_core::Sink as _;
     use faucet_sink_redis::{RedisSink, RedisSinkConfig, RedisSinkType};
     use redis::AsyncCommands;
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
@@ -90,6 +91,18 @@ mod idempotent {
     #[tokio::test(flavor = "multi_thread")]
     async fn conformance_capabilities_truthful() {
         let (_container, url, sink) = fresh_sink().await;
+        // Check 10: connector_name is non-empty (metric-cardinality contract).
+        faucet_conformance::assert_connector_name_nonempty_value(
+            sink.connector_name(),
+            sink.connector_name(),
+        );
+        // Check 11: preflight check() is well-formed against the live server
+        // (Redis `PING` → a Pass probe inside Ok(report); nothing written).
+        faucet_conformance::assert_sink_preflight_check_wellformed(
+            &sink,
+            &faucet_core::check::CheckContext::default(),
+        )
+        .await;
         faucet_conformance::assert_capabilities_truthful(&sink, || {
             let url = url.clone();
             async move { count_entries(&url).await }

--- a/crates/sink/s3/tests/conformance.rs
+++ b/crates/sink/s3/tests/conformance.rs
@@ -88,6 +88,19 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "s3");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let config = S3SinkConfig::new("does-not-exist")
+        .endpoint_url("http://127.0.0.1:1".to_string())
+        .region(REGION.to_string());
+    let sink = S3Sink::new(config).await.expect("sink builds lazily");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_capabilities_truthful() {
     let (_container, endpoint) = start_minio().await;

--- a/crates/sink/sftp/tests/conformance.rs
+++ b/crates/sink/sftp/tests/conformance.rs
@@ -31,6 +31,27 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "sftp");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+/// `SftpSink::new` is lazy (no connect at build time), so this runs
+/// unconditionally with no container.
+#[test]
+fn conformance_connector_name_nonempty() {
+    let conn = SftpConnectionConfig {
+        host: "127.0.0.1".to_string(),
+        port: 1,
+        username: "nobody".to_string(),
+        auth: SftpAuth::Password {
+            password: "x".to_string(),
+        },
+        known_hosts: HostKeyPolicy::Insecure,
+    };
+    let sink = SftpSink::new(SftpSinkConfig::new(conn, "/data")).expect("sink builds lazily");
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
 // ── Check 5: capabilities truthful (Docker) ─────────────────────────────────
 
 async fn start_sftp() -> Option<(ContainerAsync<GenericImage>, u16)> {

--- a/crates/sink/snowflake/tests/conformance.rs
+++ b/crates/sink/snowflake/tests/conformance.rs
@@ -1,12 +1,26 @@
-//! `faucet-conformance` battery — Check 1 (config schema validity).
-//! Passing this battery in CI is the Tier-1 (supported) criterion.
-use faucet_conformance::assert_config_schema_valid_value;
+//! `faucet-conformance` battery — Check 1 (config schema validity) and Check 10
+//! (connector_name non-empty). Passing this battery in CI is the Tier-1
+//! (supported) criterion.
+use faucet_conformance::{assert_config_schema_valid_value, assert_connector_name_nonempty_value};
+use faucet_sink_snowflake::{Sink as _, SnowflakeAuth, SnowflakeSink, SnowflakeSinkConfig};
 
 #[test]
 fn conformance_config_schema_valid() {
-    let schema = serde_json::to_value(schemars::schema_for!(
-        faucet_sink_snowflake::SnowflakeSinkConfig
-    ))
-    .unwrap();
+    let schema = serde_json::to_value(schemars::schema_for!(SnowflakeSinkConfig)).unwrap();
     assert_config_schema_valid_value(&schema, "snowflake");
+}
+
+// ── Check 10: connector_name is non-empty (offline, lazy sink) ───────────────
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink = SnowflakeSink::new(SnowflakeSinkConfig::new(
+        "xy12345",
+        "WH",
+        "DB",
+        "PUBLIC",
+        "t",
+        SnowflakeAuth::OAuth { token: "t".into() },
+    ))
+    .expect("sink builds lazily");
+    assert_connector_name_nonempty_value(sink.connector_name(), sink.connector_name());
 }

--- a/crates/sink/spanner/tests/conformance.rs
+++ b/crates/sink/spanner/tests/conformance.rs
@@ -12,7 +12,8 @@
 mod support;
 
 use faucet_conformance::assert_config_schema_valid_value;
-use faucet_core::{WriteMode, WriteSpec};
+use faucet_core::Sink as _;
+use faucet_core::{DeleteMarker, WriteMode, WriteSpec};
 use faucet_sink_spanner::{SpannerSink, SpannerSinkConfig};
 
 #[test]
@@ -47,6 +48,34 @@ async fn fresh_sink(database: &str) -> SpannerSink {
     SpannerSink::new(cfg).await.expect("sink")
 }
 
+/// Like [`fresh_sink`] but configured with the standard `cdc_unwrap` delete
+/// marker, so the delete sub-check of `assert_write_modes_truthful` can drive a
+/// keyed removal through the trait.
+async fn fresh_sink_delete(database: &str) -> SpannerSink {
+    let conn = support::create_database(
+        database,
+        vec!["CREATE TABLE t (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)".to_string()],
+    )
+    .await;
+    let mut cfg = SpannerSinkConfig::new(
+        conn.project_id.clone(),
+        conn.instance.clone(),
+        conn.database.clone(),
+        "t",
+    )
+    .with_batch_size(0);
+    cfg.connection.emulator_host = conn.emulator_host.clone();
+    cfg.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: Some(DeleteMarker {
+            field: faucet_conformance::doubles::DELETE_MARKER_FIELD.to_string(),
+            values: vec![faucet_conformance::doubles::DELETE_MARKER_VALUE.to_string()],
+        }),
+    };
+    SpannerSink::new(cfg).await.expect("sink")
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn conformance_idempotent_replay() {
     // Check 4: re-delivering committed rows leaves no duplicates.
@@ -63,8 +92,34 @@ async fn conformance_idempotent_replay() {
 async fn conformance_capabilities_truthful() {
     // Check 5: advertised capabilities match real behaviour.
     let sink = fresh_sink("conf-caps").await;
+    // Check 10: connector_name() is non-empty (reuses this live instance).
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
     let conn = support::connection("conf-caps", &support::emulator_host().await);
     faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let conn = conn.clone();
+        async move { support::count_rows(&conn, "t").await }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_schema_evolution_effective() {
+    // Check 8: evolve_schema adds a column that then appears in a fresh
+    // current_schema() (Spanner advertises schema evolution).
+    let sink = fresh_sink("conf-evolve").await;
+    faucet_conformance::assert_schema_evolution_effective(&sink).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_write_modes_truthful() {
+    // Check 7: the advertised Upsert/Delete modes genuinely converge by key and
+    // remove on the delete marker; missing/null keys are reported as failed.
+    let sink = fresh_sink_delete("conf-wm").await;
+    let conn = support::connection("conf-wm", &support::emulator_host().await);
+    faucet_conformance::assert_write_modes_truthful(&sink, || {
         let conn = conn.clone();
         async move { support::count_rows(&conn, "t").await }
     })

--- a/crates/sink/sqlite/tests/conformance.rs
+++ b/crates/sink/sqlite/tests/conformance.rs
@@ -11,7 +11,7 @@
 //!
 //! Runs against a tempfile SQLite database — no Docker required.
 
-use faucet_core::{Sink, WriteMode, WriteSpec};
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
 use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
 use sqlx::Row;
 use sqlx::sqlite::SqlitePoolOptions;
@@ -42,7 +42,10 @@ async fn fresh_sink() -> (TempDir, String, SqliteSink) {
         write: WriteSpec {
             write_mode: WriteMode::Upsert,
             key: vec!["id".to_string()],
-            delete_marker: None,
+            delete_marker: Some(DeleteMarker {
+                field: "__op".to_string(),
+                values: vec!["d".to_string()],
+            }),
         },
     };
     let sink = SqliteSink::new(cfg).await.expect("sink");
@@ -64,6 +67,20 @@ async fn count_rows(url: &str) -> usize {
     n as usize
 }
 
+/// Empty the data table so a following check starts from a known-clean state.
+async fn reset_rows(url: &str) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("connect");
+    sqlx::query("DELETE FROM t")
+        .execute(&pool)
+        .await
+        .expect("reset rows");
+    pool.close().await;
+}
+
 #[tokio::test]
 async fn conformance_config_schema_valid() {
     let (_dir, _url, sink) = fresh_sink().await;
@@ -76,17 +93,41 @@ async fn conformance_config_schema_valid() {
 #[tokio::test]
 async fn conformance_idempotent_replay() {
     let (_dir, url, sink) = fresh_sink().await;
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }
     })
     .await;
+    // Check 8: schema evolution is effective (add-column surfaces in a fresh
+    // current_schema()). Independent of row state, so it can follow the replay.
+    faucet_conformance::assert_schema_evolution_effective(&sink).await;
 }
 
 #[tokio::test]
 async fn conformance_capabilities_truthful() {
     let (_dir, url, sink) = fresh_sink().await;
+    // Check 11: the sink's preflight check() returns Ok(report) with well-formed
+    // probes (non-mutating).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
     faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let url = url.clone();
+        async move { count_rows(&url).await }
+    })
+    .await;
+    // Check 7: write modes are truthful (upsert converges, delete removes,
+    // missing/null keys are reported failed). Needs a clean table because the
+    // capabilities check above wrote rows.
+    reset_rows(&url).await;
+    faucet_conformance::assert_write_modes_truthful(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }
     })

--- a/crates/sink/sqs/tests/conformance.rs
+++ b/crates/sink/sqs/tests/conformance.rs
@@ -96,6 +96,19 @@ async fn conformance_capabilities_truthful() {
     cfg.credentials = test_credentials();
     let sink = SqsSink::new(cfg).await.expect("sink");
 
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+    // Check 11: preflight check() is well-formed against the live queue
+    // (`GetQueueAttributes` → a Pass probe inside Ok(report); nothing written).
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
     let client_ref = &client;
     let url = queue_url.clone();
     faucet_conformance::assert_capabilities_truthful(&sink, || {

--- a/crates/sink/stdout/tests/conformance.rs
+++ b/crates/sink/stdout/tests/conformance.rs
@@ -62,6 +62,29 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "stdout");
 }
 
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[test]
+fn conformance_connector_name_nonempty() {
+    let sink = StdoutSink::new(StdoutSinkConfig::new());
+    faucet_conformance::assert_connector_name_nonempty_value(
+        sink.connector_name(),
+        sink.connector_name(),
+    );
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // The stdout sink's probe always passes; the check must return Ok(report)
+    // with a well-formed probe.
+    let sink = StdoutSink::new(StdoutSinkConfig::new());
+    faucet_conformance::assert_sink_preflight_check_wellformed(
+        &sink,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn conformance_capabilities_truthful() {
     let capture = CaptureWriter::default();

--- a/crates/source/azure-blob/tests/conformance.rs
+++ b/crates/source/azure-blob/tests/conformance.rs
@@ -19,6 +19,24 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "faucet-source-azure-blob");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+/// The `object_store` Azure builder is lazy, so this runs unconditionally with
+/// no container.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let config = AzureBlobSourceConfig::new("does-not-exist")
+        .account("devstoreaccount1")
+        .auth(AzureCredentials::AccountKey {
+            account_key: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==".into(),
+        })
+        .endpoint("http://127.0.0.1:1")
+        .allow_http(true);
+    let source = AzureBlobSource::new(config)
+        .await
+        .expect("source builds lazily");
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
 // ── Check 6: errors, not panics (no container) ──────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/source/bigquery/tests/conformance.rs
+++ b/crates/source/bigquery/tests/conformance.rs
@@ -13,7 +13,8 @@
 //! `batch_size` (250), so peak page is 250 < 6 000.
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
+    assert_errors_not_panics,
 };
 use faucet_source_bigquery::{BigQueryCredentials, BigQuerySource, BigQuerySourceConfig};
 use gcp_bigquery_client::client_builder::ClientBuilder;
@@ -193,6 +194,9 @@ async fn conformance_errors_not_panics() {
         "SELECT id FROM events",
     );
     let source = BigQuerySource::from_parts(config, client);
+
+    // Check 10: connector_name() is non-empty (reuses this offline instance).
+    assert_connector_name_nonempty(&source);
 
     assert_errors_not_panics(&source).await;
 }

--- a/crates/source/clickhouse/tests/conformance.rs
+++ b/crates/source/clickhouse/tests/conformance.rs
@@ -8,7 +8,8 @@
 //! in CI is the Tier-1 (supported) criterion.
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
+    assert_errors_not_panics,
 };
 use faucet_source_clickhouse::{ClickHouseSource, ClickHouseSourceConfig};
 use testcontainers_modules::clickhouse::ClickHouse;
@@ -55,6 +56,8 @@ async fn conformance_errors_not_panics() {
         "SELECT 1",
     ))
     .expect("source builds lazily");
+    // Check 10: connector_name() is non-empty (reuses this offline instance).
+    assert_connector_name_nonempty(&source);
     assert_errors_not_panics(&source).await;
 }
 

--- a/crates/source/csv/tests/conformance.rs
+++ b/crates/source/csv/tests/conformance.rs
@@ -1,17 +1,65 @@
 //! Proves `faucet-source-csv` upholds the shared connector contract by invoking
-//! the reusable `faucet-conformance` battery (checks 1, 2 & 6).
+//! the reusable `faucet-conformance` battery (checks 1, 2, 6, 9, 10 & 11).
 //!
 //! CSV is a full-table source (no bookmark) and not a sink, so check 3
-//! (bookmark round-trip) and checks 4/5 (sink capabilities) do not apply.
+//! (bookmark round-trip) and checks 4/5/7/8 (sink capabilities) do not apply.
 
 use std::io::Write;
 
 use faucet_source_csv::{CsvSource, CsvSourceConfig};
 
+/// Write a small CSV with `total` `(id, name)` rows and return the temp file.
+fn small_fixture(total: usize) -> tempfile::NamedTempFile {
+    let mut file = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(file, "id,name").unwrap();
+    for i in 0..total {
+        writeln!(file, "{i},row-{i}").unwrap();
+    }
+    file.flush().unwrap();
+    file
+}
+
 #[test]
 fn conformance_config_schema_valid() {
     let source = CsvSource::new(CsvSourceConfig::new("/tmp/does-not-matter.csv"));
     faucet_conformance::assert_config_schema_valid(&source);
+}
+
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[test]
+fn conformance_connector_name_nonempty() {
+    let source = CsvSource::new(CsvSourceConfig::new("/tmp/does-not-matter.csv"));
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
+// ── Check 9: batch_size=0 yields a single page ────────────────────────────────
+#[tokio::test]
+async fn conformance_batch_size_zero_single_page() {
+    // `batch_size = 0` is the CSV source's "no batching" sentinel — it drains the
+    // whole file into one page. The config value is authoritative.
+    let file = small_fixture(6);
+    let config = CsvSourceConfig {
+        batch_size: 0,
+        ..CsvSourceConfig::new(file.path().to_string_lossy().to_string())
+    };
+    let source = CsvSource::new(config);
+    faucet_conformance::assert_batch_size_zero_single_page(&source).await;
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // A valid file makes the default page-pull probe pass; the check must return
+    // Ok(report) with a well-formed probe regardless.
+    let file = small_fixture(6);
+    let source = CsvSource::new(CsvSourceConfig::new(
+        file.path().to_string_lossy().to_string(),
+    ));
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/source/databricks/tests/conformance.rs
+++ b/crates/source/databricks/tests/conformance.rs
@@ -5,7 +5,9 @@
 //! batch_size, every row streamed) against a wiremock-served result set, i.e.
 //! memory stays O(batch_size) regardless of total rows.
 
-use faucet_conformance::{assert_bounded_memory, assert_config_schema_valid_value};
+use faucet_conformance::{
+    assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
+};
 use faucet_core::AuthSpec;
 use faucet_source_databricks::{
     DatabricksAuth, DatabricksReplication, DatabricksSource, DatabricksSourceConfig,
@@ -60,6 +62,9 @@ async fn conformance_bounded_memory() {
     let src = DatabricksSource::new(config)
         .unwrap()
         .with_endpoint_base(server.uri());
+
+    // Check 10: connector_name() is non-empty (reuses this instance).
+    assert_connector_name_nonempty(&src);
 
     assert_bounded_memory(&src, batch, total).await;
 }

--- a/crates/source/delta/tests/conformance.rs
+++ b/crates/source/delta/tests/conformance.rs
@@ -6,8 +6,10 @@
 //! criterion — see the connector catalog's "Support tiers" note.
 //!
 //! Checks exercised: 1 (config schema, offline), 2 (bounded-memory streaming),
-//! and 6 (errors, not panics). Delta is a snapshot source (no incremental
-//! bookmark), so checks 3–5 do not apply.
+//! 6 (errors, not panics), 9 (`batch_size = 0` single page), 10
+//! (`connector_name()` non-empty), and 11 (`check()` well-formed). Delta is a
+//! snapshot source (no incremental bookmark) and not a sink, so checks 3 and
+//! 4/5/7/8 do not apply.
 
 use std::sync::Arc;
 
@@ -19,7 +21,8 @@ use deltalake::kernel::engine::arrow_conversion::TryIntoKernel;
 use deltalake::operations::create::CreateBuilder;
 use deltalake::writer::{DeltaWriter, RecordBatchWriter};
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_core::Source as _;
 use faucet_source_delta::{DeltaSource, DeltaSourceConfig};
@@ -97,4 +100,45 @@ async fn conformance_errors_not_panics() {
     if let Ok(source) = DeltaSource::new(DeltaSourceConfig::new(&uri)).await {
         assert_errors_not_panics(&source).await;
     }
+}
+
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "name");
+    seed(&uri, 1).await;
+    let source = DeltaSource::new(DeltaSourceConfig::new(&uri))
+        .await
+        .expect("source");
+    assert_connector_name_nonempty(&source);
+}
+
+// ── Check 9: batch_size=0 yields a single page ────────────────────────────────
+/// A small single-commit table read under the `batch_size = 0` sentinel (native
+/// row-group cadence) must surface as exactly one page.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_batch_size_zero_single_page() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "single_page");
+    seed(&uri, 6).await;
+
+    let mut cfg = DeltaSourceConfig::new(&uri);
+    cfg.batch_size = 0;
+    let source = DeltaSource::new(cfg).await.expect("source");
+    assert_batch_size_zero_single_page(&source).await;
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+/// A seeded table makes delta's metadata-open probe pass; the check must return
+/// Ok(report) with a well-formed probe.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_preflight_check_wellformed() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "preflight");
+    seed(&uri, 6).await;
+    let source = DeltaSource::new(DeltaSourceConfig::new(&uri))
+        .await
+        .expect("source");
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 }

--- a/crates/source/duckdb/tests/conformance.rs
+++ b/crates/source/duckdb/tests/conformance.rs
@@ -37,6 +37,22 @@ async fn conformance_config_schema_valid() {
         .await
         .expect("source");
     faucet_conformance::assert_config_schema_valid(&source);
+    // Check 10: connector_name() is non-empty (reuses this offline instance).
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
+#[tokio::test]
+async fn conformance_batch_size_zero_single_page() {
+    // Check 9: a source built with `batch_size = 0` yields the whole result set
+    // as a single page (the DuckDB "no batching" sentinel).
+    let total = 200;
+    let (_dir, path) = seed(total);
+    let source = DuckdbSource::new(
+        DuckdbSourceConfig::new(path, "SELECT id, name FROM t ORDER BY id").with_batch_size(0),
+    )
+    .await
+    .expect("source");
+    faucet_conformance::assert_batch_size_zero_single_page(&source).await;
 }
 
 #[tokio::test]

--- a/crates/source/elasticsearch/tests/conformance.rs
+++ b/crates/source/elasticsearch/tests/conformance.rs
@@ -15,7 +15,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_elasticsearch::{ElasticsearchSource, ElasticsearchSourceConfig};
 use serde_json::{Value, json};
@@ -120,15 +121,52 @@ async fn conformance_bounded_memory() {
     assert_bounded_memory(&source, 250, 6_250).await;
 }
 
+// ── Check 9: batch_size=0 emits a single page ─────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_batch_size_zero_single_page() {
+    // `batch_size = 0` is the "no batching" sentinel — the source issues a
+    // single non-scroll `_search` and yields the whole result set as one page.
+    let server = MockServer::start().await;
+    mount_paged_responder(&server, PagedResponder::new(1, 500)).await;
+
+    let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(0);
+    let source = ElasticsearchSource::new(config).expect("source new");
+
+    assert_batch_size_zero_single_page(&source).await;
+}
+
 // ── Check 6: errors, not panics ──────────────────────────────────────────────
+
+/// A source pointed at an unreachable endpoint. `new()` builds (lazy HTTP
+/// client); the first read errors with a typed `FaucetError` (connection
+/// refused). Port 1 refuses connections immediately on all platforms.
+fn unreachable_source() -> ElasticsearchSource {
+    ElasticsearchSource::new(ElasticsearchSourceConfig::new("http://127.0.0.1:1", "idx"))
+        .expect("source new")
+}
 
 #[tokio::test]
 async fn conformance_errors_not_panics() {
-    // Unreachable endpoint: `new()` builds (lazy HTTP client), the first read
-    // errors with a typed `FaucetError` (connection refused) without panicking.
-    // Port 1 refuses connections immediately on all platforms.
-    let source =
-        ElasticsearchSource::new(ElasticsearchSourceConfig::new("http://127.0.0.1:1", "idx"))
-            .expect("source new");
-    assert_errors_not_panics(&source).await;
+    assert_errors_not_panics(&unreachable_source()).await;
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    assert_connector_name_nonempty(&unreachable_source());
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // The default `Source::check` probes the real read path; an unreachable
+    // endpoint surfaces as a `Fail` probe inside `Ok(report)`, never an `Err`.
+    assert_preflight_check_wellformed(
+        &unreachable_source(),
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }

--- a/crates/source/gcs/tests/conformance.rs
+++ b/crates/source/gcs/tests/conformance.rs
@@ -28,6 +28,21 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "faucet-source-gcs");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+/// Building the gRPC storage clients with `Anonymous` creds + an endpoint
+/// override performs no I/O, so this runs unconditionally (no emulator needed).
+/// Check 9 (`batch_size = 0` single page) is intentionally *not* added: like the
+/// bounded-memory check it would need the gRPC read path, which `fake-gcs-server`
+/// cannot serve.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let config = GcsSourceConfig::new("does-not-exist")
+        .auth(GcsCredentials::Anonymous)
+        .storage_host("http://127.0.0.1:1");
+    let source = GcsSource::new(config).await.expect("source builds lazily");
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
 // ── Check 2: bounded-memory streaming (live gRPC backend, ignored) ──────────
 
 /// Spawn `fake-gcs-server` and return `(host_url, bucket_name)`.

--- a/crates/source/graphql/tests/conformance.rs
+++ b/crates/source/graphql/tests/conformance.rs
@@ -6,7 +6,8 @@
 //! the batch cap and strictly < the total).
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_graphql::config::GraphqlPagination;
 use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
@@ -115,14 +116,69 @@ async fn conformance_bounded_memory() {
 
 // ── Check 6: errors, not panics ──────────────────────────────────────────────
 
-#[tokio::test]
-async fn conformance_errors_not_panics() {
-    // Unreachable endpoint: `new()` builds (lazy HTTP client), the first read
-    // errors with a typed `FaucetError` (connection refused) without panicking.
-    // Port 1 refuses connections immediately on all platforms.
-    let source = GraphqlStream::new(GraphqlStreamConfig::new(
+/// A source pointed at an unreachable endpoint. `new()` is lazy (it builds the
+/// HTTP client), so the failure surfaces on first read. Port 1 refuses
+/// connections immediately on all platforms.
+fn unreachable_source() -> GraphqlStream {
+    GraphqlStream::new(GraphqlStreamConfig::new(
         "http://127.0.0.1:1",
         "query { users { edges { node { id } } } }",
-    ));
-    assert_errors_not_panics(&source).await;
+    ))
+}
+
+#[tokio::test]
+async fn conformance_errors_not_panics() {
+    assert_errors_not_panics(&unreachable_source()).await;
+}
+
+// ── Check 9: batch_size=0 emits a single page ─────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_batch_size_zero_single_page() {
+    // With `batch_size = 0` the source omits the `first:` variable and expects
+    // the upstream to return the whole result set in one response — so a single
+    // GraphQL response with `hasNextPage: false` is emitted as one `StreamPage`.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(make_page(0, 50, None)))
+        .mount(&server)
+        .await;
+
+    let config = GraphqlStreamConfig::new(
+        server.uri(),
+        "query($first: Int, $after: String) { users(first: $first, after: $after) { \
+         edges { node { id } } pageInfo { hasNextPage endCursor } } }",
+    )
+    .records_path("$.data.users.edges[*].node")
+    .pagination(GraphqlPagination {
+        has_next_page_path: "$.data.users.pageInfo.hasNextPage".into(),
+        cursor_path: "$.data.users.pageInfo.endCursor".into(),
+        cursor_variable: "after".into(),
+        page_size_variable: "first".into(),
+    })
+    .with_batch_size(0);
+
+    let source = GraphqlStream::new(config);
+    assert_batch_size_zero_single_page(&source).await;
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    assert_connector_name_nonempty(&unreachable_source());
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // The default `Source::check` probes the real read path; an unreachable
+    // endpoint surfaces as a `Fail` probe inside `Ok(report)`, never an `Err`.
+    assert_preflight_check_wellformed(
+        &unreachable_source(),
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }

--- a/crates/source/grpc/tests/conformance.rs
+++ b/crates/source/grpc/tests/conformance.rs
@@ -14,7 +14,8 @@
 mod common;
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
+    assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, RpcKind};
 use serde_json::json;
@@ -53,16 +54,15 @@ async fn conformance_bounded_memory() {
 
 // ── Check 6: errors, not panics ──────────────────────────────────────────────
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn conformance_errors_not_panics() {
-    // Unreachable endpoint: `new()` only validates config (no eager connect),
-    // so the channel connect happens at read time and fails with a typed
-    // `FaucetError`. Port 1 refuses connections immediately on all platforms.
-    // Unary is the default RPC kind — its single connect attempt surfaces the
-    // error directly (ServerStreaming would retry forever on the unlimited
-    // default `reconnect_max_attempts`). A real descriptor set is still
-    // required to construct the source, so reuse the shared fixture path; the
-    // connect fails before the RPC method is ever invoked.
+/// A source pointed at an unreachable endpoint in **unary** mode. `new()` only
+/// validates config (no eager connect), so the channel connect happens at read
+/// time and fails with a typed `FaucetError`. Port 1 refuses connections
+/// immediately on all platforms. Unary is used deliberately — its single
+/// connect attempt surfaces the error directly (ServerStreaming would retry
+/// forever on the unlimited default `reconnect_max_attempts`). A real
+/// descriptor set is still required to construct the source, so reuse the
+/// shared fixture path; the connect fails before the RPC method is invoked.
+fn unreachable_source() -> GrpcStream {
     let config = GrpcStreamConfig::new(
         "http://127.0.0.1:1",
         "faucet.test.echo.EchoService",
@@ -71,7 +71,31 @@ async fn conformance_errors_not_panics() {
     )
     .request(json!({ "count": 1 }))
     .rpc_kind(RpcKind::Unary);
+    GrpcStream::new(config).expect("grpc stream builds from a valid config")
+}
 
-    let stream = GrpcStream::new(config).expect("grpc stream builds from a valid config");
-    assert_errors_not_panics(&stream).await;
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conformance_errors_not_panics() {
+    assert_errors_not_panics(&unreachable_source()).await;
+}
+
+// ── Check 10: connector_name non-empty ────────────────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    assert_connector_name_nonempty(&unreachable_source());
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conformance_preflight_check_wellformed() {
+    // The default `Source::check` probes the real read path; an unreachable
+    // endpoint (unary) surfaces as a `Fail` probe inside `Ok(report)`, never
+    // an `Err`.
+    assert_preflight_check_wellformed(
+        &unreachable_source(),
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }

--- a/crates/source/kafka/tests/conformance.rs
+++ b/crates/source/kafka/tests/conformance.rs
@@ -108,6 +108,16 @@ async fn conformance_bounded_memory() {
     let cfg = source_config(&brokers, topic, "g-conformance-bounded", 5_000, 250);
     let source = KafkaSource::new(cfg).await.expect("source new");
 
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty(&source);
+    // Check 11: preflight check() is well-formed against the live broker
+    // (`fetch_metadata` → a Pass probe inside Ok(report); no records consumed).
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
     // _container stays alive to here
 }

--- a/crates/source/kinesis/tests/conformance.rs
+++ b/crates/source/kinesis/tests/conformance.rs
@@ -150,6 +150,15 @@ async fn conformance_bounded_memory() {
         .await
         .expect("source");
 
+    // Check 11: preflight check() is well-formed against the live stream
+    // (`DescribeStreamSummary` → a Pass probe inside Ok(report); no records
+    // consumed).
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
     // _container stays alive to here
 }
@@ -199,5 +208,7 @@ async fn conformance_errors_not_panics() {
     cfg.max_messages = Some(10);
 
     let source = KinesisSource::new(cfg).await.expect("source builds lazily");
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty(&source);
     assert_errors_not_panics(&source).await;
 }

--- a/crates/source/mongodb-cdc/tests/conformance.rs
+++ b/crates/source/mongodb-cdc/tests/conformance.rs
@@ -16,7 +16,7 @@
 
 use faucet_conformance::{
     assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
-    assert_errors_not_panics,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_mongodb_cdc::{MongoCdcSource, MongoCdcSourceConfig};
 use mongodb::Client;
@@ -89,6 +89,13 @@ async fn conformance_bounded_memory() {
     }
 
     let source = MongoCdcSource::new(config(&uri)).await.expect("source");
+
+    // Check 10: connector_name is non-empty (pure — no I/O).
+    assert_connector_name_nonempty(&source);
+    // Check 11: preflight check() is well-formed against the live replica set.
+    // The CDC check() is overridden to run a read-only `hello` + topology probe
+    // (never a page pull), so it is safe to call in the live test.
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 
     // Concurrent writer: wait ~2 s for the change stream to open, then insert
     // TOTAL documents (each a distinct change event). After the writer goes

--- a/crates/source/mongodb/tests/conformance.rs
+++ b/crates/source/mongodb/tests/conformance.rs
@@ -6,7 +6,7 @@
 //! matches the existing streaming integration test's container boot + seeding
 //! path verbatim.
 
-use faucet_conformance::assert_config_schema_valid_value;
+use faucet_conformance::{assert_config_schema_valid_value, assert_connector_name_nonempty};
 use faucet_source_mongodb::{MongoSource, MongoSourceConfig};
 use mongodb::Client;
 use mongodb::bson::{Document, doc};
@@ -52,10 +52,30 @@ async fn conformance_bounded_memory() {
     let (_container, uri) = start_mongo().await;
     seed_docs(&uri, "testdb", "events", 5_000).await;
 
-    let config = MongoSourceConfig::new(uri, "testdb", "events").with_batch_size(250);
+    let config = MongoSourceConfig::new(uri.as_str(), "testdb", "events").with_batch_size(250);
     let source = MongoSource::new(config).await.expect("source new");
 
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
+
+    // Check 10: connector_name is non-empty.
+    assert_connector_name_nonempty(&source);
+
+    // Check 11: preflight check() is well-formed against the live server (the
+    // MongoDB source uses the default real-read-path probe — a non-mutating
+    // find of the first page).
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
+    // Check 9: batch_size = 0 (the "no batching" sentinel) yields the entire
+    // result set as a single page. Reuses the same container + seeded data.
+    let zero_config = MongoSourceConfig::new(uri.as_str(), "testdb", "events").with_batch_size(0);
+    let zero_source = MongoSource::new(zero_config)
+        .await
+        .expect("zero-batch source new");
+    faucet_conformance::assert_batch_size_zero_single_page(&zero_source).await;
     // _container stays alive to here
 }
 
@@ -76,6 +96,9 @@ async fn conformance_errors_not_panics() {
     let source = MongoSource::new(config)
         .await
         .expect("builds lazily; read fails");
+
+    // Check 10: connector_name is non-empty (pure — runs offline, no Docker).
+    assert_connector_name_nonempty(&source);
 
     faucet_conformance::assert_errors_not_panics(&source).await;
 }

--- a/crates/source/mssql-cdc/tests/conformance.rs
+++ b/crates/source/mssql-cdc/tests/conformance.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
 use faucet_conformance::{
     assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_connector_name_nonempty, assert_preflight_check_wellformed,
 };
 use faucet_source_mssql_cdc::{MssqlCdcSource, MssqlCdcSourceConfig};
 use serde_json::json;
@@ -250,6 +251,13 @@ async fn conformance_bounded_memory() {
     let source = MssqlCdcSource::new(build_config(&conn))
         .await
         .expect("source new");
+
+    // Check 10: connector_name is non-empty (pure — no I/O).
+    assert_connector_name_nonempty(&source);
+    // Check 11: preflight check() is well-formed against the live server. The
+    // CDC check() is overridden to run a read-only connect + CDC-status +
+    // capture-instance probe (never a page pull), so it is safe in the live test.
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 
     // Each committed single-row transaction is its own page (1 record) → peak
     // == 1, which is ≤ BATCH and < TOTAL.

--- a/crates/source/mssql/tests/conformance.rs
+++ b/crates/source/mssql/tests/conformance.rs
@@ -91,6 +91,29 @@ async fn conformance_bounded_memory() {
     let source = MssqlSource::new(scfg).await.expect("source new");
 
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
+
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty(&source);
+
+    // Check 11: preflight check() returns Ok(report) with well-formed probes.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
+    // Check 9: batch_size=0 yields the entire result set as a single page. Reuse
+    // the same seeded container with a fresh source configured for no batching.
+    let mut scfg0 = MssqlSourceConfig::new(
+        cfg.connection_url.clone().unwrap(),
+        "SELECT id FROM dbo.events ORDER BY id",
+    );
+    scfg0.connection.tls = cfg.tls.clone();
+    scfg0.batch_size = 0;
+    let single_page = MssqlSource::new(scfg0)
+        .await
+        .expect("source new (batch_size=0)");
+    faucet_conformance::assert_batch_size_zero_single_page(&single_page).await;
     // _container stays alive to here
 }
 

--- a/crates/source/mysql-cdc/tests/conformance.rs
+++ b/crates/source/mysql-cdc/tests/conformance.rs
@@ -18,7 +18,7 @@
 
 use faucet_conformance::{
     assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
-    assert_errors_not_panics,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_mysql_cdc::{MysqlCdcSource, MysqlCdcSourceConfig};
 use mysql_async::{Conn, Opts, prelude::Queryable};
@@ -99,6 +99,13 @@ async fn conformance_bounded_memory() {
     let source = MysqlCdcSource::new(build_config(&url))
         .await
         .expect("source new");
+
+    // Check 10: connector_name is non-empty (pure — no I/O).
+    assert_connector_name_nonempty(&source);
+    // Check 11: preflight check() is well-formed against the live server. The
+    // CDC check() is overridden to run a read-only connect + binlog-config probe
+    // (never a page pull), so it is safe to call in the live test.
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 
     // Concurrent writer: wait ~2 s for the binlog stream to open, then perform
     // TOTAL single-row autocommitted INSERTs — each its own transaction, hence

--- a/crates/source/mysql/tests/conformance.rs
+++ b/crates/source/mysql/tests/conformance.rs
@@ -88,10 +88,29 @@ async fn conformance_bounded_memory() {
     seed_events(&url, 5_000).await;
 
     let config =
-        MysqlSourceConfig::new(url, "SELECT id FROM events ORDER BY id").with_batch_size(250);
+        MysqlSourceConfig::new(&url, "SELECT id FROM events ORDER BY id").with_batch_size(250);
     let source = MysqlSource::new(config).await.expect("source new");
 
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
+
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty(&source);
+
+    // Check 11: preflight check() returns Ok(report) with well-formed probes.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
+    // Check 9: batch_size=0 yields the entire result set as a single page. Reuse
+    // the same seeded container with a fresh source configured for no batching.
+    let single_page = MysqlSource::new(
+        MysqlSourceConfig::new(&url, "SELECT id FROM events ORDER BY id").with_batch_size(0),
+    )
+    .await
+    .expect("source new (batch_size=0)");
+    faucet_conformance::assert_batch_size_zero_single_page(&single_page).await;
     // _container stays alive to here
 }
 

--- a/crates/source/nats/tests/conformance.rs
+++ b/crates/source/nats/tests/conformance.rs
@@ -34,6 +34,8 @@ async fn conformance_errors_not_panics() {
     let source = NatsSource::new(cfg)
         .await
         .expect("lazy construction succeeds");
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty(&source);
     assert_errors_not_panics(&source).await;
 }
 

--- a/crates/source/parquet/tests/conformance.rs
+++ b/crates/source/parquet/tests/conformance.rs
@@ -4,6 +4,13 @@
 //! Check 2 — `stream_pages` pages under a bounded batch size (every record
 //! streamed; peak page ≤ batch_size and < total), i.e. memory is O(batch_size)
 //! regardless of total volume.
+//! Check 6 — a bad path surfaces a typed error, never a panic.
+//! Check 9 — `batch_size = 0` yields the whole (small) result set as one page.
+//! Check 10 — `connector_name()` is non-empty.
+//! Check 11 — `check()` returns a well-formed `Ok(report)`.
+//!
+//! Parquet is a snapshot source (no incremental bookmark) and not a sink, so
+//! checks 3 and 4/5/7/8 do not apply.
 
 use std::fs::File;
 use std::path::Path;
@@ -12,7 +19,8 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_parquet::{ParquetSource, ParquetSourceConfig};
 use parquet::arrow::ArrowWriter;
@@ -83,4 +91,42 @@ async fn conformance_errors_not_panics() {
     .await
     .expect("source builds without touching the file");
     assert_errors_not_panics(&source).await;
+}
+
+// ── Check 10: connector_name is non-empty ─────────────────────────────────────
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let source = ParquetSource::new(ParquetSourceConfig::local("/tmp/does-not-matter.parquet"))
+        .await
+        .unwrap();
+    assert_connector_name_nonempty(&source);
+}
+
+// ── Check 9: batch_size=0 yields a single page ────────────────────────────────
+/// A small single-row-group fixture read under the `batch_size = 0` sentinel
+/// (native row-group cadence) must surface as exactly one page.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_batch_size_zero_single_page() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("small.parquet");
+    write_fixture(&path, 6);
+
+    let source =
+        ParquetSource::new(ParquetSourceConfig::local(path.to_str().unwrap()).with_batch_size(0))
+            .await
+            .unwrap();
+    assert_batch_size_zero_single_page(&source).await;
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_preflight_check_wellformed() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("small.parquet");
+    write_fixture(&path, 6);
+
+    let source = ParquetSource::new(ParquetSourceConfig::local(path.to_str().unwrap()))
+        .await
+        .unwrap();
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 }

--- a/crates/source/postgres-cdc/tests/conformance.rs
+++ b/crates/source/postgres-cdc/tests/conformance.rs
@@ -16,7 +16,7 @@
 
 use faucet_conformance::{
     assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
-    assert_errors_not_panics,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_core::Source;
 use faucet_source_postgres_cdc::{PostgresCdcSource, PostgresCdcSourceConfig};
@@ -106,6 +106,15 @@ async fn conformance_bounded_memory() {
     .await;
 
     let source = PostgresCdcSource::new(cfg(&url)).await.expect("source");
+
+    // Check 10: connector_name is non-empty (pure — no I/O).
+    assert_connector_name_nonempty(&source);
+    // Check 11: preflight check() is well-formed against the live server. The
+    // CDC check() is overridden to run a read-only connect + slot metadata probe
+    // (never a page pull), so it is safe to call in the live test. The slot does
+    // not exist yet, so the slot probe is a well-formed `Skip` — still a valid
+    // report inside `Ok`.
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 
     // Warm-up fetch: materialise the slot so the seeded changes below land in
     // the replicated WAL. idle_timeout drains 0 records.

--- a/crates/source/postgres/tests/conformance.rs
+++ b/crates/source/postgres/tests/conformance.rs
@@ -52,12 +52,32 @@ async fn conformance_bounded_memory() {
     seed(&url, total as i64).await;
 
     let source = PostgresSource::new(
-        PostgresSourceConfig::new(url, "SELECT id, name FROM events ORDER BY id")
+        PostgresSourceConfig::new(&url, "SELECT id, name FROM events ORDER BY id")
             .with_batch_size(batch),
     )
     .await
     .expect("source new");
     faucet_conformance::assert_bounded_memory(&source, batch, total).await;
+
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty(&source);
+
+    // Check 11: preflight check() returns Ok(report) with well-formed probes.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
+    // Check 9: batch_size=0 yields the entire result set as a single page. Reuse
+    // the same seeded container with a fresh source configured for no batching.
+    let single_page = PostgresSource::new(
+        PostgresSourceConfig::new(&url, "SELECT id, name FROM events ORDER BY id")
+            .with_batch_size(0),
+    )
+    .await
+    .expect("source new (batch_size=0)");
+    faucet_conformance::assert_batch_size_zero_single_page(&single_page).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/source/pubsub/tests/conformance.rs
+++ b/crates/source/pubsub/tests/conformance.rs
@@ -106,5 +106,15 @@ async fn conformance_bounded_memory() {
     cfg.batch_size = 30;
     let source = PubsubSource::new(cfg).await.expect("source builds");
 
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty(&source);
+    // Check 11: preflight check() is well-formed against the emulator (the
+    // subscription created above exists → a Pass probe inside Ok(report)).
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
     faucet_conformance::assert_bounded_memory(&source, 30, 150).await;
 }

--- a/crates/source/redis/tests/conformance.rs
+++ b/crates/source/redis/tests/conformance.rs
@@ -92,6 +92,24 @@ async fn conformance_bounded_memory() {
     let source = RedisSource::new(config).unwrap();
 
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
+
+    // Check 9: batch_size=0 is the "no batching" sentinel — the stream mode
+    // drains the whole `events` stream in one XRANGE and emits it as a single
+    // page (see `RedisSourceConfig::batch_size`). A fresh source over the same
+    // (non-destructively read, no consumer group) seeded stream exercises it
+    // without a new container.
+    let config0 = RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Stream {
+            key: "events".into(),
+            group: None,
+            consumer: None,
+            count: None,
+        },
+    )
+    .with_batch_size(0);
+    let source0 = RedisSource::new(config0).unwrap();
+    faucet_conformance::assert_batch_size_zero_single_page(&source0).await;
     // _container stays alive to here
 }
 
@@ -116,5 +134,14 @@ async fn conformance_errors_not_panics() {
     );
     let source = RedisSource::new(config).expect("builds lazily; read fails");
 
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty(&source);
     faucet_conformance::assert_errors_not_panics(&source).await;
+    // Check 11: the default page-pull check() surfaces the connect failure as a
+    // Fail probe inside Ok(report) — never an Err from check() itself.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }

--- a/crates/source/rest/tests/conformance.rs
+++ b/crates/source/rest/tests/conformance.rs
@@ -3,6 +3,13 @@
 //! - check 1 `assert_config_schema_valid`
 //! - check 6 `assert_errors_not_panics` — an unreachable endpoint surfaces a
 //!   typed `FaucetError` (connection refused) rather than panicking.
+//! - check 9 `assert_batch_size_zero_single_page` — a single-page (`None`
+//!   pagination) upstream is emitted as one `StreamPage` (REST chunks by
+//!   upstream-API page boundaries, so an unpaginated response is one page).
+//! - check 10 `assert_connector_name_nonempty` — the connector label is
+//!   non-empty (offline).
+//! - check 11 `assert_preflight_check_wellformed` — `check()` surfaces an
+//!   unreachable endpoint as a `Fail` probe inside `Ok(report)`, never `Err`.
 //!
 //! check 2 (bounded-memory streaming) and the incremental resume path (check 3)
 //! are covered in depth by this crate's dedicated `stream_test.rs`,
@@ -10,6 +17,9 @@
 //! server; the battery here adds the uniform schema + error-handling contract.
 
 use faucet_source_rest::{PaginationStyle, RestStream, RestStreamConfig};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn unreachable_source() -> RestStream {
     // Port 1 refuses connections immediately on all platforms — a fast,
@@ -28,4 +38,48 @@ fn conformance_config_schema_valid() {
 #[tokio::test]
 async fn conformance_errors_not_panics() {
     faucet_conformance::assert_errors_not_panics(&unreachable_source()).await;
+}
+
+// ── Check 9: batch_size=0 emits a single page ─────────────────────────────────
+
+#[tokio::test]
+async fn conformance_batch_size_zero_single_page() {
+    // `None` pagination: the upstream returns the whole result set in one
+    // response, which the source emits as exactly one `StreamPage`.
+    let server = MockServer::start().await;
+    let data: Vec<_> = (0..50).map(|i| json!({ "id": i })).collect();
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": data })))
+        .mount(&server)
+        .await;
+
+    let source = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/items")
+            .records_path("$.data[*]")
+            .pagination(PaginationStyle::None),
+    )
+    .unwrap();
+
+    faucet_conformance::assert_batch_size_zero_single_page(&source).await;
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    faucet_conformance::assert_connector_name_nonempty(&unreachable_source());
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // The default `Source::check` probes the real read path; an unreachable
+    // endpoint surfaces as a `Fail` probe inside `Ok(report)`, never an `Err`.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &unreachable_source(),
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }

--- a/crates/source/s3/tests/conformance.rs
+++ b/crates/source/s3/tests/conformance.rs
@@ -27,6 +27,16 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "faucet-source-s3");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_connector_name_nonempty() {
+    let config = S3SourceConfig::new("does-not-exist")
+        .endpoint_url("http://127.0.0.1:1".to_string())
+        .region(REGION.to_string());
+    let source = S3Source::new(config).await.expect("source builds lazily");
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
 // ── Check 2: bounded-memory streaming (Docker) ──────────────────────────────
 
 /// Start a MinIO container and return the container handle plus the
@@ -123,6 +133,12 @@ async fn conformance_bounded_memory() {
     let source = build_source(&endpoint, config).await;
 
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
+
+    // Check 9: reuse the same MinIO instance + seeded bucket — a source built
+    // with `batch_size = 0` must yield the whole object as a single page.
+    let zero_config = S3SourceConfig::new(TEST_BUCKET).with_batch_size(0);
+    let zero_source = build_source(&endpoint, zero_config).await;
+    faucet_conformance::assert_batch_size_zero_single_page(&zero_source).await;
     // _container stays alive to here
 }
 

--- a/crates/source/sftp/tests/conformance.rs
+++ b/crates/source/sftp/tests/conformance.rs
@@ -29,6 +29,25 @@ fn conformance_config_schema_valid() {
     assert_config_schema_valid_value(&schema, "faucet-source-sftp");
 }
 
+// ── Check 10: connector_name is non-empty (offline, lazy build) ──────────────
+/// `SftpSource::new` is lazy (no connect at build time), so this runs
+/// unconditionally with no container.
+#[test]
+fn conformance_connector_name_nonempty() {
+    let conn = SftpConnectionConfig {
+        host: "127.0.0.1".to_string(),
+        port: 1,
+        username: "nobody".to_string(),
+        auth: SftpAuth::Password {
+            password: "x".to_string(),
+        },
+        known_hosts: HostKeyPolicy::Insecure,
+    };
+    let source =
+        SftpSource::new(SftpSourceConfig::new(conn, "/data")).expect("source builds lazily");
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
 // ── Check 2: bounded-memory streaming (Docker) ──────────────────────────────
 
 /// Start an `atmoz/sftp` container with user `faucet:faucetpass` and a writable

--- a/crates/source/singer/tests/conformance.rs
+++ b/crates/source/singer/tests/conformance.rs
@@ -58,9 +58,35 @@ async fn conformance_bookmark_roundtrip() {
 async fn conformance_errors_not_panics() {
     // A tap executable that does not exist must surface a typed FaucetError when
     // the bridge tries to spawn it — never a panic.
-    let source = SingerSource::new(SingerSourceConfig::new(
+    faucet_conformance::assert_errors_not_panics(&missing_tap_source()).await;
+}
+
+/// A source whose configured tap binary does not exist.
+fn missing_tap_source() -> SingerSource {
+    SingerSource::new(SingerSourceConfig::new(
         "/nonexistent/faucet-conformance-tap-binary",
         "s",
-    ));
-    faucet_conformance::assert_errors_not_panics(&source).await;
+    ))
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    let source = SingerSource::new(SingerSourceConfig::new(fake_tap(), "s"));
+    faucet_conformance::assert_connector_name_nonempty(&source);
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // The Singer source overrides `check()` (tap-executable + catalog probes);
+    // a missing tap surfaces as a `Fail` probe inside `Ok(report)`, never an
+    // `Err`.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &missing_tap_source(),
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }

--- a/crates/source/snowflake/tests/conformance.rs
+++ b/crates/source/snowflake/tests/conformance.rs
@@ -14,7 +14,8 @@
 //! 250 < 6 000.
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
+    assert_errors_not_panics,
 };
 use faucet_source_snowflake::{SnowflakeAuth, SnowflakeSource, SnowflakeSourceConfig};
 use serde_json::{Value, json};
@@ -119,5 +120,7 @@ async fn conformance_errors_not_panics() {
     let source = SnowflakeSource::new(config)
         .expect("source new")
         .with_endpoint_base("http://127.0.0.1:1");
+    // Check 10: connector_name() is non-empty (reuses this offline instance).
+    assert_connector_name_nonempty(&source);
     assert_errors_not_panics(&source).await;
 }

--- a/crates/source/spanner/tests/conformance.rs
+++ b/crates/source/spanner/tests/conformance.rs
@@ -9,7 +9,7 @@ mod support;
 
 use faucet_conformance::{
     assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
-    assert_errors_not_panics,
+    assert_connector_name_nonempty, assert_errors_not_panics,
 };
 use faucet_source_spanner::{SpannerReplication, SpannerSource, SpannerSourceConfig};
 
@@ -60,6 +60,9 @@ async fn conformance_bounded_memory() {
     cfg.connection = support::connection(&emu.host, "conformance");
     cfg.batch_size = 500;
     let source = SpannerSource::new(cfg).await.expect("source");
+
+    // Check 10: connector_name() is non-empty (reuses this live instance).
+    assert_connector_name_nonempty(&source);
 
     assert_bounded_memory(&source, 500, 5_000).await;
 }

--- a/crates/source/sqlite/tests/conformance.rs
+++ b/crates/source/sqlite/tests/conformance.rs
@@ -44,6 +44,8 @@ async fn conformance_config_schema_valid() {
         .await
         .expect("source");
     faucet_conformance::assert_config_schema_valid(&source);
+    // Check 10: connector_name is non-empty.
+    faucet_conformance::assert_connector_name_nonempty(&source);
 }
 
 #[tokio::test]
@@ -52,11 +54,26 @@ async fn conformance_bounded_memory() {
     let batch = 100;
     let (_dir, url) = seed(total).await;
     let source = SqliteSource::new(
-        SqliteSourceConfig::new(url, "SELECT id, name FROM t ORDER BY id").with_batch_size(batch),
+        SqliteSourceConfig::new(&url, "SELECT id, name FROM t ORDER BY id").with_batch_size(batch),
     )
     .await
     .expect("source");
     faucet_conformance::assert_bounded_memory(&source, batch, total).await;
+
+    // Check 11: preflight check() returns Ok(report) with well-formed probes.
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
+
+    // Check 9: batch_size=0 yields the entire result set as a single page.
+    let single_page = SqliteSource::new(
+        SqliteSourceConfig::new(&url, "SELECT id, name FROM t ORDER BY id").with_batch_size(0),
+    )
+    .await
+    .expect("source (batch_size=0)");
+    faucet_conformance::assert_batch_size_zero_single_page(&single_page).await;
 }
 
 #[tokio::test]

--- a/crates/source/sqs/tests/conformance.rs
+++ b/crates/source/sqs/tests/conformance.rs
@@ -39,6 +39,8 @@ async fn conformance_errors_not_panics() {
     cfg.max_messages = Some(10);
 
     let source = SqsSource::new(cfg).await.expect("source builds lazily");
+    // Check 10: connector_name is non-empty (metric-cardinality contract).
+    faucet_conformance::assert_connector_name_nonempty(&source);
     assert_errors_not_panics(&source).await;
 }
 
@@ -131,6 +133,14 @@ async fn conformance_bounded_memory() {
     cfg.batch_size = 250;
 
     let source = SqsSource::new(cfg).await.expect("source");
+    // Check 11: preflight check() is well-formed against the live queue
+    // (`GetQueueAttributes` → a Pass probe inside Ok(report); no messages
+    // consumed).
+    faucet_conformance::assert_preflight_check_wellformed(
+        &source,
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
     // _container stays alive to here
 }

--- a/crates/source/webhook/tests/conformance.rs
+++ b/crates/source/webhook/tests/conformance.rs
@@ -17,7 +17,10 @@
 //! binds a `TcpListener` to `listen_addr` at read time, so an unbindable
 //! address deterministically drives the failure path.
 
-use faucet_conformance::{assert_config_schema_valid_value, assert_errors_not_panics};
+use faucet_conformance::{
+    assert_config_schema_valid_value, assert_connector_name_nonempty, assert_errors_not_panics,
+    assert_preflight_check_wellformed,
+};
 use faucet_source_webhook::{WebhookSource, WebhookSourceConfig};
 
 #[test]
@@ -39,4 +42,23 @@ async fn conformance_errors_not_panics() {
     let source =
         WebhookSource::new(WebhookSourceConfig::new().listen_addr("999.999.999.999:99999"));
     assert_errors_not_panics(&source).await;
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    let source = WebhookSource::new(WebhookSourceConfig::new());
+    assert_connector_name_nonempty(&source);
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+/// The webhook source overrides `check()` with a bind probe. Against a bindable
+/// ephemeral address (`127.0.0.1:0`) it returns a `Pass` probe inside
+/// `Ok(report)` — a well-formed report, which is what the contract requires.
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    let source = WebhookSource::new(WebhookSourceConfig::new().listen_addr("127.0.0.1:0"));
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 }

--- a/crates/source/websocket/tests/conformance.rs
+++ b/crates/source/websocket/tests/conformance.rs
@@ -10,7 +10,8 @@
 //!          the drain via `max_messages` (with `idle_timeout` as a backstop).
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
+    assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_core::AuthSpec;
 use faucet_source_websocket::{
@@ -99,4 +100,23 @@ async fn conformance_bounded_memory() {
 async fn conformance_errors_not_panics() {
     let source = WebsocketSource::new(base_config("ws://127.0.0.1:1")).unwrap();
     assert_errors_not_panics(&source).await;
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    let source = WebsocketSource::new(base_config("ws://127.0.0.1:1")).unwrap();
+    assert_connector_name_nonempty(&source);
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+/// The websocket source overrides `check()` with a TCP-connect probe. Pointed
+/// at an unreachable endpoint it surfaces the failure as a `Fail` probe inside
+/// `Ok(report)`, never an `Err` — exactly what the contract requires.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_preflight_check_wellformed() {
+    let source = WebsocketSource::new(base_config("ws://127.0.0.1:1")).unwrap();
+    assert_preflight_check_wellformed(&source, &faucet_core::check::CheckContext::default()).await;
 }

--- a/crates/source/xml/tests/conformance.rs
+++ b/crates/source/xml/tests/conformance.rs
@@ -6,7 +6,8 @@
 //! cap and strictly < the total), never materialising the whole result set.
 
 use faucet_conformance::{
-    assert_bounded_memory, assert_config_schema_valid_value, assert_errors_not_panics,
+    assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
 use faucet_source_xml::{XmlStream, XmlStreamConfig};
 use wiremock::matchers::{method, path};
@@ -64,13 +65,60 @@ async fn conformance_bounded_memory() {
     assert_bounded_memory(&source, BATCH, TOTAL).await;
 }
 
+// ── Check 9: batch_size=0 emits a single page ─────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_batch_size_zero_single_page() {
+    // `batch_size = 0` is the "no batching" sentinel — the event-driven parser
+    // accumulates the whole document into a single `StreamPage`.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(build_doc(200)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .with_batch_size(0);
+    let source = XmlStream::new(config);
+    assert_batch_size_zero_single_page(&source).await;
+}
+
 // ── Check 6: errors, not panics ──────────────────────────────────────────────
+
+/// A source pointed at an unreachable endpoint. `new()` is lazy (it builds the
+/// HTTP client), so the failure surfaces on first read. Port 1 refuses
+/// connections immediately on all platforms.
+fn unreachable_source() -> XmlStream {
+    XmlStream::new(XmlStreamConfig::new("http://127.0.0.1:1", "/feed.xml"))
+}
 
 #[tokio::test]
 async fn conformance_errors_not_panics() {
-    // Unreachable endpoint: `new()` builds (lazy HTTP client), the first read
-    // errors with a typed `FaucetError` (connection refused) without panicking.
-    // Port 1 refuses connections immediately on all platforms.
-    let source = XmlStream::new(XmlStreamConfig::new("http://127.0.0.1:1", "/feed.xml"));
-    assert_errors_not_panics(&source).await;
+    assert_errors_not_panics(&unreachable_source()).await;
+}
+
+// ── Check 10: connector_name non-empty (offline) ──────────────────────────────
+
+#[test]
+fn conformance_connector_name_nonempty() {
+    assert_connector_name_nonempty(&unreachable_source());
+}
+
+// ── Check 11: preflight check() is well-formed ────────────────────────────────
+
+#[tokio::test]
+async fn conformance_preflight_check_wellformed() {
+    // The default `Source::check` probes the real read path; an unreachable
+    // endpoint surfaces as a `Fail` probe inside `Ok(report)`, never an `Err`.
+    assert_preflight_check_wellformed(
+        &unreachable_source(),
+        &faucet_core::check::CheckContext::default(),
+    )
+    .await;
 }


### PR DESCRIPTION
Adopts the new `faucet-conformance` capability checks (from #465) into **every** connector's `tests/conformance.rs`. Each connector now *proves* the capabilities it advertises, not just that its config schema is valid.

Purely additive to tests — **63 test files touched, 0 source files changed.**

## What each connector gets (only where it applies)

| Check | Applied to |
|---|---|
| `assert_connector_name_nonempty` | **every** connector — guards the metric-cardinality rule (a blank `connector_name()` would become the `"unknown"` label) |
| `assert_batch_size_zero_single_page` | data-emitting sources that honor the `batch_size=0` sentinel (csv, parquet/delta, SQL sources, mongodb, redis, rest/graphql/xml/elasticsearch) |
| `assert_write_modes_truthful` | the 8 upsert sinks (postgres, mysql, mssql, sqlite, mongodb, elasticsearch, bigquery, spanner), each with a `delete_marker: {__op: [d]}` so the delete leg runs |
| `assert_schema_evolution_effective` | the schema-evolving sinks (postgres, mysql, mssql, sqlite, bigquery, elasticsearch, spanner) |
| `assert_preflight_check_wellformed` | connectors whose `check()` returns `Ok(report)` with well-formed probes (verified against each real `check()` impl) |

**Deliberately not added** (correct, not gaps): batch-size-zero on incremental pollers (kafka/nats/pubsub/sqs/kinesis) and change-stream CDC sources — they emit multiple pages regardless; write-modes/schema-evolution on append-only/schemaless sinks; and a handful of schema-only conformance tests with no cheap instance (bigquery/redshift sinks, redshift source) — noted inline in those files.

## Approach & verification

- Checks were folded into each crate's **existing** live/offline test — **no new container boots**. Behavioral checks needing a real backend stay Docker-gated and run in CI, as the rest of these suites already do.
- The offline/wiremock connectors (csv, parquet, delta, jsonl, stdout, iceberg, rest, graphql, xml, elasticsearch, http, sqlite, mongodb, redis, …) were **run locally and pass** — including the ES sink's write-modes + schema-evolution wired through stateful wiremock responders, and sqlite's full upsert/delete/evolution/preflight paths.
- `clippy --all-targets -D warnings` + `cargo fmt --check` clean on **61 of 63** crates. The two exceptions are `faucet-source-duckdb` / `faucet-sink-duckdb`, whose bundled `libduckdb-sys` C++ build won't link on the dev machine — their edits were verified by review (imports in scope, `with_batch_size`/`seed` reused correctly) and compile under CI's `--all-features`.

Done by six parallel workers (one per connector family), each verifying compilation per-crate; I reviewed and integrated. CI's `--all-features` Test/Coverage runs the Docker-gated behavioral assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
