### PR TITLE
feat(conformance): add discover-roundtrip and cancellation-flush integration checks

### DIFF
--- a/crates/conformance/README.md
+++ b/crates/conformance/README.md
@@ -12,14 +12,33 @@ invokes and passes these checks in CI; connectors that don't are Tier-2
 
 ## Checks
 
-| # | Function | Status |
+Every check ships with both a passing and a `#[should_panic]` failing test in
+this crate — a check that cannot fail is worthless.
+
+| # | Function | What it proves |
 |---|---|---|
-| 1 | `assert_config_schema_valid` | ✅ implemented — `config_schema()` is a valid, round-tripping JSON Schema |
-| 2 | `assert_bounded_memory` | ✅ implemented — `stream_pages` pages instead of buffering the whole set |
-| 3 | `assert_bookmark_roundtrip` | ✅ implemented — a resumed run picks up *after* the emitted bookmark; strictly fewer records reappear |
-| 4 | `assert_idempotent_replay` | ✅ implemented — atomic-watermark replay (or keyed-upsert) converges to one row per key, no double-writes |
-| 5 | `assert_capabilities_truthful` | ✅ implemented — advertised `supports_*` capabilities match actual behavior (idempotency, schema evolution) |
-| 6 | `assert_errors_not_panics` | ✅ implemented — a failing source surfaces a typed `FaucetError` without unwinding |
+| 1 | `assert_config_schema_valid` | `config_schema()` is a valid, round-tripping JSON Schema |
+| 2 | `assert_bounded_memory` | `stream_pages` pages instead of buffering the whole set |
+| 3 | `assert_bookmark_roundtrip` | a resumed run picks up *after* the emitted bookmark; strictly fewer records reappear |
+| 4 | `assert_idempotent_replay` | atomic-watermark replay (or keyed-upsert) converges to one row per key, no double-writes |
+| 5 | `assert_capabilities_truthful` | advertised `supports_*` capabilities match actual behavior (idempotency, schema evolution) |
+| 6 | `assert_errors_not_panics` | a failing source surfaces a typed `FaucetError` without unwinding |
+| 7 | `assert_write_modes_truthful` | a sink advertising `Upsert`/`Delete` converges by key and removes on delete; missing/null keys are reported as failed |
+| 8 | `assert_schema_evolution_effective` | an evolvable sink's `evolve_schema` makes the added column appear in a fresh `current_schema()` |
+| 9 | `assert_batch_size_zero_single_page` | a source built with `batch_size = 0` yields the whole result set as one page |
+| 10 | `assert_connector_name_nonempty` | `connector_name()` is non-empty (an empty name becomes the `"unknown"` metric label) |
+| 11 | `assert_preflight_check_wellformed` | `check()` returns `Ok(CheckReport)` with well-formed probes; a probe failure is a `Fail` probe, not an `Err` |
+
+### Integration-level checks
+
+These drive a **live backend** or the **real pipeline**, so they belong in a
+connector's testcontainers/tempfile conformance test rather than against the
+synthetic doubles:
+
+| # | Function | What it proves |
+|---|---|---|
+| 12 | `assert_discover_roundtrips` | every `discover()` descriptor is genuinely selectable — deep-merge its `config_patch` (via `merge_config_patch`), rebuild, and read |
+| 13 | `assert_cancellation_flushes` | a mid-run cancel stops at a page boundary and flushes the sink, so buffered output survives (#146 H16) |
 
 ## Usage
 

--- a/crates/conformance/src/doubles.rs
+++ b/crates/conformance/src/doubles.rs
@@ -651,6 +651,152 @@ impl Sink for ErringCheckSink {
     }
 }
 
+/// A source with a catalog it can [`discover`](Source::discover) — used to
+/// exercise [`assert_discover_roundtrips`](crate::assert_discover_roundtrips).
+///
+/// Each discovered dataset becomes a [`DatasetDescriptor`](faucet_core::DatasetDescriptor)
+/// whose `config_patch` is `{"dataset": <name>}` — the partial override a
+/// `rebuild` closure deep-merges to select that dataset. The read path is
+/// irrelevant to the check (the `rebuild` closure returns the source that is
+/// actually read), so [`fetch_with_context`](Source::fetch_with_context)
+/// returns nothing.
+///
+/// Construct with [`DiscoverableSource::new`] for a populated catalog, or
+/// [`DiscoverableSource::empty`] to model a source that advertises discovery
+/// but finds no datasets (used to prove the check *fails* on an empty catalog).
+pub struct DiscoverableSource {
+    datasets: Vec<String>,
+}
+
+impl DiscoverableSource {
+    /// A discoverable source over two synthetic datasets (`orders`, `customers`).
+    pub fn new() -> Self {
+        Self {
+            datasets: vec!["orders".to_string(), "customers".to_string()],
+        }
+    }
+
+    /// A discoverable source whose catalog is empty — `discover()` returns no
+    /// descriptors even though `supports_discover()` is `true`.
+    pub fn empty() -> Self {
+        Self {
+            datasets: Vec::new(),
+        }
+    }
+}
+
+impl Default for DiscoverableSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for DiscoverableSource {
+    async fn fetch_with_context(
+        &self,
+        _context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(Vec::new())
+    }
+
+    fn supports_discover(&self) -> bool {
+        true
+    }
+
+    async fn discover(&self) -> Result<Vec<faucet_core::DatasetDescriptor>, FaucetError> {
+        Ok(self
+            .datasets
+            .iter()
+            .map(|name| {
+                faucet_core::DatasetDescriptor::new(
+                    name.clone(),
+                    "table",
+                    json!({ "dataset": name }),
+                )
+            })
+            .collect())
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "discoverable-source"
+    }
+}
+
+/// A sink that buffers writes and only makes them **durable on
+/// [`flush`](Sink::flush)** — modelling a real buffered sink whose output is
+/// committed at flush time (a Parquet footer, an S3 multipart completion).
+/// Used to exercise [`assert_cancellation_flushes`](crate::assert_cancellation_flushes):
+/// the pipeline must flush at the cancellation page boundary or the staged rows
+/// are lost.
+///
+/// Construct with [`BufferedSink::new`] for a faithful sink (flush commits the
+/// staging buffer) or [`BufferedSink::broken`] for one whose `flush` silently
+/// drops the buffer (used to prove the check *fails* when a cancel does not
+/// yield durable output).
+#[derive(Clone)]
+pub struct BufferedSink {
+    staged: Arc<Mutex<Vec<Value>>>,
+    durable: Arc<Mutex<Vec<Value>>>,
+    commit_on_flush: bool,
+}
+
+impl BufferedSink {
+    /// A buffered sink whose `flush` durably commits everything staged so far.
+    pub fn new() -> Self {
+        Self {
+            staged: Arc::new(Mutex::new(Vec::new())),
+            durable: Arc::new(Mutex::new(Vec::new())),
+            commit_on_flush: true,
+        }
+    }
+
+    /// A broken buffered sink whose `flush` is a silent no-op — staged rows
+    /// never become durable, so any output buffered when the run ends is lost.
+    pub fn broken() -> Self {
+        Self {
+            commit_on_flush: false,
+            ..Self::new()
+        }
+    }
+
+    /// Number of rows that are **durable** (committed via a flush).
+    pub fn durable_len(&self) -> usize {
+        self.durable.lock().unwrap().len()
+    }
+
+    /// Number of rows currently staged but not yet flushed.
+    pub fn staged_len(&self) -> usize {
+        self.staged.lock().unwrap().len()
+    }
+}
+
+impl Default for BufferedSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Sink for BufferedSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        self.staged.lock().unwrap().extend(records.iter().cloned());
+        Ok(records.len())
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        if self.commit_on_flush {
+            let mut staged = self.staged.lock().unwrap();
+            self.durable.lock().unwrap().extend(staged.drain(..));
+        }
+        Ok(())
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "buffered-sink"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -824,5 +970,50 @@ mod tests {
         assert_eq!(sink.connector_name(), "erring-check-sink");
         assert_eq!(sink.write_batch(&[json!({ "x": 1 })]).await.unwrap(), 1);
         assert!(sink.check(&ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn discoverable_source_enumerates_its_catalog() {
+        let s = DiscoverableSource::new();
+        assert_eq!(s.connector_name(), "discoverable-source");
+        assert!(s.supports_discover());
+        let ds = s.discover().await.unwrap();
+        assert_eq!(ds.len(), 2);
+        assert_eq!(ds[0].name, "orders");
+        assert_eq!(ds[0].config_patch, json!({ "dataset": "orders" }));
+        // The read path is deliberately empty — the rebuild closure supplies the
+        // source that is actually read.
+        assert!(
+            s.fetch_with_context(&HashMap::new())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // The empty-catalog variant still advertises discovery.
+        let empty = DiscoverableSource::empty();
+        assert!(empty.supports_discover());
+        assert!(empty.discover().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn buffered_sink_only_durable_after_flush_unless_broken() {
+        let s = BufferedSink::new();
+        assert_eq!(s.connector_name(), "buffered-sink");
+        s.write_batch(&[json!({ "id": 1 }), json!({ "id": 2 })])
+            .await
+            .unwrap();
+        // Staged, not yet durable.
+        assert_eq!(s.staged_len(), 2);
+        assert_eq!(s.durable_len(), 0);
+        s.flush().await.unwrap();
+        assert_eq!(s.staged_len(), 0);
+        assert_eq!(s.durable_len(), 2, "flush must commit the staged rows");
+
+        // The broken variant never commits, even on flush.
+        let broken = BufferedSink::broken();
+        broken.write_batch(&[json!({ "id": 1 })]).await.unwrap();
+        broken.flush().await.unwrap();
+        assert_eq!(broken.durable_len(), 0, "broken flush drops the buffer");
     }
 }

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -44,6 +44,14 @@
 //! 11. [`assert_preflight_check_wellformed`] — `check()` returns `Ok(CheckReport)`
 //!     with well-formed probes; a probe failure is a `Fail` probe, not an `Err`.
 //!
+//! Integration-level checks — these drive a live backend / the real pipeline,
+//! so they belong in a connector's testcontainers/tempfile conformance test
+//! (not the synthetic unit doubles):
+//! 12. [`assert_discover_roundtrips`] — a source's `discover()` descriptors are
+//!     genuinely selectable: deep-merge each `config_patch`, rebuild, and read.
+//! 13. [`assert_cancellation_flushes`] — a mid-run cancel stops at a page
+//!     boundary and flushes the sink, so buffered output survives (#146 H16).
+//!
 //! Each check has both a passing and a `#[should_panic]` failing test in this
 //! crate — a check that cannot fail is worthless.
 
@@ -810,13 +818,175 @@ fn assert_report_wellformed(
     }
 }
 
+// ── Check 12: discovery round-trips (discoverable sources) ────────────────────
+
+/// Deep-merge a discovery `config_patch` onto a base config `Value` and return
+/// the merged config — objects merge recursively, scalars and arrays replace
+/// wholesale. This mirrors the deep-merge the CLI applies when it turns a
+/// [`DatasetDescriptor`](faucet_core::DatasetDescriptor) into a matrix row, so a
+/// `rebuild` closure for [`assert_discover_roundtrips`] can compose the patch
+/// onto the real base config exactly as production does:
+///
+/// ```
+/// use faucet_conformance::merge_config_patch;
+/// use serde_json::json;
+/// let base = json!({ "url": "…", "query": "SELECT 1" });
+/// let merged = merge_config_patch(base, &json!({ "query": "SELECT * FROM t" }));
+/// assert_eq!(merged["query"], "SELECT * FROM t");
+/// assert_eq!(merged["url"], "…");
+/// ```
+pub fn merge_config_patch(mut base: Value, patch: &Value) -> Value {
+    merge_into(&mut base, patch);
+    base
+}
+
+fn merge_into(base: &mut Value, patch: &Value) {
+    match (base, patch) {
+        (Value::Object(base_map), Value::Object(patch_map)) => {
+            for (k, v) in patch_map {
+                merge_into(base_map.entry(k.clone()).or_insert(Value::Null), v);
+            }
+        }
+        (base_slot, patch) => *base_slot = patch.clone(),
+    }
+}
+
+/// **Check 12.** For a source that advertises
+/// [`supports_discover`](Source::supports_discover): enumerate its datasets via
+/// [`discover`](Source::discover), then for each descriptor deep-merge its
+/// [`config_patch`](faucet_core::DatasetDescriptor::config_patch) onto the base
+/// config (via the caller's `rebuild` closure) and assert the rebuilt source is
+/// actually readable — the dataset the catalog advertised is genuinely
+/// selectable end-to-end, not just a name in a list.
+///
+/// This is an **integration-level** check: it needs a live, seeded backend so
+/// `discover()` returns real descriptors and the rebuilt source reads real (or
+/// legitimately empty) data. Run it in a connector's testcontainers/tempfile
+/// conformance test, reusing the already-seeded backend. `rebuild` receives the
+/// descriptor's `config_patch` and returns the source built from
+/// `base config ⊕ patch` — [`merge_config_patch`] writes that closure in one
+/// line.
+///
+/// Asserts: the source advertises discovery; `discover()` returns at least one
+/// descriptor (a seeded backend must expose something — an empty catalog makes
+/// the round-trip vacuous); and every rebuilt source drains through
+/// `stream_pages` **without error** (≥ 0 rows — the selected dataset may be
+/// legitimately empty, but selecting it must not fail).
+pub async fn assert_discover_roundtrips<S, F, Fut>(source: &S, rebuild: F)
+where
+    S: Source + ?Sized,
+    F: Fn(Value) -> Fut,
+    Fut: std::future::Future<Output = Box<dyn Source>>,
+{
+    let label = source.connector_name();
+    assert!(
+        source.supports_discover(),
+        "[{label}] does not advertise discovery (supports_discover()=false) — call this only \
+         on a discoverable source"
+    );
+
+    let descriptors = source
+        .discover()
+        .await
+        .unwrap_or_else(|e| panic!("[{label}] discover() errored: {e}"));
+    assert!(
+        !descriptors.is_empty(),
+        "[{label}] discover() returned no datasets — seed the backend before the round-trip so \
+         there is a real dataset to re-select (an empty catalog makes the check vacuous)"
+    );
+
+    for descriptor in &descriptors {
+        let patch = descriptor.config_patch.clone();
+        let rebuilt = rebuild(patch.clone()).await;
+        // Drive the real read path of the rebuilt source. The dataset selected
+        // by the patch must be readable; it may legitimately hold zero rows.
+        let ctx: HashMap<String, Value> = HashMap::new();
+        let mut stream = rebuilt.stream_pages(&ctx, 100);
+        while let Some(page) = stream.next().await {
+            page.unwrap_or_else(|e| {
+                panic!(
+                    "[{label}] rebuilt source for dataset `{}` (config_patch {patch}) errored on \
+                     read: {e} — the descriptor the catalog advertised is not actually selectable",
+                    descriptor.name
+                )
+            });
+        }
+    }
+}
+
+// ── Check 13: cancellation flushes buffered output ────────────────────────────
+
+/// **Check 13.** Assert the flush-completing cancellation contract
+/// ([ADR 0011](https://github.com/faucet-hq/faucet-stream/blob/main/docs/adr/0011-cooperative-cancellation.md),
+/// #146 H16): a [`CancellationToken`](faucet_core::CancellationToken) fired
+/// mid-run stops [`run_stream`](faucet_core::run_stream) at the next page
+/// boundary, **flushes the sink** so buffered output is made durable, and
+/// returns `Ok` with the partial result — as opposed to dropping the run
+/// future, which would flush nothing and orphan a buffered sink's output (a
+/// Parquet footer, an S3 multipart).
+///
+/// Drives the **real** `faucet_core::run_stream` with a synthetic source that
+/// yields one page and then cancels the token (deterministic — no timers, no
+/// flakiness). `durable_count` reports the number of rows the sink has made
+/// **durable** (for [`BufferedSink`](doubles::BufferedSink),
+/// `|| async { sink.durable_len() }`; for a real buffered sink, whatever a
+/// reader observes *after* the run). Asserts `run_stream` returned `Ok`, the
+/// partial result counts the written page, and every written row is durable —
+/// i.e. the cancel path flushed. A sink whose `flush` does not commit fails
+/// here, as does a pipeline that skips the on-cancel flush.
+pub async fn assert_cancellation_flushes<S, F, Fut>(sink: &S, durable_count: F)
+where
+    S: Sink + ?Sized,
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = usize>,
+{
+    use faucet_core::{CancellationToken, RunStreamOptions, StreamPage, run_stream};
+
+    let label = sink.connector_name();
+    let before = durable_count().await;
+
+    let page = rows(&[1, 2, 3]);
+    let n = page.len();
+
+    let token = CancellationToken::new();
+    let stream_token = token.clone();
+    // Yield one page, then fire the token and block. The only way `run_stream`
+    // exits is the cooperative cancel at the page boundary — so the flush it
+    // performs there is exactly the #146 H16 behaviour under test.
+    let stream = Box::pin(async_stream::stream! {
+        yield Ok(StreamPage { records: page, bookmark: None });
+        stream_token.cancel();
+        futures::future::pending::<()>().await;
+    });
+
+    let result = run_stream(stream, sink, RunStreamOptions::new().with_cancel(token))
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "[{label}] a cooperative cancel must return Ok with the partial result, got \
+                 Err({e})"
+            )
+        });
+    assert_eq!(
+        result.records_written, n,
+        "[{label}] the page written before cancellation is not counted in the partial result"
+    );
+
+    let durable = durable_count().await - before;
+    assert_eq!(
+        durable, n,
+        "[{label}] the sink was not flushed on the cancel path: {durable} of {n} written rows \
+         are durable — buffered output would be lost when a run is cancelled"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use doubles::{
-        CountingSource, EmptyNameSource, ErringCheckSink, ErringCheckSource, EvolvingSink,
-        FailingSource, LyingIdempotentSink, LyingKeyedSink, MultiPageZeroSource, NoOpEvolvingSink,
-        PanickingSource, TestSink,
+        BufferedSink, CountingSource, DiscoverableSource, EmptyNameSource, ErringCheckSink,
+        ErringCheckSource, EvolvingSink, FailingSource, LyingIdempotentSink, LyingKeyedSink,
+        MultiPageZeroSource, NoOpEvolvingSink, PanickingSource, TestSink,
     };
 
     #[test]
@@ -1111,5 +1281,107 @@ mod tests {
     async fn check11_fails_when_sink_check_returns_err() {
         let ctx = faucet_core::check::CheckContext::default();
         assert_sink_preflight_check_wellformed(&ErringCheckSink, &ctx).await;
+    }
+
+    // ── merge_config_patch ────────────────────────────────────────────────────
+
+    #[test]
+    fn merge_config_patch_is_recursive_with_scalar_and_array_replace() {
+        let base = serde_json::json!({
+            "url": "keep",
+            "query": "SELECT 1",
+            "opts": { "a": 1, "b": 2 },
+            "keys": [1, 2, 3],
+        });
+        let merged = merge_config_patch(
+            base,
+            &serde_json::json!({
+                "query": "SELECT * FROM t",   // scalar replace
+                "opts": { "b": 9, "c": 3 },   // recursive object merge
+                "keys": [7],                    // array replaces wholesale
+            }),
+        );
+        assert_eq!(merged["url"], "keep");
+        assert_eq!(merged["query"], "SELECT * FROM t");
+        assert_eq!(
+            merged["opts"],
+            serde_json::json!({ "a": 1, "b": 9, "c": 3 })
+        );
+        assert_eq!(merged["keys"], serde_json::json!([7]));
+    }
+
+    // ── Check 12: discovery round-trips ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn check12_passes_when_every_dataset_rebuilds_and_reads() {
+        let source = DiscoverableSource::new();
+        assert_discover_roundtrips(&source, |patch| async move {
+            // The patch selects a dataset; a real adopter would deep-merge it
+            // onto the base config and rebuild. Here the rebuilt source just
+            // reads a small, healthy set.
+            let name = patch["dataset"].as_str().unwrap_or("");
+            assert!(!name.is_empty(), "config_patch must carry the dataset");
+            Box::new(CountingSource::new(3, 1)) as Box<dyn Source>
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "does not advertise discovery")]
+    async fn check12_fails_for_a_non_discoverable_source() {
+        let source = CountingSource::new(3, 1);
+        assert_discover_roundtrips(&source, |_patch| async {
+            Box::new(CountingSource::new(3, 1)) as Box<dyn Source>
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "returned no datasets")]
+    async fn check12_fails_when_catalog_is_empty() {
+        let source = DiscoverableSource::empty();
+        assert_discover_roundtrips(&source, |_patch| async {
+            Box::new(CountingSource::new(3, 1)) as Box<dyn Source>
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "errored on read")]
+    async fn check12_fails_when_rebuilt_source_is_unreadable() {
+        let source = DiscoverableSource::new();
+        assert_discover_roundtrips(&source, |_patch| async {
+            // The catalog advertised a dataset the rebuilt source can't read.
+            Box::new(FailingSource) as Box<dyn Source>
+        })
+        .await;
+    }
+
+    // ── Check 13: cancellation flushes ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn check13_passes_for_a_sink_that_flushes_on_cancel() {
+        let sink = BufferedSink::new();
+        let s = sink.clone();
+        assert_cancellation_flushes(&sink, || {
+            let s = s.clone();
+            async move { s.durable_len() }
+        })
+        .await;
+        // The written page was flushed to durable storage on the cancel path.
+        assert_eq!(sink.durable_len(), 3);
+        assert_eq!(sink.staged_len(), 0);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "was not flushed on the cancel path")]
+    async fn check13_fails_for_a_sink_whose_flush_drops_the_buffer() {
+        let sink = BufferedSink::broken();
+        let s = sink.clone();
+        assert_cancellation_flushes(&sink, || {
+            let s = s.clone();
+            async move { s.durable_len() }
+        })
+        .await;
     }
 }

--- a/crates/source/bigquery/tests/conformance.rs
+++ b/crates/source/bigquery/tests/conformance.rs
@@ -163,6 +163,106 @@ async fn conformance_bounded_memory() {
     assert_bounded_memory(&source, 250, TOTAL_ROWS).await;
 }
 
+// ── Check 12: discovery round-trips ───────────────────────────────────────────
+
+/// Every table `discover()` reports (datasets.list → tables.list → tables.get)
+/// must be genuinely selectable: deep-merge its config_patch (`{"query": …}`)
+/// onto the base config, rebuild the source, and read it via `jobs.query`. A
+/// realistic mock of the BigQuery catalog + query REST API.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+
+    // Catalog: one dataset `sales` with one physical table `orders`.
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/datasets")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "kind": "bigquery#datasetList",
+            "etag": "etag-0",
+            "datasets": [{
+                "datasetReference": { "projectId": PROJECT_ID, "datasetId": "sales" }
+            }]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/projects/{PROJECT_ID}/datasets/sales/tables"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tables": [{
+                "type": "TABLE",
+                "tableReference": {
+                    "projectId": PROJECT_ID, "datasetId": "sales", "tableId": "orders"
+                }
+            }]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/projects/{PROJECT_ID}/datasets/sales/tables/orders"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {
+                "projectId": PROJECT_ID, "datasetId": "sales", "tableId": "orders"
+            },
+            "schema": schema_one_col(),
+            "numRows": "3",
+        })))
+        .mount(&server)
+        .await;
+    // Read path for the rebuilt source: a single jobs.query page of 3 rows.
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_one_col(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": JOB_ID},
+            "rows": rows(0, 3),
+        })))
+        .mount(&server)
+        .await;
+
+    let base_cfg = BigQuerySourceConfig::new(
+        PROJECT_ID,
+        BigQueryCredentials::ApplicationDefault,
+        "SELECT 1",
+    );
+    let (source, _sa_file) = build_source(&server, base_cfg).await;
+
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let server_uri = server.uri();
+        async move {
+            // Rebuild against the same mock: a fresh client + config carrying
+            // the discovered query. `build_source` needs a &MockServer, so
+            // reconstruct the client the same way here.
+            let query = patch["query"].as_str().expect("query patch").to_string();
+            let cfg = BigQuerySourceConfig::new(
+                PROJECT_ID,
+                BigQueryCredentials::ApplicationDefault,
+                query,
+            );
+            let sa_json = dummy_service_account_json(&server_uri);
+            let sa_file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(
+                sa_file.path(),
+                serde_json::to_string_pretty(&sa_json).unwrap(),
+            )
+            .unwrap();
+            let client = ClientBuilder::new()
+                .with_auth_base_url(format!("{server_uri}{AUTH_SCOPE_BASE}"))
+                .with_v2_base_url(server_uri)
+                .build_from_service_account_key_file(sa_file.path().to_str().unwrap())
+                .await
+                .expect("build bigquery client against mock");
+            Box::new(BigQuerySource::from_parts(cfg, client)) as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+}
+
 // ── Check 6: errors, not panics ──────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/source/elasticsearch/tests/conformance.rs
+++ b/crates/source/elasticsearch/tests/conformance.rs
@@ -136,6 +136,52 @@ async fn conformance_batch_size_zero_single_page() {
     assert_batch_size_zero_single_page(&source).await;
 }
 
+// ── Check 12: discovery round-trips ───────────────────────────────────────────
+
+/// Every index `discover()` reports (`GET _cat/indices` + `GET /<idx>/_mapping`)
+/// must be genuinely selectable: deep-merge its config_patch (`{"index": …}`)
+/// onto the base config, rebuild the source, and read it (`POST /<idx>/_search`).
+/// A realistic mock of the Elasticsearch catalog + scroll API — the integration
+/// analogue of the synthetic double.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let server = MockServer::start().await;
+    // Catalog: one non-system index `test`.
+    Mock::given(method("GET"))
+        .and(path("/_cat/indices"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([{ "index": "test", "docs.count": "3" }])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/test/_mapping"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "test": { "mappings": { "properties": { "id": { "type": "long" } } } }
+        })))
+        .mount(&server)
+        .await;
+    // Read path for the rebuilt source: one scroll page of 3 docs, then empty.
+    mount_paged_responder(&server, PagedResponder::new(1, 3)).await;
+
+    let source = ElasticsearchSource::new(ElasticsearchSourceConfig::new(server.uri(), "test"))
+        .expect("source new");
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let uri = server.uri();
+        async move {
+            let base = serde_json::to_value(ElasticsearchSourceConfig::new(&uri, "test"))
+                .expect("serialize base config");
+            let merged = faucet_conformance::merge_config_patch(base, &patch);
+            let cfg: ElasticsearchSourceConfig =
+                serde_json::from_value(merged).expect("deserialize merged config");
+            Box::new(ElasticsearchSource::new(cfg).expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+}
+
 // ── Check 6: errors, not panics ──────────────────────────────────────────────
 
 /// A source pointed at an unreachable endpoint. `new()` builds (lazy HTTP

--- a/crates/source/gcs/tests/conformance.rs
+++ b/crates/source/gcs/tests/conformance.rs
@@ -135,6 +135,61 @@ async fn conformance_bounded_memory() {
     faucet_conformance::assert_bounded_memory(&source, 250, 5_000).await;
 }
 
+// ── Check 12: discovery round-trips (live gRPC backend, ignored) ─────────────
+
+/// Every dataset `discover()` reports must be genuinely selectable: take its
+/// config_patch (a `{"prefix": …}` override) and rebuild the source pointed at
+/// that prefix, then read it. `#[ignore]`d for the same reason as the
+/// bounded-memory check — `discover()` and the read path both use the gRPC
+/// storage client, which `fake-gcs-server` (REST-only) cannot serve. Run with
+/// `cargo test -- --ignored` against a real GCS-compatible gRPC backend.
+#[tokio::test]
+#[ignore = "requires a real GCS-compatible gRPC backend; fake-gcs-server only speaks REST. Run with `cargo test -- --ignored` against a live backend."]
+async fn conformance_discover_roundtrips() {
+    let Some((host, bucket)) = spawn_fake_gcs().await else {
+        return;
+    };
+    seed_object(
+        &host,
+        &bucket,
+        "orders/data.jsonl",
+        &jsonl_body(3),
+        "application/x-ndjson",
+    )
+    .await;
+    seed_object(
+        &host,
+        &bucket,
+        "customers/data.jsonl",
+        &jsonl_body(3),
+        "application/x-ndjson",
+    )
+    .await;
+
+    let source = GcsSource::new(
+        GcsSourceConfig::new(&bucket)
+            .auth(GcsCredentials::Anonymous)
+            .storage_host(&host),
+    )
+    .await
+    .unwrap();
+
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let host = host.clone();
+        let bucket = bucket.clone();
+        async move {
+            let prefix = patch["prefix"].as_str().expect("prefix patch").to_string();
+            let cfg = GcsSourceConfig::new(&bucket)
+                .prefix(&prefix)
+                .auth(GcsCredentials::Anonymous)
+                .storage_host(&host);
+            Box::new(GcsSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+}
+
 // ── Check 6: errors, not panics (no container) ──────────────────────────────
 
 /// Point the source at an unreachable GCS storage host (`http://127.0.0.1:1`,

--- a/crates/source/mongodb/tests/conformance.rs
+++ b/crates/source/mongodb/tests/conformance.rs
@@ -79,6 +79,35 @@ async fn conformance_bounded_memory() {
     // _container stays alive to here
 }
 
+// ── Check 12: discovery round-trips (Docker) ────────────────────────────────
+
+/// Every collection `discover()` reports must be genuinely selectable:
+/// deep-merge its config_patch (`{"collection": …}`) onto the base config,
+/// rebuild the source, and read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let (_container, uri) = start_mongo().await;
+    seed_docs(&uri, "testdb", "events", 3).await;
+
+    let source = MongoSource::new(MongoSourceConfig::new(uri.as_str(), "testdb", "events"))
+        .await
+        .expect("source new");
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let uri = uri.clone();
+        async move {
+            let base = serde_json::to_value(MongoSourceConfig::new(&uri, "testdb", "events"))
+                .expect("serialize base config");
+            let merged = faucet_conformance::merge_config_patch(base, &patch);
+            let cfg: MongoSourceConfig =
+                serde_json::from_value(merged).expect("deserialize merged config");
+            Box::new(MongoSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+    // _container stays alive to here
+}
+
 // ── Check 6: errors, not panics (no Docker) ─────────────────────────────────
 
 /// `MongoSource::new` only parses the URI and spawns the driver's background

--- a/crates/source/mssql/tests/conformance.rs
+++ b/crates/source/mssql/tests/conformance.rs
@@ -170,6 +170,40 @@ async fn conformance_bookmark_roundtrip() {
     // _container stays alive to here
 }
 
+// ── Check 12: discovery round-trips (Docker) ────────────────────────────────
+
+/// Every dataset `discover()` reports must be genuinely selectable: take its
+/// config_patch (`{"query": …}`), rebuild the source pointed at that query, and
+/// read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let _serial = SERIAL.lock().await;
+    let (_container, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+    seed_events(&pool, 3).await;
+
+    let url = cfg.connection_url.clone().unwrap();
+    let tls = cfg.tls.clone();
+    let mut base = MssqlSourceConfig::new(url.clone(), "SELECT 1");
+    base.connection.tls = tls.clone();
+    let source = MssqlSource::new(base).await.expect("source new");
+
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let url = url.clone();
+        let tls = tls.clone();
+        async move {
+            let query = patch["query"].as_str().expect("query patch").to_string();
+            let mut cfg = MssqlSourceConfig::new(url, query);
+            cfg.connection.tls = tls;
+            Box::new(MssqlSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+    // _container stays alive to here
+}
+
 // ── Check 6: errors, not panics (Docker) ────────────────────────────────────
 
 /// The source builds against a live container (so `new()` — which eagerly

--- a/crates/source/mysql/tests/conformance.rs
+++ b/crates/source/mysql/tests/conformance.rs
@@ -114,6 +114,33 @@ async fn conformance_bounded_memory() {
     // _container stays alive to here
 }
 
+// ── Check 12: discovery round-trips (Docker) ────────────────────────────────
+
+/// Every dataset `discover()` reports must be genuinely selectable: deep-merge
+/// its config_patch onto the base config, rebuild the source, and read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let (_container, url) = start_mysql().await;
+    seed_events(&url, 3).await;
+    let source = MysqlSource::new(MysqlSourceConfig::new(&url, "SELECT 1"))
+        .await
+        .expect("source new");
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let url = url.clone();
+        async move {
+            let base = serde_json::to_value(MysqlSourceConfig::new(&url, "SELECT 1"))
+                .expect("serialize base config");
+            let merged = faucet_conformance::merge_config_patch(base, &patch);
+            let cfg: MysqlSourceConfig =
+                serde_json::from_value(merged).expect("deserialize merged config");
+            Box::new(MysqlSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+    // _container stays alive to here
+}
+
 // ── Check 6: errors, not panics (Docker) ────────────────────────────────────
 
 /// The source builds against a live container (so `new()` — which eagerly

--- a/crates/source/postgres/tests/conformance.rs
+++ b/crates/source/postgres/tests/conformance.rs
@@ -81,6 +81,30 @@ async fn conformance_bounded_memory() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    // Check 12: every dataset `discover()` reports must be genuinely selectable
+    // — deep-merge its config_patch onto the base config, rebuild, and read.
+    let (_container, url) = start_postgres().await;
+    seed(&url, 3).await;
+    let source = PostgresSource::new(PostgresSourceConfig::new(&url, "SELECT 1"))
+        .await
+        .expect("source new");
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let url = url.clone();
+        async move {
+            let base = serde_json::to_value(PostgresSourceConfig::new(&url, "SELECT 1"))
+                .expect("serialize base config");
+            let merged = faucet_conformance::merge_config_patch(base, &patch);
+            let cfg: PostgresSourceConfig =
+                serde_json::from_value(merged).expect("deserialize merged config");
+            Box::new(PostgresSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn conformance_errors_not_panics() {
     let (_container, url) = start_postgres().await;
     // Valid connection, but the query hits a table that does not exist — the

--- a/crates/source/s3/tests/conformance.rs
+++ b/crates/source/s3/tests/conformance.rs
@@ -142,6 +142,40 @@ async fn conformance_bounded_memory() {
     // _container stays alive to here
 }
 
+// ── Check 12: discovery round-trips (Docker) ────────────────────────────────
+
+/// Every dataset `discover()` reports must be genuinely selectable: deep-merge
+/// its config_patch (a `{"prefix": …}` override) onto the base config, rebuild
+/// the source, and read it. Objects are seeded under two "directory" prefixes
+/// so the delimiter listing yields prefix datasets.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let (_container, endpoint) = start_minio().await;
+    seed_bucket(
+        &endpoint,
+        &[
+            ("orders/data.jsonl".to_string(), jsonl_body(1, 3)),
+            ("customers/data.jsonl".to_string(), jsonl_body(4, 6)),
+        ],
+    )
+    .await;
+
+    let source = build_source(&endpoint, S3SourceConfig::new(TEST_BUCKET)).await;
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let endpoint = endpoint.clone();
+        async move {
+            let base = serde_json::to_value(S3SourceConfig::new(TEST_BUCKET))
+                .expect("serialize base config");
+            let merged = faucet_conformance::merge_config_patch(base, &patch);
+            let cfg: S3SourceConfig =
+                serde_json::from_value(merged).expect("deserialize merged config");
+            Box::new(build_source(&endpoint, cfg).await) as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+    // _container stays alive to here
+}
+
 // ── Check 6: errors, not panics (no container) ──────────────────────────────
 
 /// Point the source at an unreachable S3 endpoint (`http://127.0.0.1:1`, which

--- a/crates/source/snowflake/tests/conformance.rs
+++ b/crates/source/snowflake/tests/conformance.rs
@@ -19,7 +19,7 @@ use faucet_conformance::{
 };
 use faucet_source_snowflake::{SnowflakeAuth, SnowflakeSource, SnowflakeSourceConfig};
 use serde_json::{Value, json};
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{body_string_contains, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const HANDLE: &str = "conformance-handle";
@@ -100,6 +100,97 @@ async fn conformance_bounded_memory() {
         .with_endpoint_base(server.uri());
 
     assert_bounded_memory(&source, 250, NUM_PARTITIONS * ROWS_PER_PARTITION).await;
+}
+
+// ── Check 12: discovery round-trips ───────────────────────────────────────────
+
+/// Every table `discover()` reports (from the `information_schema` catalog SQL)
+/// must be genuinely selectable: take its config_patch (`{"query": …}`), rebuild
+/// the source pointed at that query, and read it. Both the catalog SQL and the
+/// data query hit `POST /api/v2/statements`, so the mock distinguishes them by
+/// body — a realistic mock of the Snowflake SQL REST API.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let server = MockServer::start().await;
+
+    // Catalog statement: the `information_schema` query returns one table
+    // `PUBLIC.ORDERS` with a single column `ID`.
+    let catalog_meta = json!({
+        "rowType": [
+            {"name": "TABLE_SCHEMA", "type": "text"},
+            {"name": "TABLE_NAME", "type": "text"},
+            {"name": "COLUMN_NAME", "type": "text"},
+            {"name": "DATA_TYPE", "type": "text"},
+            {"name": "IS_NULLABLE", "type": "text"},
+            {"name": "ROW_COUNT", "type": "fixed"},
+        ],
+        "partitionInfo": [{"rowCount": 1}],
+        "format": "jsonv2",
+        "numRows": 1,
+    });
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("information_schema"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": HANDLE,
+            "resultSetMetaData": catalog_meta,
+            "data": [["PUBLIC", "ORDERS", "ID", "NUMBER", "NO", "3"]],
+        })))
+        .mount(&server)
+        .await;
+
+    // Data query for the rebuilt source: `SELECT * FROM "PUBLIC"."ORDERS"`.
+    let data_meta = json!({
+        "rowType": [{"name": "ID", "type": "fixed"}],
+        "partitionInfo": [{"rowCount": 3}],
+        "format": "jsonv2",
+        "numRows": 3,
+    });
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("ORDERS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "data-handle",
+            "resultSetMetaData": data_meta,
+            "data": [["0"], ["1"], ["2"]],
+        })))
+        .mount(&server)
+        .await;
+
+    let base = SnowflakeSourceConfig::new(
+        "xy12345",
+        "WH",
+        "DB",
+        "PUBLIC",
+        SnowflakeAuth::OAuth { token: "t".into() },
+        "SELECT 1",
+    );
+    let source = SnowflakeSource::new(base)
+        .expect("source new")
+        .with_endpoint_base(server.uri());
+
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let uri = server.uri();
+        async move {
+            let query = patch["query"].as_str().expect("query patch").to_string();
+            let cfg = SnowflakeSourceConfig::new(
+                "xy12345",
+                "WH",
+                "DB",
+                "PUBLIC",
+                SnowflakeAuth::OAuth { token: "t".into() },
+                query,
+            );
+            Box::new(
+                SnowflakeSource::new(cfg)
+                    .expect("rebuilt source")
+                    .with_endpoint_base(uri),
+            ) as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
 }
 
 // ── Check 6: errors, not panics ──────────────────────────────────────────────

--- a/crates/source/spanner/tests/conformance.rs
+++ b/crates/source/spanner/tests/conformance.rs
@@ -103,6 +103,45 @@ async fn conformance_bookmark_roundtrip() {
     assert_bookmark_roundtrip(&source).await;
 }
 
+// ── Check 12: discovery round-trips (Docker) ────────────────────────────────
+
+/// Every dataset `discover()` reports must be genuinely selectable: take its
+/// config_patch (`{"query": …}`), rebuild the source pointed at that query, and
+/// read it against the emulator.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_discover_roundtrips() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "discover",
+        &["CREATE TABLE nums (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "discover").await;
+    seed_nums(&client, 3).await;
+
+    let mut base =
+        SpannerSourceConfig::new(support::PROJECT, support::INSTANCE, "discover", "SELECT 1");
+    base.connection = support::connection(&emu.host, "discover");
+    let source = SpannerSource::new(base).await.expect("source");
+
+    let host = emu.host.clone();
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let host = host.clone();
+        async move {
+            let query = patch["query"].as_str().expect("query patch").to_string();
+            let mut cfg =
+                SpannerSourceConfig::new(support::PROJECT, support::INSTANCE, "discover", query);
+            cfg.connection = support::connection(&host, "discover");
+            Box::new(SpannerSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+}
+
 // ── Check 6: errors, not panics (Docker) ────────────────────────────────────
 
 /// Query a table that does not exist — both `fetch_all` and `stream_pages`

--- a/crates/source/sqlite/tests/conformance.rs
+++ b/crates/source/sqlite/tests/conformance.rs
@@ -86,3 +86,26 @@ async fn conformance_errors_not_panics() {
         .expect("source builds; the query only fails at read time");
     faucet_conformance::assert_errors_not_panics(&source).await;
 }
+
+#[tokio::test]
+async fn conformance_discover_roundtrips() {
+    // Check 12: every dataset `discover()` reports must be genuinely selectable —
+    // deep-merge its config_patch onto the base config, rebuild, and read.
+    let (_dir, url) = seed(3).await;
+    let source = SqliteSource::new(SqliteSourceConfig::new(&url, "SELECT 1"))
+        .await
+        .expect("source");
+    faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+        let url = url.clone();
+        async move {
+            let base = serde_json::to_value(SqliteSourceConfig::new(&url, "SELECT 1"))
+                .expect("serialize base config");
+            let merged = faucet_conformance::merge_config_patch(base, &patch);
+            let cfg: SqliteSourceConfig =
+                serde_json::from_value(merged).expect("deserialize merged config");
+            Box::new(SqliteSource::new(cfg).await.expect("rebuilt source"))
+                as Box<dyn faucet_core::Source>
+        }
+    })
+    .await;
+}

--- a/docs/book/src/extending/authoring-connectors.md
+++ b/docs/book/src/extending/authoring-connectors.md
@@ -145,6 +145,28 @@ use `assert_idempotent_replay` and `assert_capabilities_truthful` — both take 
 `distinct_count` closure that returns the destination's current row count (for a
 real sink, a `SELECT count(*)` against the target table).
 
+A **discoverable source** (one that overrides `supports_discover`) adds
+`assert_discover_roundtrips`, an *integration-level* check that proves every
+dataset `discover()` reports is genuinely selectable — it deep-merges each
+descriptor's `config_patch` onto the base config (the `merge_config_patch`
+helper does this), rebuilds the source, and reads it. Run it against the same
+live/seeded backend your other checks use:
+
+```rust,ignore
+faucet_conformance::assert_discover_roundtrips(&source, |patch| {
+    let base = /* the connection config as a serde_json::Value */;
+    let merged = faucet_conformance::merge_config_patch(base, &patch);
+    let cfg = serde_json::from_value(merged).unwrap();
+    async move { Box::new(FooSource::new(cfg).await.unwrap()) as Box<dyn faucet_core::Source> }
+})
+.await;
+```
+
+`assert_cancellation_flushes` covers the flush-completing cancellation contract
+(a mid-run `CancellationToken` stops at a page boundary and still flushes) by
+driving the real pipeline — most useful for a buffered sink (Parquet footer, S3
+multipart) whose output only commits on `flush()`.
+
 **Assert the honest branch.** Where a connector legitimately can't satisfy a
 check — an append-only sink has no idempotency mechanism, for instance — don't
 skip it: assert the honest behaviour instead. The capability method returns

--- a/docs/book/src/reference/conformance.md
+++ b/docs/book/src/reference/conformance.md
@@ -70,6 +70,37 @@ apply, so a community connector is typically graded on its config schema and the
 capabilities it advertises. Publish a PR adding a `verified` registry entry to
 have it scored like a built-in.
 
+## The behavioral conformance battery
+
+The score above is a **static** grade (registry entry, config schema, advertised
+capabilities). It is complemented by the
+[`faucet-conformance`](https://crates.io/crates/faucet-conformance) crate — a
+**runtime** test battery a connector calls from its own `tests/` to prove it
+actually upholds the contract, not just advertises it. There are 13 checks; each
+ships with a passing *and* a `#[should_panic]` failing test in the battery, so no
+check can be vacuous.
+
+Checks 1–11 run against synthetic in-memory doubles or a single connector
+instance (config-schema validity, bounded-memory paging, bookmark resume,
+idempotent replay, truthful capabilities/write-modes, effective schema
+evolution, `batch_size = 0` single-page, non-empty `connector_name`, well-formed
+`check()` probes). Two more are **integration-level** — they need a live backend
+or the real pipeline, so they live in a connector's testcontainers/tempfile
+test:
+
+- **`assert_discover_roundtrips`** *(discoverable sources)* — every dataset
+  `discover()` reports is genuinely selectable: deep-merge its `config_patch`,
+  rebuild the source, and read it. Adopted by all 11 catalog-backed sources
+  (postgres, mysql, mssql, sqlite, mongodb, elasticsearch, bigquery, snowflake,
+  spanner, s3, gcs).
+- **`assert_cancellation_flushes`** — a mid-run `CancellationToken` stops at a
+  page boundary and flushes the sink, so buffered output (a Parquet footer, an
+  S3 multipart) survives cancellation rather than being orphaned
+  ([ADR 0011](https://github.com/faucet-hq/faucet-stream/blob/main/docs/adr/0011-cooperative-cancellation.md)).
+
+See [Authoring connectors](../extending/authoring-connectors.md#self-certify-with-the-conformance-battery)
+for how to wire the battery into a new connector.
+
 ## Related
 
 - [`faucet conformance`](./cli.md#conformance) — the command


### PR DESCRIPTION
## Summary

Adds the two `faucet-conformance` behavioral checks deliberately deferred from #465 — `assert_discover_roundtrips` and `assert_cancellation_flushes` — as **integration-level** checks. As #471 notes, neither can be made meaningful against the crate's synthetic in-memory doubles (a double has no backing catalog to re-read from; timing-sensitive mid-run cancellation is flaky in a unit test), so both drive a live backend / the real pipeline where they belong.

## What's added

**Check 12 — `assert_discover_roundtrips`** (discoverable sources)
For each `DatasetDescriptor` a source's `discover()` reports, deep-merge its `config_patch` onto the base config, rebuild the source, and assert the dataset is genuinely readable end-to-end (not just a name in a list). A new pure `merge_config_patch(base, patch)` helper (recursive object merge, scalar/array replace — mirroring the CLI's deep-merge) writes the `rebuild` closure in one line.

Adopted in **all 11 catalog-backed sources**: postgres, mysql, mssql, sqlite, mongodb, elasticsearch, bigquery, snowflake, spanner, s3, gcs — reusing each existing seeded backend (testcontainers / MinIO / emulator / tempfile / wiremock). GCS is `#[ignore]`d for the same reason its bounded-memory check is (the read path needs gRPC; `fake-gcs-server` is REST-only).

**Check 13 — `assert_cancellation_flushes`**
Drives the **real** `faucet_core::run_stream` with a deterministic self-cancelling source (no timers, no flakiness): one page, then the source fires the token and blocks. Asserts `run_stream` returns `Ok` with the partial result **and** the buffered sink's `flush()` ran (records are durable) — the #146 H16 / [ADR 0011](https://github.com/faucet-hq/faucet-stream/blob/main/docs/adr/0011-cooperative-cancellation.md) flush-completing cancellation contract.

## Non-vacuous by construction

Per the crate's discipline (a check that cannot fail is worthless), each new check ships with a passing **and** a `#[should_panic]` failing self-test, backed by two new doubles:
- `DiscoverableSource` (+ `empty()`) — drives the pass path and the empty-catalog / non-discoverable / unreadable-rebuild failure paths.
- `BufferedSink` (+ `broken()`) — models a sink that only commits on `flush`; the broken variant (flush drops the buffer) drives the failure path.

New lib code is at **100% patch coverage** (measured via `cargo llvm-cov`; every line of `merge_config_patch` / `assert_discover_roundtrips` / `assert_cancellation_flushes` is exercised).

## Verification

- `cargo test -p faucet-conformance` — 52 unit tests + 2 doctests green.
- Ran the round-trip live against real backends locally: **sqlite, postgres, mysql, mongodb, s3 (MinIO), spanner (emulator)**, plus the wiremock trio **elasticsearch, bigquery, snowflake** — all pass. mssql compiles (SQL Server is CI-only on arm64); gcs compiles (`#[ignore]`d, gRPC backend).
- `cargo clippy --tests -D warnings` clean on the conformance crate and all 11 adopted source crates; `cargo fmt`; rustdoc `-D warnings` clean.

## Docs

- `crates/conformance/README.md` — the checks table now lists all 13 (7–11 were already shipped but undocumented) plus an integration-level section.
- `docs/book/src/extending/authoring-connectors.md` — how to wire the two integration checks into a new connector.
- `docs/book/src/reference/conformance.md` — a "behavioral conformance battery" section distinguishing the runtime battery from the static score.

Closes #471.

Related: #465 (deferred these two), #470 (adopted checks 1–11), #211 (dataset discovery), #146 H16 (flush-completing cancellation). Roadmap epic #38.