### PR TITLE
fix(ci): only build Docker images on the faucet-cli release

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -7,7 +7,10 @@ name: Docker images
 #
 # Triggers:
 #   - manual (workflow_dispatch), optional push
-#   - on a published GitHub release (pushes :<profile> and :<version>-<profile>)
+#   - on a published `faucet-cli-v*` GitHub release (pushes :<profile> and
+#     :<version>-<profile>). release-plz publishes a GitHub release per crate
+#     tag, so both jobs gate on the faucet-cli tag to build ONCE per app
+#     release rather than once per crate.
 
 on:
   workflow_dispatch:
@@ -28,6 +31,11 @@ permissions:
 
 jobs:
   build:
+    # release-plz publishes one GitHub release per crate tag, but the images
+    # should build ONCE per app release. Gate to the faucet-cli release (or a
+    # manual dispatch) so a `faucet-source-*` / `faucet-sink-*` crate tag does
+    # not trigger a full image build. Mirrors the `helm` job's guard below.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'faucet-cli-v')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

The `docker-images.yml` workflow triggers on every published GitHub release (`on: release: [published]`). But `release-plz` publishes **one GitHub release per crate tag**, and the `build` job had no ref guard — so every `faucet-source-*` / `faucet-sink-*` / `faucet-common-*` / `faucet-transform-*` crate tag kicked off a full 4-profile image build. The last release spawned ~47 wasted image-build runs (all cancelled manually).

The `helm` job in the same workflow already guarded on `startsWith(github.ref_name, 'faucet-cli-v')`. This applies the **same guard to the `build` job** so images build once per app release (the `faucet-cli-v*` tag) or on manual `workflow_dispatch` — not once per crate.

## Change

```yaml
  build:
    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'faucet-cli-v')
```

Plus a clarifying header comment on the trigger intent.

## Notes

- `release` events run the workflow from the **default branch**, so this fix takes effect for the *next* release after merge; it does not affect releases already fired.
- No behavior change for the intended path: the `faucet-cli-v*` release and manual dispatch still build all four profiles exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)