### PR TITLE
fix(docs): render wide mermaid pipeline diagrams legibly on the book site

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -199,7 +199,11 @@ mark {
   overflow-x: auto;
 }
 .content .mermaid svg {
-  max-width: 100%;
+  /* Render at natural size (paired with mermaid's useMaxWidth:false); the
+     enclosing .mermaid box caps width at 100% and scrolls horizontally, so a
+     long left-to-right pipeline stays legible instead of being shrunk to a
+     thin, unreadable strip. */
+  max-width: none;
   height: auto;
 }
 

--- a/docs/book/mermaid-init.js
+++ b/docs/book/mermaid-init.js
@@ -62,7 +62,12 @@
         startOnLoad: true,
         theme: 'base',
         themeVariables: lastThemeWasLight ? lightVars : darkVars,
-        flowchart: { htmlLabels: true, padding: 12, useMaxWidth: true, nodeSpacing: 36, rankSpacing: 44 },
+        // useMaxWidth:false → mermaid emits a natural-width SVG instead of one
+        // shrunk to the column. Long left-to-right pipelines (8–9 nodes) then
+        // stay legible and scroll horizontally inside their box (see the
+        // `.content .mermaid` overflow-x rule) rather than collapsing into an
+        // unreadable thin strip.
+        flowchart: { htmlLabels: true, padding: 12, useMaxWidth: false, nodeSpacing: 36, rankSpacing: 44 },
     });
 
     // Re-render diagrams in the new palette when the reader switches theme.


### PR DESCRIPTION
## Problem

On the published docs site, the long left-to-right flow diagrams on **Learn the architecture** (`getting-started/learn.md`) — *How a run is assembled* (9 nodes), *The pipeline loop* (8), *streaming* (8), *incremental* (8) — rendered as unreadable thin strips: an empty box with a faint dash. The short 3-node diagrams (Chapters 1–2) were fine.

## Cause

Mermaid's `flowchart.useMaxWidth: true` (in `mermaid-init.js`) combined with `.content .mermaid svg { max-width: 100% }` (in `custom.css`) forced **every** diagram's SVG to shrink to the column width. A long horizontal chain then scaled down proportionally to a ~30px-tall strip, and because the SVG was capped at 100% it never overflowed — so the `.mermaid` box's existing `overflow-x: auto` never engaged.

## Fix

- `mermaid-init.js`: `useMaxWidth: false` → mermaid emits a natural-width SVG.
- `custom.css`: `.content .mermaid svg { max-width: none }` → the SVG keeps its intrinsic width and the enclosing box scrolls horizontally.

Long pipelines now render at full, legible size and scroll within their box; short diagrams are unchanged (they already fit and stay centered). Purely a docs-site asset change — no Markdown edited, so GitHub's native mermaid rendering is unaffected.

## Verification

Rebuilt the book (`mdbook build docs/book`) and screenshotted the page headless before/after — the 8-node streaming diagram now shows full-size `page 1 → write → page 2 → …` instead of an empty strip.

Roadmap epic #38.