### PR TITLE
feat(serve): per-run completion callbacks, with run identity in the notify payload

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -330,7 +330,11 @@ schedule = ["dep:croner"]
 # Enables `observability` (serve renders /metrics on its own port). Gates the
 # tokio net/time features here (rather than the base dep) so slim non-serve
 # builds don't link the TCP stack.
-serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:subtle", "dep:dashmap", "dep:sha2", "dep:async-stream"]
+# `dep:reqwest` is needed by `serve::callback` (#481) — per-run completion
+# callbacks POST to a caller-supplied URL, so the HTTP client must be linked by
+# `serve` itself rather than relying on another feature (e.g. `notify`) pulling
+# it in; the feature-isolation CI matrix builds `serve` alone.
+serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:subtle", "dep:dashmap", "dep:sha2", "dep:async-stream", "dep:reqwest"]
 serve-history-postgres = ["serve", "dep:sqlx"]
 serve-history-sqlite = ["serve", "dep:sqlx"]
 # Embedded web console (single-page UI) served by `faucet serve` at `/`.

--- a/cli/src/backfill/orchestrator.rs
+++ b/cli/src/backfill/orchestrator.rs
@@ -285,6 +285,7 @@ fn make_opts(
 ) -> ExecuteOptions {
     ExecuteOptions {
         pipeline_name: opts.pipeline_name.clone(),
+        run_id: None,
         execution: opts.execution.clone(),
         dry_run: false,
         limit: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -944,6 +944,12 @@ pub struct ServeArgs {
     /// the `triggers` feature. See `faucet schema triggers`.
     #[arg(long)]
     pub triggers: Option<std::path::PathBuf>,
+    /// Restrict per-run completion callbacks (`callback` on a submit) to these
+    /// hosts. Repeatable. When unset, any host is permitted **except**
+    /// link-local / cloud-metadata addresses, which are always refused unless
+    /// named here. See the HTTP API reference for the egress posture.
+    #[arg(long = "callback-allow-host")]
+    pub callback_allow_host: Vec<String>,
     /// Mount the MCP (Model Context Protocol) endpoint at `/mcp`, exposing
     /// faucet as agent tool calls. Effective only in a build with the `mcp`
     /// feature; the endpoint inherits serve's bearer-auth + RBAC + audit.

--- a/cli/src/commands/history.rs
+++ b/cli/src/commands/history.rs
@@ -179,6 +179,7 @@ mod tests {
             clock: None,
             attempt: 0,
             replay_of: None,
+            callback: None,
         }
     }
 

--- a/cli/src/commands/notify.rs
+++ b/cli/src/commands/notify.rs
@@ -55,19 +55,36 @@ async fn test(args: NotifyTestArgs) -> CliResult<()> {
 
 /// Build a synthetic event for the requested kind. DLQ uses a large count so it
 /// clears any configured `dlq_threshold`.
+///
+/// Every kind except `scheduler_stuck` carries a synthetic [`RunContext`], so a
+/// receiver being tested sees the same populated `run_id` / `invocation_id` /
+/// timing fields a real run would send (#480). `scheduler_stuck` deliberately
+/// does not — it has no owning invocation in production either, so leaving it
+/// null is the faithful shape.
 fn synth_event(kind: &str, pipeline: &str) -> CliResult<NotifyEvent> {
+    let run = || {
+        crate::notify::RunContext::start(
+            Some(format!("test-run-{}", uuid::Uuid::now_v7())),
+            Some(format!("test-invocation-{}", uuid::Uuid::now_v7())),
+        )
+        .finish(std::time::Instant::now())
+    };
     Ok(match kind {
         "run_failure" => NotifyEvent::run_failure(
             pipeline,
             "",
             "test",
             "synthetic test failure from `faucet notify test`",
-        ),
-        "run_success" => NotifyEvent::run_success(pipeline, "", 0),
-        "sla_breach" => NotifyEvent::sla_breach(pipeline, "", "staleness", "synthetic SLA breach"),
-        "circuit_open" => NotifyEvent::circuit_open(pipeline, "", 5, 30),
-        "contract_abort" => NotifyEvent::contract_abort(pipeline, "", "synthetic contract breach"),
-        "dlq_threshold" => NotifyEvent::dlq_threshold(pipeline, "", 1_000_000),
+        )
+        .with_run(run()),
+        "run_success" => NotifyEvent::run_success(pipeline, "", 0).with_run(run()),
+        "sla_breach" => NotifyEvent::sla_breach(pipeline, "", "staleness", "synthetic SLA breach")
+            .with_run(run()),
+        "circuit_open" => NotifyEvent::circuit_open(pipeline, "", 5, 30).with_run(run()),
+        "contract_abort" => {
+            NotifyEvent::contract_abort(pipeline, "", "synthetic contract breach").with_run(run())
+        }
+        "dlq_threshold" => NotifyEvent::dlq_threshold(pipeline, "", 1_000_000).with_run(run()),
         "scheduler_stuck" => NotifyEvent::scheduler_stuck(pipeline, "synthetic scheduler-stuck"),
         other => {
             return Err(CliError::Config(format!(
@@ -107,5 +124,32 @@ mod tests {
     #[test]
     fn synth_event_rejects_unknown_kind() {
         assert!(synth_event("nope", "p").is_err());
+    }
+
+    #[test]
+    fn synth_events_carry_run_identity_except_scheduler_stuck() {
+        // #480: `faucet notify test` must exercise the same payload shape a real
+        // run sends, so a receiver can be validated against populated fields.
+        for kind in [
+            "run_failure",
+            "run_success",
+            "sla_breach",
+            "circuit_open",
+            "contract_abort",
+            "dlq_threshold",
+        ] {
+            let e = synth_event(kind, "p").unwrap();
+            let run = e
+                .run
+                .as_ref()
+                .unwrap_or_else(|| panic!("{kind} needs a run context"));
+            assert!(run.run_id.is_some(), "{kind} run_id");
+            assert!(run.invocation_id.is_some(), "{kind} invocation_id");
+            assert_ne!(run.run_id, run.invocation_id, "{kind} ids must differ");
+            assert!(run.finished_at.is_some(), "{kind} finished_at");
+            assert!(run.duration.is_some(), "{kind} duration");
+        }
+        // No owning invocation in production either — faithful null shape.
+        assert!(synth_event("scheduler_stuck", "p").unwrap().run.is_none());
     }
 }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -246,6 +246,7 @@ pub(crate) async fn execute(
         nodes,
         ExecuteOptions {
             pipeline_name: pipeline_name.clone(),
+            run_id: None,
             execution: cfg.execution.clone(),
             dry_run: args.dry_run,
             limit: args.limit,

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -271,6 +271,7 @@ fn make_opts(
 ) -> ExecuteOptions {
     ExecuteOptions {
         pipeline_name: pipeline_name.to_string(),
+        run_id: None,
         execution: execution.clone(),
         dry_run: false,
         limit: None,

--- a/cli/src/dlq_replay/mod.rs
+++ b/cli/src/dlq_replay/mod.rs
@@ -209,6 +209,7 @@ pub async fn replay(
         vec![node],
         ExecuteOptions {
             pipeline_name: inputs.pipeline_name,
+            run_id: None,
             execution: inputs.execution,
             dry_run: inputs.dry_run,
             limit: None,

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -51,6 +51,16 @@ pub struct ExecuteOptions {
     /// Pipeline name — used in log lines and as the first segment of every
     /// state key.
     pub pipeline_name: String,
+    /// Correlation id for the submitted run (#480). `faucet serve` passes the
+    /// id it returned from `POST /v1/runs` so a completion notification can be
+    /// matched back to the submission; every other runtime leaves it `None` and
+    /// each invocation falls back to its own generated id.
+    ///
+    /// Deliberately *not* the observability `run_id`: one submitted run expands
+    /// to one invocation per matrix row, and the span identity stays unique per
+    /// invocation. Notifications carry both — `run_id` (this) to correlate to
+    /// the submission, `invocation_id` to tell rows apart.
+    pub run_id: Option<String>,
     /// Override for `execution.max_concurrent`. `None` → use the value in
     /// `ExecutionSpec` or the default (`num_cpus::get().min(4)`, floored at 1).
     pub execution: Option<ExecutionSpec>,
@@ -919,6 +929,18 @@ async fn run_one_invocation(
     // Observability identity for this invocation — built once, reused by both
     // the Pipeline builder and the transform instrumentation.
     let run_id = uuid::Uuid::now_v7().to_string();
+    // Notification run identity + timing (#480). `run_id` here correlates to the
+    // *submission* (serve passes the id it returned from `POST /v1/runs`);
+    // `invocation_id` is this row's own id, so a matrix run's notifications are
+    // still individually identifiable. Monotonic `Instant` for the duration —
+    // subtracting the wall-clock stamps would go negative across an NTP step.
+    #[cfg(feature = "notify")]
+    let invocation_started = std::time::Instant::now();
+    #[cfg(feature = "notify")]
+    let notify_run = crate::notify::RunContext::start(
+        Some(opts.run_id.clone().unwrap_or_else(|| run_id.clone())),
+        Some(run_id.clone()),
+    );
     let pipeline_name = opts.pipeline_name.clone();
     let row_id = node.id.clone();
     #[cfg(feature = "lineage")]
@@ -1340,39 +1362,48 @@ async fn run_one_invocation(
         use crate::notify::NotifyEvent;
         let pipeline = obs_labels.pipeline.to_string();
         let row = obs_labels.row.to_string();
+        // Closed once here, so every event from this invocation reports the same
+        // terminal timestamp and duration.
+        let run_ctx = notify_run.clone().finish(invocation_started);
         match &result {
             Ok(r) => {
                 notifier
-                    .emit(NotifyEvent::run_success(
-                        pipeline.clone(),
-                        row.clone(),
-                        r.records_written as u64,
-                    ))
+                    .emit(
+                        NotifyEvent::run_success(
+                            pipeline.clone(),
+                            row.clone(),
+                            r.records_written as u64,
+                        )
+                        .with_run(run_ctx.clone()),
+                    )
                     .await;
                 if let Some(dlq) = &r.dlq
                     && dlq.records_dlq > 0
                 {
                     notifier
-                        .emit(NotifyEvent::dlq_threshold(
-                            pipeline.clone(),
-                            row.clone(),
-                            dlq.records_dlq as u64,
-                        ))
+                        .emit(
+                            NotifyEvent::dlq_threshold(
+                                pipeline.clone(),
+                                row.clone(),
+                                dlq.records_dlq as u64,
+                            )
+                            .with_run(run_ctx.clone()),
+                        )
                         .await;
                 }
             }
             Err(e) => {
-                notifier.emit(error_event(&pipeline, &row, e)).await;
+                notifier
+                    .emit(error_event(&pipeline, &row, e).with_run(run_ctx.clone()))
+                    .await;
             }
         }
         for v in &sla_violations {
             notifier
-                .emit(NotifyEvent::sla_breach(
-                    pipeline.clone(),
-                    row.clone(),
-                    v.kind(),
-                    v.to_string(),
-                ))
+                .emit(
+                    NotifyEvent::sla_breach(pipeline.clone(), row.clone(), v.kind(), v.to_string())
+                        .with_run(run_ctx.clone()),
+                )
                 .await;
         }
     }
@@ -1979,6 +2010,7 @@ mod tests {
             nodes,
             ExecuteOptions {
                 pipeline_name: "t".into(),
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,
@@ -2228,6 +2260,7 @@ matrix:
             nodes,
             ExecuteOptions {
                 pipeline_name: "matrix".into(),
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,
@@ -2290,6 +2323,7 @@ matrix:
             nodes,
             ExecuteOptions {
                 pipeline_name: "dagtest".into(),
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,
@@ -2517,6 +2551,7 @@ execution:
             nodes,
             ExecuteOptions {
                 pipeline_name: "stoptest".into(),
+                run_id: None,
                 execution: cfg.execution.clone(),
                 dry_run: false,
                 limit: None,
@@ -2604,6 +2639,7 @@ pipeline:
             nodes,
             ExecuteOptions {
                 pipeline_name: "bad name".into(), // space is illegal in a state key
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,
@@ -2665,6 +2701,7 @@ matrix:
             nodes,
             ExecuteOptions {
                 pipeline_name: "ok".into(),
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,
@@ -2735,6 +2772,7 @@ execution:
             nodes,
             ExecuteOptions {
                 pipeline_name: "stop_parallel".into(),
+                run_id: None,
                 execution: cfg.execution.clone(),
                 dry_run: false,
                 limit: None,
@@ -2806,6 +2844,7 @@ matrix:
             nodes,
             ExecuteOptions {
                 pipeline_name: "continuetest".into(),
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,
@@ -3060,6 +3099,7 @@ matrix:
     fn opts(name: &str) -> ExecuteOptions {
         ExecuteOptions {
             pipeline_name: name.into(),
+            run_id: None,
             execution: None,
             dry_run: false,
             limit: None,
@@ -3683,6 +3723,7 @@ matrix:
             nodes,
             ExecuteOptions {
                 pipeline_name: "projtest".into(),
+                run_id: None,
                 execution: None,
                 dry_run: false,
                 limit: None,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -295,6 +295,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
         nodes,
         executor::ExecuteOptions {
             pipeline_name,
+            run_id: None,
             execution: cfg.execution.clone(),
             dry_run: false,
             limit: None,

--- a/cli/src/notify/dispatch.rs
+++ b/cli/src/notify/dispatch.rs
@@ -422,6 +422,7 @@ mod tests {
             headers: Default::default(),
             hmac_secret: Some("s".into()),
             signature_header: "X-Faucet-Signature".into(),
+            extra_fields: Default::default(),
         });
         assert!(
             Notifier::from_specs(&[rule("w", vec![], wh)])

--- a/cli/src/notify/event.rs
+++ b/cli/src/notify/event.rs
@@ -6,11 +6,66 @@
 //! Slack / PagerDuty / webhook body lives in [`crate::notify::render`].
 
 use super::spec::{EventKind, Severity};
+use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
+use std::time::Instant;
 
 /// Scrub every resolved secret from text bound for an external channel.
 fn redact(s: String) -> String {
     crate::secrets::registry::redact(&s).into_owned()
+}
+
+/// Run identity + timing for the invocation an event belongs to (#480).
+///
+/// Built once per invocation at the emit site and stamped onto every event that
+/// invocation produces, so a receiver can correlate a notification back to the
+/// run it triggered. Before this existed the only correlation keys in the
+/// payload were `pipeline` + `row`, which are **not unique per run** — two
+/// overlapping runs of one pipeline (a `schedule` `overlap: queue`, a cluster
+/// with several workers, a backfill fanning out per window) produced
+/// indistinguishable callbacks and a receiver keying off `pipeline` would
+/// mis-attribute status.
+///
+/// `duration` is measured from a monotonic [`Instant`], never by subtracting
+/// the two wall-clock stamps — an NTP step between them would otherwise yield a
+/// negative duration.
+#[derive(Debug, Clone, Default)]
+pub struct RunContext {
+    /// Correlation id for the submitted run. Under `faucet serve` this is the
+    /// serve run id returned by `POST /v1/runs`; otherwise the invocation's own
+    /// generated id. A matrix run's rows all share one `run_id` and are told
+    /// apart by `row` (and by `invocation_id`).
+    pub run_id: Option<String>,
+    /// This single invocation's id. Distinct per matrix row within one run.
+    pub invocation_id: Option<String>,
+    /// When the invocation started (UTC).
+    pub started_at: Option<DateTime<Utc>>,
+    /// When the invocation reached its terminal state (UTC).
+    pub finished_at: Option<DateTime<Utc>>,
+    /// Monotonic elapsed wall-clock for the invocation.
+    pub duration: Option<std::time::Duration>,
+}
+
+impl RunContext {
+    /// Open a context at "now", carrying the run/invocation identity. Call
+    /// [`finish`](Self::finish) when the invocation reaches a terminal state.
+    pub fn start(run_id: Option<String>, invocation_id: Option<String>) -> Self {
+        Self {
+            run_id,
+            invocation_id,
+            started_at: Some(Utc::now()),
+            finished_at: None,
+            duration: None,
+        }
+    }
+
+    /// Close the context, stamping `finished_at` and the monotonic duration
+    /// measured from `since`.
+    pub fn finish(mut self, since: Instant) -> Self {
+        self.finished_at = Some(Utc::now());
+        self.duration = Some(since.elapsed());
+        self
+    }
 }
 
 /// A single thing worth notifying about.
@@ -29,6 +84,10 @@ pub struct NotifyEvent {
     /// Structured context rendered into channel payloads (never contains
     /// secrets — the emit sites pass only safe scalars).
     pub details: Map<String, Value>,
+    /// Run identity + timing (#480). `None` for events with no owning
+    /// invocation (e.g. `scheduler_stuck`, which is emitted by the scheduler
+    /// loop itself rather than by a run).
+    pub run: Option<RunContext>,
 }
 
 impl NotifyEvent {
@@ -59,6 +118,24 @@ impl NotifyEvent {
             title: redact(title.into()),
             message: redact(message.into()),
             details: Map::new(),
+            run: None,
+        }
+    }
+
+    /// Stamp run identity + timing onto this event (#480). Emit sites build one
+    /// [`RunContext`] per invocation and apply it to every event they produce.
+    pub fn with_run(mut self, run: RunContext) -> Self {
+        self.run = Some(run);
+        self
+    }
+
+    /// Stamp run identity from an optional context — the shape emit sites
+    /// actually have, since the notifier is feature-gated and some callers have
+    /// no run to attribute.
+    pub fn with_run_opt(self, run: Option<RunContext>) -> Self {
+        match run {
+            Some(r) => self.with_run(r),
+            None => self,
         }
     }
 

--- a/cli/src/notify/mod.rs
+++ b/cli/src/notify/mod.rs
@@ -31,8 +31,8 @@ pub mod render;
 pub mod spec;
 
 pub use dispatch::Notifier;
-pub use event::NotifyEvent;
+pub use event::{NotifyEvent, RunContext};
 pub use spec::{
-    ChannelSpec, EventKind, NotificationSpec, PagerdutyConfig, Severity, SlackConfig,
-    WebhookConfig, validate_all,
+    ChannelSpec, EventKind, NotificationSpec, PagerdutyConfig, RESERVED_BODY_KEYS, Severity,
+    SlackConfig, WebhookConfig, validate_all,
 };

--- a/cli/src/notify/render.rs
+++ b/cli/src/notify/render.rs
@@ -99,8 +99,9 @@ pub fn pagerduty(
 }
 
 /// Render a generic webhook body — a stable, machine-readable envelope.
-pub fn webhook(_cfg: &WebhookConfig, event: &NotifyEvent) -> Value {
-    json!({
+pub fn webhook(cfg: &WebhookConfig, event: &NotifyEvent) -> Value {
+    let run = event.run.as_ref();
+    let mut body = json!({
         "event": event.kind.as_str(),
         "severity": event.severity.as_str(),
         "pipeline": event.pipeline,
@@ -108,7 +109,36 @@ pub fn webhook(_cfg: &WebhookConfig, event: &NotifyEvent) -> Value {
         "title": event.title,
         "message": event.message,
         "details": Value::Object(event.details.clone()),
-    })
+        // Emitted as explicit nulls rather than omitted, so receivers can rely
+        // on a stable key set regardless of whether the event had an owning
+        // invocation (#480).
+        "run_id": run.and_then(|r| r.run_id.clone()).map_or(Value::Null, Value::String),
+        "invocation_id": run
+            .and_then(|r| r.invocation_id.clone())
+            .map_or(Value::Null, Value::String),
+        "started_at": run
+            .and_then(|r| r.started_at)
+            .map_or(Value::Null, |t| Value::String(t.to_rfc3339())),
+        "finished_at": run
+            .and_then(|r| r.finished_at)
+            .map_or(Value::Null, |t| Value::String(t.to_rfc3339())),
+        "duration_secs": run
+            .and_then(|r| r.duration)
+            .and_then(|d| serde_json::Number::from_f64(d.as_secs_f64()))
+            .map_or(Value::Null, Value::Number),
+    });
+
+    // Operator-authored static metadata. Reserved-key collisions are rejected at
+    // config-load time (`NotificationSpec::validate`), so this cannot shadow a
+    // faucet-emitted field.
+    if !cfg.extra_fields.is_empty()
+        && let Some(map) = body.as_object_mut()
+    {
+        for (k, v) in &cfg.extra_fields {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+    body
 }
 
 /// Best-effort scalar stringification for Slack context lines.
@@ -201,11 +231,93 @@ mod tests {
             headers: Default::default(),
             hmac_secret: None,
             signature_header: "X-Faucet-Signature".into(),
+            extra_fields: Default::default(),
         };
         let e = NotifyEvent::dlq_threshold("p", "r", 42);
         let body = webhook(&cfg, &e);
         assert_eq!(body["event"], "dlq_threshold");
         assert_eq!(body["severity"], Severity::Warning.as_str());
         assert_eq!(body["details"]["records_dlq"], 42);
+    }
+
+    fn webhook_cfg() -> WebhookConfig {
+        WebhookConfig {
+            url: "u".into(),
+            method: "POST".into(),
+            headers: Default::default(),
+            hmac_secret: None,
+            signature_header: "X-Faucet-Signature".into(),
+            extra_fields: Default::default(),
+        }
+    }
+
+    #[test]
+    fn webhook_carries_run_identity_and_timing() {
+        // #480: the payload must let a receiver correlate the callback back to
+        // the run it triggered. `pipeline` + `row` alone cannot — two
+        // overlapping runs of one pipeline share both.
+        let run =
+            crate::notify::RunContext::start(Some("run-abc".into()), Some("invocation-1".into()))
+                .finish(std::time::Instant::now());
+        let e = NotifyEvent::run_success("p", "r", 7).with_run(run);
+        let body = webhook(&webhook_cfg(), &e);
+
+        assert_eq!(body["run_id"], "run-abc");
+        assert_eq!(body["invocation_id"], "invocation-1");
+        assert!(body["started_at"].is_string(), "started_at must be RFC3339");
+        assert!(body["finished_at"].is_string());
+        assert!(
+            body["duration_secs"].as_f64().unwrap() >= 0.0,
+            "monotonic duration is never negative"
+        );
+    }
+
+    #[test]
+    fn webhook_emits_explicit_nulls_when_no_run_context() {
+        // Stable key set regardless of whether the event had an owning
+        // invocation — receivers must not have to branch on key presence.
+        let e = NotifyEvent::scheduler_stuck("p", "no heartbeat");
+        let body = webhook(&webhook_cfg(), &e);
+        for k in [
+            "run_id",
+            "invocation_id",
+            "started_at",
+            "finished_at",
+            "duration_secs",
+        ] {
+            assert!(body.get(k).is_some(), "{k} key must be present");
+            assert!(body[k].is_null(), "{k} must be null, not omitted");
+        }
+    }
+
+    #[test]
+    fn webhook_merges_extra_fields() {
+        let mut cfg = webhook_cfg();
+        cfg.extra_fields
+            .insert("tenant".into(), Value::String("acme".into()));
+        cfg.extra_fields.insert("attempt".into(), Value::from(2));
+        let e = NotifyEvent::run_success("p", "r", 1);
+        let body = webhook(&cfg, &e);
+        assert_eq!(body["tenant"], "acme");
+        assert_eq!(body["attempt"], 2);
+        // Faucet-emitted fields still intact.
+        assert_eq!(body["event"], "run_success");
+    }
+
+    #[test]
+    fn two_runs_of_one_pipeline_are_distinguishable() {
+        // The regression this feature exists to prevent: identical pipeline+row,
+        // different runs.
+        let mk = |id: &str| {
+            NotifyEvent::run_success("p", "r", 1).with_run(
+                crate::notify::RunContext::start(Some(id.into()), Some(id.into()))
+                    .finish(std::time::Instant::now()),
+            )
+        };
+        let a = webhook(&webhook_cfg(), &mk("run-a"));
+        let b = webhook(&webhook_cfg(), &mk("run-b"));
+        assert_eq!(a["pipeline"], b["pipeline"]);
+        assert_eq!(a["row"], b["row"]);
+        assert_ne!(a["run_id"], b["run_id"]);
     }
 }

--- a/cli/src/notify/spec.rs
+++ b/cli/src/notify/spec.rs
@@ -199,7 +199,38 @@ pub struct WebhookConfig {
     /// Header carrying the HMAC signature (default `X-Faucet-Signature`).
     #[serde(default = "default_signature_header")]
     pub signature_header: String,
+
+    /// Static fields merged into the emitted JSON body (#480), so a callback can
+    /// be tagged with a tenant, environment, or external job id. Values go
+    /// through the normal interpolation pass, so `${env:...}` / `${vars.X}` /
+    /// `${secret:...}` all work.
+    ///
+    /// Keys that collide with a field faucet itself emits (`event`, `severity`,
+    /// `pipeline`, `row`, `title`, `message`, `details`, `run_id`,
+    /// `invocation_id`, `started_at`, `finished_at`, `duration_secs`) are
+    /// rejected at load time. A typo'd `event` key would otherwise let a config
+    /// silently spoof the success/failure signal a receiver keys off, so this
+    /// fails fast rather than dropping the key at render time.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub extra_fields: std::collections::BTreeMap<String, serde_json::Value>,
 }
+
+/// Top-level keys faucet emits in the webhook body. `extra_fields` may not
+/// shadow any of them (see [`WebhookConfig::extra_fields`]).
+pub const RESERVED_BODY_KEYS: &[&str] = &[
+    "event",
+    "severity",
+    "pipeline",
+    "row",
+    "title",
+    "message",
+    "details",
+    "run_id",
+    "invocation_id",
+    "started_at",
+    "finished_at",
+    "duration_secs",
+];
 
 fn default_webhook_method() -> String {
     "POST".to_string()
@@ -229,6 +260,22 @@ impl NotificationSpec {
             ChannelSpec::Pagerduty(c) if c.routing_key.trim().is_empty() => bad("routing_key"),
             ChannelSpec::Webhook(c) if c.url.trim().is_empty() => bad("url"),
             ChannelSpec::Webhook(c) if c.method.trim().is_empty() => bad("method"),
+            ChannelSpec::Webhook(c) => {
+                // Reject a reserved key rather than silently dropping it at
+                // render time: `extra_fields: { event: "ok" }` would otherwise
+                // look accepted while never reaching the receiver.
+                for key in c.extra_fields.keys() {
+                    if RESERVED_BODY_KEYS.contains(&key.as_str()) {
+                        return Err(CliError::Config(format!(
+                            "notifications rule `{}`: `extra_fields.{key}` collides with a field \
+                             faucet emits — reserved keys are: {}",
+                            self.name,
+                            RESERVED_BODY_KEYS.join(", ")
+                        )));
+                    }
+                }
+                Ok(())
+            }
             _ => Ok(()),
         }
     }
@@ -334,6 +381,64 @@ mod tests {
         }
         // Empty `on` means "all kinds".
         assert!(s.on.is_empty());
+    }
+
+    /// Build a webhook rule carrying `extra_fields`.
+    fn webhook_with_extra(name: &str, key: &str) -> NotificationSpec {
+        let mut extra = std::collections::BTreeMap::new();
+        extra.insert(key.to_string(), serde_json::Value::String("x".into()));
+        NotificationSpec {
+            name: name.into(),
+            on: vec![],
+            min_severity: Severity::default(),
+            dedupe_window_secs: None,
+            dlq_threshold: None,
+            channel: ChannelSpec::Webhook(WebhookConfig {
+                url: "http://x".into(),
+                method: "POST".into(),
+                headers: Default::default(),
+                hmac_secret: None,
+                signature_header: "X-Faucet-Signature".into(),
+                extra_fields: extra,
+            }),
+        }
+    }
+
+    #[test]
+    fn extra_fields_accepts_a_non_reserved_key() {
+        assert!(webhook_with_extra("w", "tenant").validate().is_ok());
+    }
+
+    #[test]
+    fn extra_fields_rejects_every_reserved_key() {
+        // #480: a reserved key must fail fast at load time rather than be
+        // silently dropped at render time — `extra_fields: { event: "ok" }`
+        // would otherwise look accepted while never reaching the receiver, and
+        // a receiver keying off `event` would be spoofed if it *did*.
+        for key in RESERVED_BODY_KEYS {
+            let err = webhook_with_extra("w", key)
+                .validate()
+                .expect_err("reserved key must be rejected");
+            let msg = err.to_string();
+            assert!(msg.contains(key), "error should name the key: {msg}");
+            assert!(
+                msg.contains("extra_fields"),
+                "error should name the field: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_fields_defaults_to_empty() {
+        let json = serde_json::json!({
+            "name": "w",
+            "channel": { "type": "webhook", "config": { "url": "http://x" } }
+        });
+        let s: NotificationSpec = serde_json::from_value(json).unwrap();
+        match &s.channel {
+            ChannelSpec::Webhook(c) => assert!(c.extra_fields.is_empty()),
+            _ => panic!("expected webhook"),
+        }
     }
 
     #[test]

--- a/cli/src/replication/orchestrator.rs
+++ b/cli/src/replication/orchestrator.rs
@@ -88,6 +88,7 @@ fn phase_failure(summary: &crate::executor::RunSummary, phase: &str) -> CliError
 fn make_opts(opts: &ReplicationOptions, cancel: Option<CancellationToken>) -> ExecuteOptions {
     ExecuteOptions {
         pipeline_name: opts.pipeline_name.clone(),
+        run_id: None,
         execution: opts.execution.clone(),
         dry_run: false,
         limit: None,

--- a/cli/src/serve/callback.rs
+++ b/cli/src/serve/callback.rs
@@ -1,0 +1,480 @@
+//! Per-run completion callbacks (#481).
+//!
+//! A caller that submits a run over HTTP usually owns a job record and wants to
+//! be told when the run finishes, at an endpoint that varies per job. The
+//! config-declared `notifications:` block cannot express that — it is static per
+//! pipeline — so the callback destination rides the *submission* instead
+//! (`POST /v1/runs`, `POST /v1/templates/{id}/runs`) and is stored on the run
+//! record.
+//!
+//! ## Delivery guarantee: at-most-once
+//!
+//! The callback fires from the in-process terminal transitions — [`fire`] is
+//! called by `runner::finalize`, by `runner::maybe_finalize_parent` (the sharded
+//! parent), and by the pending-cancel handler. It is **not** fired by the
+//! recovery sweeps that live inside the history backend (lease-expiry orphan
+//! recovery, reclaim-poison, the sharded-parent completion sweep), because those
+//! run inside the SQL layer and never see this dispatcher.
+//!
+//! So: if the instance owning a run dies and the run is later failed by lease
+//! recovery, **no callback is delivered**. A caller must therefore treat a
+//! missing callback as "unknown", not as "still running", and reconcile against
+//! `GET /v1/runs/{id}`, which is always authoritative. This is stated in the
+//! HTTP API reference too — it is the one thing that will hang an integration
+//! that assumes otherwise.
+//!
+//! ## Egress
+//!
+//! [`CallbackSpec::validate`] restricts the scheme to http/https and refuses
+//! link-local / cloud-metadata targets, which is the concrete SSRF risk called
+//! out in the serve cookbook. `--callback-allow-host` narrows it further to an
+//! explicit allowlist. Note the broader posture is unchanged: a caller who can
+//! submit a run can already point a `rest` source anywhere, so this guard closes
+//! the metadata hole rather than pretending to be a general egress control.
+
+use crate::serve::history::{RunRecord, RunStatus};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Per-attempt HTTP timeout for a callback POST.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Total attempts (1 initial + retries) before giving up.
+const MAX_ATTEMPTS: u32 = 3;
+/// Base backoff between attempts.
+const RETRY_BASE: Duration = Duration::from_millis(250);
+
+/// Top-level keys the callback body always carries. `extra_fields` may not
+/// shadow any of them — the same fail-fast rule the notify webhook uses, for the
+/// same reason: a typo'd `status` key would otherwise let a submission spoof the
+/// very signal the receiver keys off.
+pub const RESERVED_BODY_KEYS: &[&str] = &[
+    "event",
+    "run_id",
+    "status",
+    "name",
+    "labels",
+    "submitted_at",
+    "started_at",
+    "finished_at",
+    "elapsed_secs",
+    "records_written",
+    "error",
+    "attempt",
+];
+
+/// A caller-supplied completion callback, carried on the run record.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CallbackSpec {
+    /// Destination URL. `http`/`https` only.
+    pub url: String,
+    /// HTTP method — defaults to `POST`.
+    #[serde(default = "default_method")]
+    pub method: String,
+    /// Extra headers sent with the request.
+    ///
+    /// These are **credentials** in practice, so a clustered server refuses them
+    /// (see [`CallbackSpec::reject_secrets_in_cluster`]): a clustered submit
+    /// persists the run record — including this map — into the shared history
+    /// database for a peer to execute, which would store the value in clear
+    /// text.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+    /// Static fields merged into the callback body (e.g. the caller's own job
+    /// id). A key colliding with a faucet-emitted field is rejected at submit
+    /// time — see [`RESERVED_BODY_KEYS`].
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra_fields: BTreeMap<String, Value>,
+    /// Terminal statuses to fire on. Empty (the default) means **all** of them,
+    /// which is what a job-status callback wants — a caller that only subscribes
+    /// to success will hang on a cancelled run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub on: Vec<RunStatus>,
+}
+
+fn default_method() -> String {
+    "POST".to_string()
+}
+
+impl CallbackSpec {
+    /// Structural + egress validation, run at submit time so a bad callback is a
+    /// `422` on the submission rather than a silent no-op an hour later when the
+    /// run finishes.
+    pub fn validate(&self, allow_hosts: &[String]) -> Result<(), String> {
+        if self.url.trim().is_empty() {
+            return Err("callback.url must be non-empty".into());
+        }
+        if self.method.trim().is_empty() {
+            return Err("callback.method must be non-empty".into());
+        }
+        if reqwest::Method::from_bytes(self.method.as_bytes()).is_err() {
+            return Err(format!("callback.method `{}` is not valid", self.method));
+        }
+        for key in self.extra_fields.keys() {
+            if RESERVED_BODY_KEYS.contains(&key.as_str()) {
+                return Err(format!(
+                    "callback.extra_fields.{key} collides with a field faucet emits — \
+                     reserved keys are: {}",
+                    RESERVED_BODY_KEYS.join(", ")
+                ));
+            }
+        }
+        for st in &self.on {
+            if !st.is_terminal() {
+                return Err(format!(
+                    "callback.on contains non-terminal status `{}` — a callback \
+                     only fires on a terminal state (completed, failed, cancelled)",
+                    st.as_str()
+                ));
+            }
+        }
+
+        let url = reqwest::Url::parse(&self.url)
+            .map_err(|e| format!("callback.url is not a valid URL: {e}"))?;
+        match url.scheme() {
+            "http" | "https" => {}
+            other => {
+                return Err(format!(
+                    "callback.url scheme `{other}` is not allowed (http or https only)"
+                ));
+            }
+        }
+        let host = url
+            .host_str()
+            .ok_or_else(|| "callback.url has no host".to_string())?;
+
+        if !allow_hosts.is_empty() {
+            if !allow_hosts.iter().any(|h| h == host) {
+                return Err(format!(
+                    "callback.url host `{host}` is not in the server's callback allowlist \
+                     ({}) — set --callback-allow-host to permit it",
+                    allow_hosts.join(", ")
+                ));
+            }
+            // An explicitly allowlisted host is trusted, metadata range or not.
+            return Ok(());
+        }
+
+        if is_link_local(host) {
+            return Err(format!(
+                "callback.url host `{host}` is a link-local / cloud-metadata address, \
+                 which the server refuses to call. Add it to --callback-allow-host if \
+                 this is genuinely intended"
+            ));
+        }
+        Ok(())
+    }
+
+    /// A clustered submit persists the run record for a peer to execute, so
+    /// caller-supplied credentials would land in the shared history database in
+    /// clear text. Mirrors the guard the template registry already applies to
+    /// secret params.
+    pub fn reject_secrets_in_cluster(&self, clustered: bool) -> Result<(), String> {
+        if clustered && !self.headers.is_empty() {
+            return Err(
+                "this callback carries `headers`, and a clustered server persists the run \
+                 record so a peer can execute it — which would store those values in the \
+                 shared run-history database in clear text. Authenticate the callback \
+                 without a request header (e.g. a capability token embedded in a \
+                 single-use URL path), or submit to a non-clustered server"
+                    .into(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Whether this spec subscribes to `status`.
+    pub fn fires_on(&self, status: RunStatus) -> bool {
+        status.is_terminal() && (self.on.is_empty() || self.on.contains(&status))
+    }
+}
+
+/// Whether `host` is a link-local address (IPv4 `169.254.0.0/16`, IPv6
+/// `fe80::/10`) — the range cloud instance-metadata services live on.
+fn is_link_local(host: &str) -> bool {
+    // Strip an IPv6 literal's brackets if the caller passed them.
+    let bare = host.trim_start_matches('[').trim_end_matches(']');
+    match bare.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(v4)) => v4.is_link_local(),
+        Ok(std::net::IpAddr::V6(v6)) => {
+            // `Ipv6Addr::is_unicast_link_local` is unstable; check fe80::/10.
+            let seg = v6.segments()[0];
+            (seg & 0xffc0) == 0xfe80
+        }
+        // Not an IP literal. The well-known metadata hostnames resolve into the
+        // link-local range, so refuse them by name too rather than relying on
+        // resolution at request time.
+        Err(_) => matches!(
+            bare,
+            "metadata" | "metadata.google.internal" | "metadata.goog" | "instance-data"
+        ),
+    }
+}
+
+/// The body delivered to the callback URL.
+fn payload(rec: &RunRecord, spec: &CallbackSpec) -> Value {
+    let mut body = serde_json::json!({
+        "event": format!("run.{}", rec.status.as_str()),
+        "run_id": rec.run_id,
+        "status": rec.status.as_str(),
+        "name": rec.name.clone().map_or(Value::Null, Value::String),
+        "labels": rec.labels.iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect::<serde_json::Map<String, Value>>(),
+        "submitted_at": rec.submitted_at.to_rfc3339(),
+        "started_at": rec.started_at.map_or(Value::Null, |t| Value::String(t.to_rfc3339())),
+        "finished_at": rec.finished_at.map_or(Value::Null, |t| Value::String(t.to_rfc3339())),
+        "elapsed_secs": rec.elapsed_secs
+            .and_then(serde_json::Number::from_f64)
+            .map_or(Value::Null, Value::Number),
+        "records_written": rec.records_written,
+        // Redacted: an error string frequently embeds the material that produced
+        // it (a request URL with an API key in a query param), and a callback
+        // leaves the trust boundary entirely.
+        "error": rec.error.as_deref()
+            .map(|e| Value::String(crate::secrets::registry::redact(e).into_owned()))
+            .unwrap_or(Value::Null),
+        "attempt": rec.attempt,
+    });
+    if let Some(map) = body.as_object_mut() {
+        for (k, v) in &spec.extra_fields {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+    body
+}
+
+/// Deliver the completion callback for `rec`, if it has one that subscribes to
+/// its terminal status. Never propagates an error: a callback is best-effort and
+/// must not affect the recorded outcome of a run that already finished.
+pub async fn fire(rec: &RunRecord) {
+    let Some(spec) = rec.callback.as_ref() else {
+        return;
+    };
+    if !spec.fires_on(rec.status) {
+        return;
+    }
+    let body = payload(rec, spec);
+    match deliver(spec, &body).await {
+        Ok(()) => tracing::debug!(run_id = %rec.run_id, "callback delivered"),
+        Err(e) => tracing::warn!(
+            run_id = %rec.run_id,
+            // The URL can itself embed a token, so redact before logging.
+            url = %crate::secrets::registry::redact(&spec.url),
+            error = %e,
+            "callback delivery failed; the run outcome is unaffected \
+             (reconcile via GET /v1/runs/<id>)"
+        ),
+    }
+}
+
+/// One bounded, retried delivery attempt sequence.
+async fn deliver(spec: &CallbackSpec, body: &Value) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .timeout(ATTEMPT_TIMEOUT)
+        .build()
+        .map_err(|e| format!("building callback client: {e}"))?;
+    let method = reqwest::Method::from_bytes(spec.method.as_bytes())
+        .map_err(|_| format!("invalid method `{}`", spec.method))?;
+
+    let mut last = String::new();
+    for attempt in 1..=MAX_ATTEMPTS {
+        let mut req = client
+            .request(method.clone(), &spec.url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .json(body);
+        for (k, v) in &spec.headers {
+            req = req.header(k, v);
+        }
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => return Ok(()),
+            Ok(resp) => {
+                let status = resp.status();
+                last = format!("HTTP {status}");
+                // 4xx other than 408/429 will not succeed on retry.
+                if status.is_client_error()
+                    && status != reqwest::StatusCode::REQUEST_TIMEOUT
+                    && status != reqwest::StatusCode::TOO_MANY_REQUESTS
+                {
+                    return Err(last);
+                }
+            }
+            Err(e) => last = format!("request failed: {e}"),
+        }
+        if attempt < MAX_ATTEMPTS {
+            tokio::time::sleep(RETRY_BASE * 2u32.pow(attempt - 1)).await;
+        }
+    }
+    Err(last)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(url: &str) -> CallbackSpec {
+        CallbackSpec {
+            url: url.into(),
+            method: "POST".into(),
+            headers: BTreeMap::new(),
+            extra_fields: BTreeMap::new(),
+            on: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn accepts_a_plain_https_url() {
+        assert!(spec("https://caller.example/hook").validate(&[]).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_http_schemes() {
+        for u in ["file:///etc/passwd", "gopher://x/", "ftp://x/"] {
+            let err = spec(u).validate(&[]).expect_err("scheme must be refused");
+            assert!(err.contains("scheme"), "{err}");
+        }
+    }
+
+    #[test]
+    fn rejects_link_local_and_metadata_targets() {
+        // The concrete SSRF risk documented for serve: cloud instance metadata.
+        for u in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://metadata.google.internal/computeMetadata/v1/",
+            "http://[fe80::1]/",
+        ] {
+            let err = spec(u).validate(&[]).expect_err("must be refused");
+            assert!(err.contains("link-local"), "{err}");
+        }
+    }
+
+    #[test]
+    fn loopback_is_allowed_without_an_allowlist() {
+        // Deliberate: the guard closes the metadata hole, it is not a general
+        // egress control, and a local receiver is a legitimate deployment.
+        assert!(spec("http://127.0.0.1:8080/cb").validate(&[]).is_ok());
+    }
+
+    #[test]
+    fn allowlist_restricts_to_named_hosts() {
+        let allow = vec!["caller.example".to_string()];
+        assert!(spec("https://caller.example/hook").validate(&allow).is_ok());
+        let err = spec("https://elsewhere.example/hook")
+            .validate(&allow)
+            .expect_err("must be refused");
+        assert!(err.contains("allowlist"), "{err}");
+    }
+
+    #[test]
+    fn allowlist_overrides_the_link_local_refusal() {
+        let allow = vec!["169.254.169.254".to_string()];
+        assert!(
+            spec("http://169.254.169.254/x").validate(&allow).is_ok(),
+            "an explicitly allowlisted host is trusted"
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_extra_field_keys() {
+        for key in RESERVED_BODY_KEYS {
+            let mut s = spec("https://x.example/h");
+            s.extra_fields
+                .insert((*key).to_string(), Value::String("x".into()));
+            let err = s.validate(&[]).expect_err("reserved key must be refused");
+            assert!(err.contains(key), "{err}");
+        }
+    }
+
+    #[test]
+    fn rejects_a_non_terminal_on_filter() {
+        let mut s = spec("https://x.example/h");
+        s.on = vec![RunStatus::Running];
+        let err = s.validate(&[]).expect_err("must be refused");
+        assert!(err.contains("non-terminal"), "{err}");
+    }
+
+    #[test]
+    fn rejects_bad_method_and_empty_url() {
+        let mut s = spec("https://x.example/h");
+        s.method = "NOT A METHOD".into();
+        assert!(s.validate(&[]).is_err());
+        assert!(spec("   ").validate(&[]).is_err());
+    }
+
+    #[test]
+    fn cluster_guard_refuses_caller_supplied_headers() {
+        let mut s = spec("https://x.example/h");
+        s.headers
+            .insert("Authorization".into(), "Bearer t".to_string());
+        // Non-clustered: fine, nothing is persisted for a peer.
+        assert!(s.reject_secrets_in_cluster(false).is_ok());
+        let err = s
+            .reject_secrets_in_cluster(true)
+            .expect_err("clustered must refuse");
+        assert!(err.contains("shared run-history"), "{err}");
+        // Without headers a clustered submit is fine.
+        assert!(
+            spec("https://x.example/h")
+                .reject_secrets_in_cluster(true)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn fires_on_respects_the_filter_and_terminality() {
+        let mut s = spec("https://x.example/h");
+        // Empty filter = every terminal status.
+        assert!(s.fires_on(RunStatus::Completed));
+        assert!(s.fires_on(RunStatus::Failed));
+        assert!(s.fires_on(RunStatus::Cancelled));
+        assert!(!s.fires_on(RunStatus::Running));
+        assert!(!s.fires_on(RunStatus::Queued));
+
+        s.on = vec![RunStatus::Failed];
+        assert!(s.fires_on(RunStatus::Failed));
+        assert!(!s.fires_on(RunStatus::Completed));
+    }
+
+    #[test]
+    fn payload_carries_run_identity_and_merges_extra_fields() {
+        let mut rec = RunRecord::queued(
+            "run-7".into(),
+            Some("orders".into()),
+            BTreeMap::from([("env".to_string(), "prod".to_string())]),
+            None,
+            chrono::Utc::now(),
+        );
+        rec.status = RunStatus::Completed;
+        rec.records_written = 42;
+        rec.finished_at = Some(chrono::Utc::now());
+        rec.elapsed_secs = Some(1.5);
+
+        let mut s = spec("https://x.example/h");
+        s.extra_fields
+            .insert("job_id".into(), Value::String("abc".into()));
+
+        let body = payload(&rec, &s);
+        assert_eq!(body["event"], "run.completed");
+        assert_eq!(body["run_id"], "run-7");
+        assert_eq!(body["status"], "completed");
+        assert_eq!(body["name"], "orders");
+        assert_eq!(body["labels"]["env"], "prod");
+        assert_eq!(body["records_written"], 42);
+        assert_eq!(body["elapsed_secs"], 1.5);
+        assert!(body["error"].is_null());
+        assert_eq!(body["job_id"], "abc");
+    }
+
+    #[test]
+    fn payload_emits_null_for_absent_optional_fields() {
+        let rec = RunRecord::queued("r".into(), None, BTreeMap::new(), None, chrono::Utc::now());
+        let body = payload(&rec, &spec("https://x.example/h"));
+        for k in ["name", "started_at", "finished_at", "elapsed_secs", "error"] {
+            assert!(body.get(k).is_some(), "{k} key must exist");
+            assert!(body[k].is_null(), "{k} must be null");
+        }
+    }
+}

--- a/cli/src/serve/cluster.rs
+++ b/cli/src/serve/cluster.rs
@@ -232,6 +232,7 @@ mod tests {
             ui_enabled: true,
             cluster: ClusterConfig::disabled(),
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         };
         let h = ClusterHandle::from_config(&cfg);
         h.kick();

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -104,6 +104,9 @@ pub struct ServeConfig {
     /// Path to a `--triggers` file. `None` = no event-driven triggers. The file
     /// is loaded + validated at startup (gated on the `triggers` feature).
     pub triggers_path: Option<PathBuf>,
+    /// Allowlist of hosts a per-run completion callback may target (#481).
+    /// Empty = any host except link-local / cloud-metadata addresses.
+    pub callback_allow_hosts: Vec<String>,
 }
 
 fn default_max_concurrent() -> usize {
@@ -255,6 +258,7 @@ impl ServeConfig {
             ui_enabled: !args.no_ui,
             cluster,
             triggers_path: args.triggers,
+            callback_allow_hosts: args.callback_allow_host,
         })
     }
 }
@@ -288,6 +292,7 @@ mod tests {
             cluster_poll_secs: 2,
             cluster_max_attempts: 3,
             triggers: None,
+            callback_allow_host: Vec::new(),
             mcp: false,
             mcp_allow_mutations: false,
         }

--- a/cli/src/serve/handlers/backfill.rs
+++ b/cli/src/serve/handlers/backfill.rs
@@ -62,6 +62,13 @@ pub struct BackfillSubmitRequest {
     /// Per-unit run timeout.
     #[serde(default)]
     pub timeout_secs: Option<u64>,
+    /// Accepted only so it can be **rejected** with an explanation (#481). One
+    /// `POST /v1/backfill` submits one tracked run per window unit, so a single
+    /// caller-supplied callback has no single run to attach to — firing it N
+    /// times is almost never what the caller means, and silently dropping it
+    /// would leave them waiting forever.
+    #[serde(default)]
+    pub callback: Option<crate::serve::callback::CallbackSpec>,
 }
 
 /// One planned unit's submission outcome.
@@ -95,6 +102,21 @@ pub async fn submit_backfill(
     Extension(actor): Extension<AuthContext>,
     Json(req): Json<BackfillSubmitRequest>,
 ) -> Result<(StatusCode, Json<BackfillSubmitResponse>), ServeError> {
+    // A backfill fans out into one run per window unit, so a single completion
+    // callback is ambiguous. Refuse it explicitly rather than dropping it: a
+    // caller who set it would otherwise wait on a callback that never arrives.
+    if req.callback.is_some() {
+        return Err(ServeError::Unprocessable {
+            message: "`callback` is not supported on /v1/backfill: this submits one run \
+                      per window unit, so there is no single run for a completion callback \
+                      to describe. Poll `GET /v1/runs?labels=backfill:<hash>` for unit \
+                      status, or submit the units individually via `POST /v1/runs` with a \
+                      callback on each"
+                .to_string(),
+            details: None,
+        });
+    }
+
     // Validate the config loads/expands and gate the window scoping exactly
     // like the CLI: every root's source must reference a `${backfill.*}` /
     // `${now.*}` token or each unit would replay identical data.
@@ -195,6 +217,7 @@ pub async fn submit_backfill(
             labels,
             timeout_secs: req.timeout_secs,
             doctor_first: false,
+            callback: None,
             idempotency_key: Some(format!("backfill:{hash}:{}", unit.id)),
             clock: Some(unit.start.to_rfc3339()),
         };

--- a/cli/src/serve/handlers/health.rs
+++ b/cli/src/serve/handlers/health.rs
@@ -96,6 +96,7 @@ mod tests {
             ui_enabled: true,
             cluster,
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
         ServerState::new(

--- a/cli/src/serve/handlers/runs.rs
+++ b/cli/src/serve/handlers/runs.rs
@@ -103,6 +103,17 @@ pub async fn cancel_run(
         {
             crate::serve::audit::write(&state, &actor, "run.cancel", Some(id.clone()), None, "ok")
                 .await;
+            // Terminal transition that bypasses `runner::finalize` entirely, so
+            // it must fire the completion callback itself (#481).
+            match state.history().get(&id).await {
+                Ok(Some(rec)) => crate::serve::callback::fire(&rec).await,
+                Ok(None) => {}
+                Err(e) => tracing::warn!(
+                    run_id = %id,
+                    error = %e,
+                    "could not read cancelled run for its completion callback"
+                ),
+            }
             return Ok(StatusCode::ACCEPTED);
         }
         // Otherwise it is running on a peer → flag it; the peer cancels on its

--- a/cli/src/serve/handlers/templates.rs
+++ b/cli/src/serve/handlers/templates.rs
@@ -468,6 +468,11 @@ pub struct TriggerBody {
     pub idempotency_key: Option<String>,
     #[serde(default)]
     pub clock: Option<String>,
+    /// Optional completion callback for this run (#481). The primary use case
+    /// for a per-run callback: one registered template, many callers, each
+    /// reporting to its own endpoint.
+    #[serde(default)]
+    pub callback: Option<crate::serve::callback::CallbackSpec>,
 }
 
 /// `POST /v1/templates/{id}/runs` success body (202): the ordinary submit
@@ -579,6 +584,7 @@ pub async fn trigger_template(
         doctor_first: body.doctor_first,
         idempotency_key: body.idempotency_key,
         clock: body.clock,
+        callback: body.callback,
     };
     let run = runner::submit(state.clone(), req, actor.clone()).await?;
     // `submit` already recorded `run.submit`; this second entry attributes the

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Lifecycle state of a submitted run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RunStatus {
     Queued,
@@ -117,6 +117,14 @@ pub struct RunRecord {
     /// is backward-compatible with records written before the field existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replay_of: Option<String>,
+    /// Caller-supplied completion callback (#481). Carried on the record rather
+    /// than on the in-flight request because every terminal transition that
+    /// fires it — `finalize`, the sharded-parent finalize, the pending-cancel
+    /// path — only ever has the record, never the original `SubmitRequest`.
+    /// Lives in the SQL `body` column, so a defaulted `Option` is
+    /// backward-compatible with records written before the field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub callback: Option<crate::serve::callback::CallbackSpec>,
 }
 
 impl RunRecord {
@@ -148,6 +156,7 @@ impl RunRecord {
             clock: None,
             attempt: 0,
             replay_of: None,
+            callback: None,
         }
     }
 }

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod audit;
 pub mod auth;
+pub mod callback;
 pub mod cluster;
 pub mod config;
 pub mod error;

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -426,6 +426,9 @@ async fn execute_shard(
     // so the shard's pipeline flushes at its next page boundary.
     let opts = ExecuteOptions {
         pipeline_name,
+        // Correlate notifications to the submitted run (#480). Every shard of a
+        // sharded run reports the same `run_id`; they differ by `invocation_id`.
+        run_id: Some(run_id.to_string()),
         execution: cfg.execution.clone(),
         dry_run: false,
         limit: None,
@@ -1200,6 +1203,9 @@ async fn execute_run(
     });
     let opts = ExecuteOptions {
         pipeline_name,
+        // The id returned by `POST /v1/runs`, so a completion notification can be
+        // matched back to the submission (#480).
+        run_id: Some(run_id.clone()),
         execution: cfg.execution.clone(),
         dry_run: false,
         limit: None,

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -45,6 +45,11 @@ pub struct SubmitRequest {
     pub doctor_first: bool,
     pub idempotency_key: Option<String>,
     pub clock: Option<String>,
+    /// Optional completion callback fired when this run reaches a terminal
+    /// state (#481). Validated at submit time so a bad destination is a 422 on
+    /// the submission rather than a silent no-op when the run finishes.
+    #[serde(default)]
+    pub callback: Option<crate::serve::callback::CallbackSpec>,
 }
 
 /// Wire enum mirroring `load::ConfigFormat` with serde rename.
@@ -542,6 +547,23 @@ async fn maybe_finalize_parent(state: &ServerState, run_id: &str) {
                 failed = progress.failed,
                 "sharded run finalized"
             );
+            // Fire the parent's completion callback exactly once — `Ok(true)` is
+            // the status-fenced winner, so a near-simultaneous double-finalize
+            // from two instances delivers a single callback (#481). Re-read the
+            // record: `finalize_sharded_parent` takes fields, not the record, so
+            // this is the only way to get the persisted terminal state.
+            match state.history().get(run_id).await {
+                Ok(Some(rec)) => crate::serve::callback::fire(&rec).await,
+                Ok(None) => tracing::warn!(
+                    run_id,
+                    "sharded parent vanished before its callback could fire"
+                ),
+                Err(e) => tracing::warn!(
+                    run_id,
+                    error = %e,
+                    "could not read sharded parent for its completion callback"
+                ),
+            }
         }
         Ok(false) => {} // already finalized by another shard/instance — nothing to do
         Err(e) => {
@@ -635,6 +657,22 @@ pub async fn submit(
     let sharded = loaded.cfg.shard.as_ref().is_some_and(|s| s.count >= 2);
     warn_if_cluster_at_least_once(&loaded, state.cluster().enabled(), sharded);
 
+    // Completion-callback validation (#481) — before the queue reservation, so a
+    // malformed or refused destination costs nothing and surfaces as a 422 on
+    // the submission rather than as a silent no-op when the run finishes.
+    if let Some(cb) = req.callback.as_ref() {
+        cb.validate(state.callback_allow_hosts())
+            .map_err(|message| ServeError::Unprocessable {
+                message,
+                details: None,
+            })?;
+        cb.reject_secrets_in_cluster(state.cluster().enabled())
+            .map_err(|message| ServeError::Unprocessable {
+                message,
+                details: None,
+            })?;
+    }
+
     // Reserve a queue slot first, so a Fresh idempotency claim is always followed
     // by a spawned run (no orphaned claims — spec §20.2).
     if !state.registry().try_reserve() {
@@ -711,6 +749,7 @@ pub async fn submit(
         submitted_at,
     );
     rec.doctor_report = doctor_report;
+    rec.callback = req.callback.clone();
 
     if state.cluster().enabled() {
         // A degraded (DB-unreachable) backend can't coordinate a cluster: the
@@ -1345,7 +1384,12 @@ async fn finalize(state: &ServerState, run_id: &str, started: DateTime<Utc>, ter
         // our write is a no-op and we discard our result — the reclaimer is now
         // authoritative (#197).
         match state.history().finalize_owned(&rec).await {
-            Ok(true) => metrics::record_run_finished(status, reason),
+            Ok(true) => {
+                metrics::record_run_finished(status, reason);
+                // Only the instance that won the owner-fenced write fires the
+                // callback, so a reclaimed run cannot deliver twice (#481).
+                crate::serve::callback::fire(&rec).await;
+            }
             Ok(false) => tracing::warn!(
                 run_id,
                 "finalize: run was reclaimed by another instance; discarding result"
@@ -1363,6 +1407,7 @@ async fn finalize(state: &ServerState, run_id: &str, started: DateTime<Utc>, ter
             );
         }
         metrics::record_run_finished(status, reason);
+        crate::serve::callback::fire(&rec).await;
     }
 }
 
@@ -1489,6 +1534,7 @@ mod tests {
             ui_enabled: true,
             cluster: crate::serve::cluster::ClusterConfig::disabled(),
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
         let state = ServerState::new(
@@ -1516,6 +1562,7 @@ mod tests {
             labels: BTreeMap::new(),
             timeout_secs: None,
             doctor_first: false,
+            callback: None,
             idempotency_key: Some("k".into()),
             clock: None,
         };
@@ -1561,6 +1608,7 @@ mod tests {
             ui_enabled: true,
             cluster,
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
         let state = ServerState::new(
@@ -1581,6 +1629,7 @@ mod tests {
             labels: BTreeMap::new(),
             timeout_secs: Some(99),
             doctor_first: false,
+            callback: None,
             idempotency_key: None,
             clock: None,
         };
@@ -1623,6 +1672,7 @@ mod tests {
             ui_enabled: true,
             cluster: crate::serve::cluster::ClusterConfig::disabled(),
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
         ServerState::new(
@@ -1737,6 +1787,7 @@ mod tests {
             ui_enabled: true,
             cluster,
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         };
         // A backend that is degraded from startup (primary unreachable).
         let history = Arc::new(FallbackHistory::degraded_at_startup(
@@ -1761,6 +1812,7 @@ mod tests {
             labels: BTreeMap::new(),
             timeout_secs: None,
             doctor_first: false,
+            callback: None,
             idempotency_key: None,
             clock: None,
         };
@@ -1823,6 +1875,7 @@ mod tests {
                 ui_enabled: true,
                 cluster: crate::serve::cluster::ClusterConfig::disabled(),
                 triggers_path: None,
+                callback_allow_hosts: Vec::new(),
             };
             ServerState::new(
                 &cfg,

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -35,6 +35,8 @@ struct Inner {
     default_config_path: Option<PathBuf>,
     idempotency_retention: Duration,
     probe_timeout: Duration,
+    /// Allowlist of hosts a per-run completion callback may target (#481).
+    callback_allow_hosts: Vec<String>,
     cluster: crate::serve::cluster::ClusterHandle,
     #[cfg(feature = "triggers")]
     triggers: crate::serve::triggers::health::TriggersHandle,
@@ -64,6 +66,7 @@ impl ServerState {
                 default_config_path: config.default_config_path.clone(),
                 idempotency_retention: config.idempotency_retention,
                 probe_timeout: config.probe_timeout,
+                callback_allow_hosts: config.callback_allow_hosts.clone(),
                 cluster: crate::serve::cluster::ClusterHandle::from_config(config),
                 #[cfg(feature = "triggers")]
                 triggers,
@@ -133,6 +136,12 @@ impl ServerState {
         self.inner.probe_timeout
     }
 
+    /// Hosts a per-run completion callback may target. Empty = any host except
+    /// link-local / cloud-metadata addresses (#481).
+    pub fn callback_allow_hosts(&self) -> &[String] {
+        &self.inner.callback_allow_hosts
+    }
+
     pub fn cluster(&self) -> &crate::serve::cluster::ClusterHandle {
         &self.inner.cluster
     }
@@ -170,6 +179,7 @@ mod tests {
             ui_enabled: true,
             cluster: crate::serve::cluster::ClusterConfig::disabled(),
             triggers_path: None,
+            callback_allow_hosts: Vec::new(),
         }
     }
 

--- a/cli/src/serve/test_support.rs
+++ b/cli/src/serve/test_support.rs
@@ -35,6 +35,7 @@ pub fn test_config() -> ServeConfig {
         ui_enabled: true,
         cluster: ClusterConfig::disabled(),
         triggers_path: None,
+        callback_allow_hosts: Vec::new(),
     }
 }
 

--- a/cli/src/serve/triggers/enqueue.rs
+++ b/cli/src/serve/triggers/enqueue.rs
@@ -73,6 +73,12 @@ pub fn build_submit_request(
         doctor_first: false,
         idempotency_key: Some(context::idempotency_key(name, event)),
         clock: None,
+        // Triggers carry no per-run callback (#481). A trigger is declared in the
+        // triggers file, so its destination is static — which is exactly what the
+        // config's `notifications:` block already expresses. A per-run callback
+        // exists for the opposite case: an external caller submitting a run and
+        // naming its own endpoint.
+        callback: None,
     }
 }
 

--- a/cli/tests/history_e2e.rs
+++ b/cli/tests/history_e2e.rs
@@ -48,6 +48,7 @@ fn record(id: &str, row_id: &str) -> RunRecord {
         clock: None,
         attempt: 0,
         replay_of: None,
+        callback: None,
     }
 }
 

--- a/cli/tests/notifications.rs
+++ b/cli/tests/notifications.rs
@@ -76,6 +76,7 @@ async fn webhook_delivery_signs_body() {
             headers: Default::default(),
             hmac_secret: Some("s3cr3t".into()),
             signature_header: "X-Faucet-Signature".into(),
+            extra_fields: Default::default(),
         }),
     );
     let n = Notifier::from_specs(&[spec]).unwrap().unwrap();
@@ -248,4 +249,107 @@ async fn severity_floor_filters_delivery() {
     assert!(server.received_requests().await.unwrap().is_empty());
     n.emit(NotifyEvent::circuit_open("p", "", 3, 30)).await;
     assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}
+
+/// #480 acceptance: the run identity threaded through `ExecuteOptions.run_id`
+/// reaches the delivered webhook body, and a matrix row's own `invocation_id`
+/// is distinct from it. Drives a real csv → jsonl pipeline through the executor
+/// rather than emitting a synthetic event, so the whole propagation path
+/// (options → `run_one_invocation` → `RunContext` → render → HTTP) is covered.
+#[tokio::test]
+async fn executor_propagates_submitted_run_id_into_the_payload() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/cb"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "id,name\n1,alice\n2,bob\n").unwrap();
+
+    let cfg_yaml = format!(
+        r#"
+version: 1
+name: cb_pipeline
+pipeline:
+  source:
+    type: csv
+    config:
+      path: "{}"
+  sink:
+    type: jsonl
+    config:
+      path: "{}"
+notifications:
+  - name: cb
+    on: [run_success]
+    channel:
+      type: webhook
+      config:
+        url: "{}/cb"
+        extra_fields:
+          tenant: acme
+"#,
+        input.display(),
+        output.display(),
+        server.uri()
+    );
+
+    let cfg_path = dir.path().join("p.yaml");
+    std::fs::write(&cfg_path, &cfg_yaml).unwrap();
+    let cfg =
+        faucet_cli::config::PipelineConfig::from_text(&cfg_yaml, &cfg_path).expect("config parses");
+    let nodes = faucet_cli::expand::expand(&cfg).expect("expand");
+    let notifier = faucet_cli::notify::Notifier::from_specs(&cfg.notifications)
+        .unwrap()
+        .expect("notifier built");
+
+    let opts = faucet_cli::executor::ExecuteOptions {
+        pipeline_name: "cb_pipeline".into(),
+        run_id: Some("submitted-run-42".into()),
+        execution: None,
+        dry_run: false,
+        limit: None,
+        state_path_override: None,
+        shard: None,
+        auth: Default::default(),
+        clock: chrono::Utc::now().fixed_offset(),
+        cancel: None,
+        resilience: None,
+        sla: None,
+        #[cfg(feature = "lineage")]
+        lineage: None,
+        #[cfg(feature = "lineage")]
+        lineage_cfg: None,
+        notifier: Some(notifier),
+        #[cfg(feature = "catalog")]
+        catalog: None,
+    };
+
+    let summary = faucet_cli::executor::run_expanded(nodes, opts)
+        .await
+        .expect("run");
+    assert!(!summary.had_failures(), "pipeline should succeed");
+
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1, "exactly one run_success callback");
+    let body: Value = serde_json::from_slice(&reqs[0].body).unwrap();
+
+    assert_eq!(body["event"], "run_success");
+    // The submitted run id — what a caller correlates against.
+    assert_eq!(body["run_id"], "submitted-run-42");
+    // The per-invocation id is generated, so it must differ from the submitted id.
+    assert!(body["invocation_id"].is_string());
+    assert_ne!(body["invocation_id"], body["run_id"]);
+    // Timing is populated for a real run.
+    assert!(body["started_at"].is_string());
+    assert!(body["finished_at"].is_string());
+    assert!(body["duration_secs"].as_f64().unwrap() >= 0.0);
+    // Static metadata merged.
+    assert_eq!(body["tenant"], "acme");
+    assert_eq!(body["details"]["records_written"], 2);
 }

--- a/cli/tests/serve_backfill.rs
+++ b/cli/tests/serve_backfill.rs
@@ -31,6 +31,7 @@ fn test_config(listen: &str) -> ServeConfig {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     };

--- a/cli/tests/serve_callback.rs
+++ b/cli/tests/serve_callback.rs
@@ -1,0 +1,340 @@
+//! Integration tests for per-run completion callbacks (#481).
+//!
+//! Boots a real `faucet serve`, submits runs over HTTP with a `callback`, and
+//! asserts the callback lands at a wiremock receiver with the right body — plus
+//! the refusals (bad egress target, backfill fan-out, reserved keys).
+#![cfg(feature = "serve")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use serde_json::{Value, json};
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn args_on(port: u16) -> ServeArgs {
+    ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        auth_config: None,
+        no_auth: true,
+        max_concurrent_runs: Some(4),
+        max_queued_runs: Some(16),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        lease_ttl_secs: 30,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+        no_ui: false,
+        cluster: false,
+        cluster_poll_secs: 2,
+        cluster_max_attempts: 3,
+        triggers: None,
+        callback_allow_host: Vec::new(),
+        mcp: false,
+        mcp_allow_mutations: false,
+    }
+}
+
+async fn spawn_server(port: u16) {
+    let mut config = ServeConfig::from_args(args_on(port)).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config, Default::default()).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..200 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not become healthy on port {port}");
+}
+
+/// A pipeline that succeeds.
+fn ok_yaml(input: &std::path::Path, output: &std::path::Path) -> String {
+    format!(
+        "version: 1\nname: cb\npipeline:\n  source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        input.display(),
+        output.display()
+    )
+}
+
+/// A pipeline that fails: the csv source points at a path that does not exist.
+fn failing_yaml(output: &std::path::Path) -> String {
+    format!(
+        "version: 1\nname: cb_fail\npipeline:\n  source: {{ type: csv, config: {{ path: \"/nonexistent/definitely-not-here.csv\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        output.display()
+    )
+}
+
+/// Poll the receiver until it has at least one request, or time out.
+async fn wait_for_callback(server: &MockServer) -> Value {
+    for _ in 0..200 {
+        let reqs = server.received_requests().await.unwrap();
+        if let Some(r) = reqs.first() {
+            return serde_json::from_slice(&r.body).unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("no callback received within the timeout");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn callback_fires_on_success_with_run_identity() {
+    let receiver = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/cb"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&receiver)
+        .await;
+
+    let port = free_port();
+    spawn_server(port).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "id,name\n1,alice\n2,bob\n").unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/runs"))
+        .json(&json!({
+            "config": ok_yaml(&input, &output),
+            "callback": {
+                "url": format!("{}/cb", receiver.uri()),
+                "extra_fields": { "job_id": "caller-job-1" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202, "submission accepted");
+    let submitted: Value = resp.json().await.unwrap();
+    let run_id = submitted["run_id"].as_str().unwrap().to_string();
+
+    let body = wait_for_callback(&receiver).await;
+    // The whole point: the callback correlates to the id the submission returned.
+    assert_eq!(body["run_id"], run_id);
+    assert_eq!(body["event"], "run.completed");
+    assert_eq!(body["status"], "completed");
+    assert_eq!(body["records_written"], 2);
+    assert!(body["error"].is_null());
+    assert!(body["finished_at"].is_string());
+    assert!(body["elapsed_secs"].as_f64().unwrap() >= 0.0);
+    // Caller-supplied metadata round-trips.
+    assert_eq!(body["job_id"], "caller-job-1");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn callback_fires_on_failure() {
+    let receiver = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/cb"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&receiver)
+        .await;
+
+    let port = free_port();
+    spawn_server(port).await;
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("out.jsonl");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/runs"))
+        .json(&json!({
+            "config": failing_yaml(&output),
+            "callback": { "url": format!("{}/cb", receiver.uri()) }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202);
+
+    let body = wait_for_callback(&receiver).await;
+    assert_eq!(body["event"], "run.failed");
+    assert_eq!(body["status"], "failed");
+    assert!(
+        body["error"].is_string(),
+        "a failed run must report its error: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn on_filter_suppresses_unsubscribed_terminal_states() {
+    // Subscribing only to `failed` must not deliver on a successful run.
+    let receiver = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/cb"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&receiver)
+        .await;
+
+    let port = free_port();
+    spawn_server(port).await;
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "id\n1\n").unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/runs"))
+        .json(&json!({
+            "config": ok_yaml(&input, &output),
+            "callback": { "url": format!("{}/cb", receiver.uri()), "on": ["failed"] }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202);
+    let run_id = resp.json::<Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Wait for the run itself to reach a terminal state, then assert silence.
+    for _ in 0..200 {
+        let rec: Value = client
+            .get(format!("http://127.0.0.1:{port}/v1/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        if rec["status"] == "completed" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        receiver.received_requests().await.unwrap().is_empty(),
+        "a callback subscribed only to `failed` must not fire on success"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refuses_link_local_callback_target_at_submit_time() {
+    let port = free_port();
+    spawn_server(port).await;
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "id\n1\n").unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/runs"))
+        .json(&json!({
+            "config": ok_yaml(&input, &output),
+            // The concrete SSRF risk documented for serve: cloud instance metadata.
+            "callback": { "url": "http://169.254.169.254/latest/meta-data/" }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        422,
+        "a link-local callback target must be refused at submit time"
+    );
+    let err: Value = resp.json().await.unwrap();
+    assert!(
+        err.to_string().contains("link-local"),
+        "error should explain why: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refuses_non_http_scheme_and_reserved_extra_field() {
+    let port = free_port();
+    spawn_server(port).await;
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "id\n1\n").unwrap();
+    let cfg = ok_yaml(&input, &output);
+    let client = reqwest::Client::new();
+
+    for (cb, needle) in [
+        (json!({ "url": "file:///etc/passwd" }), "scheme"),
+        (
+            json!({ "url": "https://x.example/h", "extra_fields": { "status": "ok" } }),
+            "status",
+        ),
+    ] {
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/v1/runs"))
+            .json(&json!({ "config": cfg, "callback": cb }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 422, "must be refused: {cb}");
+        let err: Value = resp.json().await.unwrap();
+        assert!(
+            err.to_string().contains(needle),
+            "error should mention `{needle}`: {err}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn backfill_refuses_a_callback_rather_than_dropping_it() {
+    let port = free_port();
+    spawn_server(port).await;
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("out.jsonl");
+
+    // Window-scoped source so the backfill gate itself passes.
+    let cfg = format!(
+        "version: 1\nname: bf\npipeline:\n  source: {{ type: csv, config: {{ path: \"./data-${{backfill.start}}.csv\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        output.display()
+    );
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/backfill"))
+        .json(&json!({
+            "config": cfg,
+            "from": "2026-01-01",
+            "to": "2026-01-04",
+            "window": "1d",
+            "callback": { "url": "https://caller.example/hook" }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        422,
+        "one POST /v1/backfill fans out into N runs, so a single callback is ambiguous"
+    );
+    let err: Value = resp.json().await.unwrap();
+    let text = err.to_string();
+    assert!(
+        text.contains("callback") && text.contains("window unit"),
+        "error should explain the fan-out: {err}"
+    );
+}

--- a/cli/tests/serve_catalog.rs
+++ b/cli/tests/serve_catalog.rs
@@ -49,6 +49,7 @@ fn serve_args(port: u16, auth_config: std::path::PathBuf) -> faucet_cli::cli::Se
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/serve_dlq.rs
+++ b/cli/tests/serve_dlq.rs
@@ -48,6 +48,7 @@ fn serve_args(port: u16, auth_config: std::path::PathBuf) -> faucet_cli::cli::Se
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/serve_history_sqlite.rs
+++ b/cli/tests/serve_history_sqlite.rs
@@ -324,6 +324,7 @@ async fn server_with_sqlite_history_persists_runs() {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     };

--- a/cli/tests/serve_lifecycle.rs
+++ b/cli/tests/serve_lifecycle.rs
@@ -42,6 +42,7 @@ fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/serve_logs.rs
+++ b/cli/tests/serve_logs.rs
@@ -39,6 +39,7 @@ fn args_on(port: u16) -> ServeArgs {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/serve_metrics.rs
+++ b/cli/tests/serve_metrics.rs
@@ -36,6 +36,7 @@ fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -178,6 +178,7 @@ async fn every_documented_route_is_wired_on_the_live_server() {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     };

--- a/cli/tests/serve_rbac.rs
+++ b/cli/tests/serve_rbac.rs
@@ -49,6 +49,7 @@ fn args_with_auth_config(port: u16, auth_config: std::path::PathBuf) -> ServeArg
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/serve_skeleton.rs
+++ b/cli/tests/serve_skeleton.rs
@@ -30,6 +30,7 @@ fn test_config(listen: &str) -> ServeConfig {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     };

--- a/cli/tests/serve_triggers.rs
+++ b/cli/tests/serve_triggers.rs
@@ -35,6 +35,7 @@ fn test_config() -> ServeConfig {
         ui_enabled: false,
         cluster: faucet_cli::serve::cluster::ClusterConfig::disabled(),
         triggers_path: None,
+        callback_allow_hosts: Vec::new(),
     }
 }
 
@@ -406,6 +407,7 @@ async fn spawn_serve_with_triggers(
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: Some(triggers_path.to_path_buf()),
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     };

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -37,6 +37,7 @@ fn args(port: u16) -> ServeArgs {
         cluster_poll_secs: 2,
         cluster_max_attempts: 3,
         triggers: None,
+        callback_allow_host: Vec::new(),
         mcp: false,
         mcp_allow_mutations: false,
     }

--- a/cli/tests/sla_monitoring.rs
+++ b/cli/tests/sla_monitoring.rs
@@ -205,6 +205,7 @@ async fn dry_run_skips_sla_evaluation() {
         nodes,
         ExecuteOptions {
             pipeline_name: "slatest".into(),
+            run_id: None,
             execution: None,
             dry_run: true,
             limit: None,

--- a/docs/book/src/cookbook/notifications.md
+++ b/docs/book/src/cookbook/notifications.md
@@ -121,7 +121,56 @@ channel:
     headers: { X-Env: prod }                  # optional extra headers
     hmac_secret: "${env:FAUCET_WEBHOOK_SECRET}"
     signature_header: "X-Faucet-Signature"    # default
+    extra_fields:                             # optional static body fields
+      tenant: "${vars.tenant}"
+      environment: prod
 ```
+
+#### Payload
+
+```json
+{
+  "event": "run_success",
+  "severity": "info",
+  "pipeline": "contacts-sync",
+  "row": "associations",
+  "run_id": "0199f3c1-8a2e-7c40-9f1b-2d7e5a6c3b04",
+  "invocation_id": "0199f3c1-8a31-7d02-b8aa-91c4e0f7d215",
+  "started_at": "2026-08-13T09:14:02.117Z",
+  "finished_at": "2026-08-13T09:16:41.402Z",
+  "duration_secs": 159.285,
+  "title": "Pipeline `contacts-sync` succeeded",
+  "message": "Run completed, 14203 records written.",
+  "details": { "records_written": 14203 }
+}
+```
+
+| Field | Notes |
+|---|---|
+| `event` | One of the event kinds listed above. |
+| `severity` | `info` / `warning` / `error` / `critical`. |
+| `pipeline`, `row` | Config identity. **Not unique per run** — see `run_id`. |
+| `run_id` | Correlates to the submitted run. Under `faucet serve` this is exactly the id returned by `POST /v1/runs`, so a completion callback can be matched to the submission. |
+| `invocation_id` | This matrix row's own id. One submitted run emits one notification per row, all sharing `run_id` and differing here. |
+| `started_at`, `finished_at` | RFC 3339 UTC. |
+| `duration_secs` | Monotonic elapsed seconds — never negative, even across a clock step. |
+| `details` | Per-event structured context (e.g. `records_written`, `error_kind`, `records_dlq`). |
+
+Every key is always present; identity and timing fields are `null` for events
+with no owning invocation (e.g. `scheduler_stuck`, emitted by the scheduler loop
+itself). Receivers can therefore rely on a stable key set.
+
+`extra_fields` merges static values into the top level of that body — useful for
+tagging a callback with a tenant or an external job id. Values go through the
+normal interpolation pass. A key that collides with any field above is
+**rejected by `faucet validate`** rather than silently dropped, so a typo can
+never spoof the `event` a receiver keys off.
+
+> Using this as a job-status callback? `run_id` is the correlation key. Two
+> overlapping runs of one pipeline — a `schedule` with `overlap: queue`, a
+> cluster with several workers, or a backfill fanning out per window — produce
+> notifications identical in `pipeline` and `row`, so keying off those will
+> mis-attribute status.
 
 ## Secrets
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -800,6 +800,7 @@ Selected flags (`faucet serve --help` for the full list):
 | `--body-limit-bytes` / `--shutdown-grace-secs` / `--retain-terminal-runs-secs` / `--idempotency-retention-secs` | Tuning knobs. |
 | `--no-ui` | Disable the embedded web console at runtime even when the binary was built with `serve-ui`. |
 | `--triggers <path>` | Path to a YAML triggers file that defines event-driven watchers (object-arrival / webhook / queue-depth). Requires the `triggers` Cargo feature. See [Triggers reference](./triggers.md). |
+| `--callback-allow-host <host>` | Restrict per-run completion callbacks to these hosts. Repeatable. Unset = any host except link-local / cloud-metadata addresses, which are always refused unless named here. See [Completion callbacks](./http-api.md#completion-callbacks). |
 
 ### Optional embedded web console (`serve-ui`)
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -778,6 +778,14 @@ should come from `${env:...}` / `${secret:...}` so they are log-redacted. See
 the [Notifications cookbook](../cookbook/notifications.md) for channel details,
 metrics, and `faucet notify test`. Schema: `faucet schema notifications`.
 
+The `webhook` channel additionally takes `headers`, `hmac_secret` /
+`signature_header`, and `extra_fields` (static values merged into the emitted
+body; a key colliding with a faucet-emitted field is rejected at load time). Its
+payload carries `run_id` / `invocation_id` / `started_at` / `finished_at` /
+`duration_secs` alongside the event, so it can drive an external job-status
+callback — under `faucet serve`, `run_id` is the id returned by `POST /v1/runs`.
+See the [payload table](../cookbook/notifications.md#payload).
+
 ## `replication`
 
 Present only when you run [`faucet replicate`](cli.md#replicate). It turns the

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -98,7 +98,11 @@ Request body:
   "timeout_secs": 3600,
   "doctor_first": true,
   "idempotency_key": "airflow-task-123-attempt-2",
-  "clock": "2026-05-29T00:00:00Z"
+  "clock": "2026-05-29T00:00:00Z",
+  "callback": {
+    "url": "https://caller.example/jobs/abc/complete",
+    "extra_fields": { "job_id": "abc" }
+  }
 }
 ```
 
@@ -113,6 +117,7 @@ Request body:
   submit returns `422` with the doctor report in `error.details`.
 - **`idempotency_key`** — replay protection (see cookbook).
 - **`clock`** — overrides the `${now.*}` clock for backfills (default: submit time).
+- **`callback`** — a per-run completion callback; see below.
 
 Response (`202`):
 
@@ -308,6 +313,79 @@ already-submitted units replay their existing run, the rest submit (a full
 queue marks the remainder `not_submitted`; re-POST to continue). A config
 carrying `shard: {count}` makes each unit a sharded run tracked via shard
 progress. Requires `RunWrite` (operator); audited as `backfill.submit`.
+
+## Completion callbacks
+
+Instead of polling, a submission can name an endpoint to be POSTed when the run
+reaches a terminal state. The destination rides the *submission*, not the config,
+so one registered pipeline (or template) can serve many callers each reporting to
+their own endpoint.
+
+```json
+"callback": {
+  "url": "https://caller.example/jobs/abc/complete",
+  "method": "POST",
+  "headers": { "X-Caller": "orchestrator" },
+  "extra_fields": { "job_id": "abc" },
+  "on": ["completed", "failed", "cancelled"]
+}
+```
+
+Accepted on `POST /v1/runs` and `POST /v1/templates/{id}/runs`. The body:
+
+```json
+{
+  "event": "run.completed",
+  "run_id": "0192…",
+  "status": "completed",
+  "name": "nightly-rollup",
+  "labels": { "requester": "airflow" },
+  "submitted_at": "2026-05-29T12:00:00Z",
+  "started_at": "2026-05-29T12:00:01Z",
+  "finished_at": "2026-05-29T12:04:11Z",
+  "elapsed_secs": 250.4,
+  "records_written": 14203,
+  "error": null,
+  "attempt": 0,
+  "job_id": "abc"
+}
+```
+
+`run_id` is the id returned by the submission. `error` is redacted. `extra_fields`
+are merged at the top level; a key colliding with any field above is refused with
+`422` at submit time rather than silently dropped.
+
+`on` defaults to **every** terminal status. Narrowing it is a footgun: a callback
+subscribed only to `completed` never fires for a failed or cancelled run, and a
+caller waiting on it will hang.
+
+> **Delivery is at-most-once, and best-effort.** The callback fires from the
+> in-process terminal transitions. It is **not** fired when a run is failed by
+> lease-expiry orphan recovery, by cluster reclaim-poison, or by the
+> sharded-parent completion sweep — those happen inside the history backend.
+> So treat a missing callback as **unknown**, never as "still running", and
+> reconcile against `GET /v1/runs/{id}`, which is always authoritative. A
+> non-2xx response is retried a few times with backoff, then dropped with a
+> warning; the run's recorded outcome is never affected.
+
+Refusals (all `422` at submit time, so a bad destination never becomes a silent
+no-op an hour later):
+
+| Condition | Why |
+|---|---|
+| Scheme is not `http`/`https` | |
+| Host is link-local / cloud-metadata (`169.254.0.0/16`, `fe80::/10`, `metadata.google.internal`, …) | Closes the instance-metadata SSRF hole. Override by naming the host in `--callback-allow-host`. |
+| `--callback-allow-host` is set and the host is not in it | Explicit allowlist mode. |
+| `headers` supplied on a **clustered** server | A clustered submit persists the run record — including these values — into the shared run-history database for a peer to execute, which would store them in clear text. Authenticate without a request header (e.g. a capability token in a single-use URL path), or submit to a non-clustered server. |
+| `extra_fields` key collides with a faucet-emitted field | Would let a submission spoof the `status`/`event` a receiver keys off. |
+| `on` contains a non-terminal status | |
+| Supplied on `POST /v1/backfill` | One backfill POST fans out into N unit runs, so a single callback has no single run to describe. Poll the unit runs by their `backfill` label instead. |
+
+**Egress posture.** This guard closes the metadata hole; it is not a general
+egress control. A caller who can submit a run can already point a `rest` source
+at an arbitrary address, so the deployment-level mitigations in the
+[serve cookbook](../cookbook/serve.md) still apply. Use `--callback-allow-host`
+(repeatable) when you want callbacks restricted to known receivers.
 
 ## Error envelope
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -931,6 +931,46 @@ components:
         doctor_first: { type: boolean, default: false, description: "Run doctor probes first; 422 with report on failure." }
         idempotency_key: { type: string, nullable: true }
         clock: { type: string, format: date-time, description: "Override the ${now.*} clock (backfills)." }
+        callback: { $ref: "#/components/schemas/CallbackSpec" }
+    CallbackSpec:
+      type: object
+      required: [url]
+      description: >-
+        Completion callback for this run (#481). Fired once when the run reaches a
+        terminal state. Delivery is **at-most-once** and best-effort: it is not
+        fired when a run is failed by lease-expiry recovery inside the history
+        backend, so treat a missing callback as "unknown" and reconcile against
+        GET /v1/runs/{id}, which is always authoritative. Refused with 422 on
+        /v1/backfill (one POST fans out into N unit runs).
+      properties:
+        url:
+          type: string
+          description: >-
+            Destination. http/https only. Link-local / cloud-metadata addresses
+            are refused unless named in the server's --callback-allow-host
+            allowlist; when that allowlist is non-empty, only its hosts are
+            permitted.
+        method: { type: string, default: POST }
+        headers:
+          type: object
+          additionalProperties: { type: string }
+          description: >-
+            Extra request headers. Refused with 422 on a clustered server, which
+            persists the run record (including this map) into the shared
+            run-history database for a peer to execute.
+        extra_fields:
+          type: object
+          additionalProperties: true
+          description: >-
+            Static fields merged into the callback body. A key colliding with a
+            faucet-emitted field is refused with 422.
+        on:
+          type: array
+          items: { $ref: "#/components/schemas/RunStatus" }
+          description: >-
+            Terminal statuses to fire on. Empty (default) = all of them. A
+            callback subscribed only to `completed` will never fire for a
+            cancelled or failed run.
     SubmitResponse:
       type: object
       required: [run_id, status, submitted_at]
@@ -964,6 +1004,7 @@ components:
         error: { type: string, nullable: true }
         idempotency_key: { type: string, nullable: true }
         doctor_report: { type: object, nullable: true }
+        callback: { $ref: "#/components/schemas/CallbackSpec" }
     ListResponse:
       type: object
       required: [runs]

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -2989,6 +2989,11 @@
           "description": "Header carrying the HMAC signature (default `X-Faucet-Signature`).",
           "type": "string",
           "default": "X-Faucet-Signature"
+        },
+        "extra_fields": {
+          "description": "Static fields merged into the emitted JSON body (#480), so a callback can\nbe tagged with a tenant, environment, or external job id. Values go\nthrough the normal interpolation pass, so `${env:...}` / `${vars.X}` /\n`${secret:...}` all work.\n\nKeys that collide with a field faucet itself emits (`event`, `severity`,\n`pipeline`, `row`, `title`, `message`, `details`, `run_id`,\n`invocation_id`, `started_at`, `finished_at`, `duration_secs`) are\nrejected at load time. A typo'd `event` key would otherwise let a config\nsilently spoof the success/failure signal a receiver keys off, so this\nfails fast rather than dropping the key at render time.",
+          "type": "object",
+          "additionalProperties": true
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Makes faucet usable as a job runner behind someone else's orchestrator: a caller
can now be *told* when a run finishes, correlated to the run it submitted.

Two commits, in dependency order — a per-run callback is close to useless without
run identity in the payload, which is what the first commit adds.

## `feat(notify)`: run identity + timing + `extra_fields` (#480)

The generic `webhook` channel delivered a fixed body with **no run identity and
no timing**. The only correlation keys were `pipeline` and `row`, and those are
not unique per run — a `schedule` with `overlap: queue`, a cluster with several
workers, or a backfill fanning out per window all produce indistinguishable
callbacks, so a receiver keying off `pipeline` mis-attributes status.

The payload now carries `run_id` (correlates to the submission; under `faucet
serve` it is exactly the id returned by `POST /v1/runs`), `invocation_id` (the
matrix row's own, so rows of one run stay distinct), and
`started_at` / `finished_at` / `duration_secs`.

- **`duration_secs` is monotonic**, measured from an `Instant` rather than by
  subtracting the two wall-clock stamps, so an NTP step cannot make it negative.
- **All five keys are always present**, explicitly `null` for events with no
  owning invocation (`scheduler_stuck`), so receivers need not branch on key
  presence.
- The observability span `run_id` stays unique per invocation — notifications
  carry both ids instead of overloading one. Changing the span identity would
  have silently altered existing traces.
- `WebhookConfig.extra_fields` merges static values into the body (tenant,
  environment, external job id). A key colliding with a faucet-emitted field is
  **rejected by `faucet validate`**, not dropped at render time: dropping makes a
  typo'd `event` key look accepted, and honouring it would let a config spoof the
  success/failure signal a receiver keys off.

## `feat(serve)`: per-run completion callback (#481)

`POST /v1/runs` and `POST /v1/templates/{id}/runs` accept a `callback` object.
The template trigger is the primary case: one registered template, many callers,
each reporting to its own endpoint.

It is stored on `RunRecord` rather than the in-flight request, because every
terminal transition that fires it — `finalize`, the sharded-parent finalize, the
pending-cancel path — only ever has the record, never the original
`SubmitRequest`. Cluster and shard paths therefore work unchanged.

**Delivery is at-most-once, and documented as such.** It cannot double-deliver:
the cluster branch fires only on the owner-fenced `Ok(true)`, the sharded parent
only on the status-fenced `Ok(true)`. It is *not* fired by the recovery sweeps
inside the history backend (lease-expiry orphan recovery, reclaim-poison, the
sharded-parent completion sweep), so the reference states plainly that a missing
callback means **unknown**, never "still running", and that `GET /v1/runs/{id}`
stays authoritative. A caller assuming otherwise would hang — that is the one
thing worth reading in the docs change.

### Refusals — all `422` at submit time

A bad destination fails on the submission, never as a silent no-op an hour later:

| Condition | Rationale |
|---|---|
| Non-`http(s)` scheme | |
| Link-local / cloud-metadata host | Closes the concrete instance-metadata SSRF hole the serve cookbook documents. Override per-host with `--callback-allow-host`. |
| Host outside `--callback-allow-host` when set | Explicit allowlist mode. |
| `headers` on a **clustered** server | A clustered submit persists the run record into the shared run-history DB for a peer to execute, which would store those credentials in clear text. Mirrors the template registry's secret-param guard (#456 C5). |
| `extra_fields` key collides with an emitted field | Would let a submission spoof the status a receiver keys off. |
| Non-terminal status in `on` | |
| Any `callback` on `POST /v1/backfill` | One backfill fans out into N unit runs, so a single callback has no single run to describe. Refused with an explanation rather than dropped. |

`on` defaults to **every** terminal status, deliberately: subscribing only to
`completed` means a failed or cancelled run never notifies.

The egress guard is scoped honestly — it closes the metadata hole, it is not a
general egress control, since a caller who can submit a run can already point a
`rest` source anywhere. The deployment-level mitigations in the serve cookbook
still apply.

## Notes

- **`serve` now pulls `dep:reqwest` itself** instead of relying on another
  feature to link it. The feature-isolation CI matrix builds `serve` alone, where
  this was a hard compile error.
- Restored a `#[cfg(feature = "catalog")]` attribute that a scripted edit had
  removed while adding a field across ~25 construction sites; every deletion in
  the diff was audited to confirm it was the only one.
- `schema_config::committed_schema_covers_current_build` fails locally under any
  feature set narrower than `--all-features` (its array check is exact
  per-element equality, so it reports e.g. `bulk_load` on the BigQuery sink as
  drift). Pre-existing and unrelated; the committed schema splice here was
  verified byte-identical apart from the 5 added lines.
- The two clippy lints that appear under narrow feature sets
  (`topology.rs` unused bindings, `commands/template.rs` unused `BODY`) are
  pre-existing in files this PR does not touch; CI's clippy runs
  `--all-features`, where that code compiles and the bindings are used.

## Tests

- 44 notify unit tests + 8 notify integration tests, including one that drives a
  real csv→jsonl pipeline through the executor and asserts the submitted run id
  reaches the delivered HTTP body.
- 13 callback unit tests (egress refusals, allowlist override, cluster guard,
  reserved keys, `on` filtering, payload shape).
- 6 new `serve_callback` integration tests against a real server + wiremock
  receiver: success, failure, `on`-filter suppression, link-local refusal,
  scheme/reserved-key refusal, backfill refusal.
- Full `serve,templates,catalog` suite green; `fmt` clean.

Closes #480
Closes #481
