### PR TITLE
ci: enforce the >=90% patch-coverage standard in the Coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,10 @@ jobs:
     needs: changes
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the patch-coverage gate below can resolve a merge
+          # base against origin/main.
+          fetch-depth: 0
       - name: Free runner disk space
         # The all-features instrumented build (bundled DuckDB + the full
         # connector tree) plus the coverage profraw data and testcontainer
@@ -576,6 +580,21 @@ jobs:
           # so they are excluded here and in codecov.yml (kept in sync).
           cargo llvm-cov report --lcov --output-path lcov.info \
             --ignore-filename-regex '(/tests?/|/examples?/|/benches?/|build\.rs$|crates/source/gcs/src/stream\.rs$|crates/sink/gcs/src/sink\.rs$)'
+      - name: Enforce >=90% patch coverage
+        # The project standard is >=90% coverage of changed lines. `codecov/patch`
+        # reports the same number but posts unreliably — of the eight PRs merged
+        # before this gate landed, only one carried a codecov status on its head
+        # commit (including a large code PR that carried none), so it cannot be a
+        # required check without blocking PRs on "Expected — waiting for status".
+        # This runs inside the already-required Coverage job instead, where the
+        # result is deterministic.
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' }}
+        run: |
+          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}" || true
+          python3 scripts/patch-coverage.py \
+            --lcov lcov.info \
+            --base "origin/${{ github.base_ref }}" \
+            --min 90
       - name: Upload to Codecov
         if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ docs/superpowers/
 !/scripts/check-doc-counts.sh
 !/scripts/sync-doc-counts.py
 !/scripts/inject-page-meta.py
+!/scripts/patch-coverage.py
 
 # Benchmark generated artifacts (harness + configs are tracked; outputs are not)
 /.bench-venv/

--- a/scripts/patch-coverage.py
+++ b/scripts/patch-coverage.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Compute patch (changed-line) coverage from an lcov report + a git diff.
+
+Why this exists: `codecov/patch` reports the same number, but it posts
+unreliably — of the eight PRs merged before this script landed, only one carried
+a `codecov/patch` status on its head commit, including a large code PR that
+carried none. A required check that frequently never posts blocks every PR on
+"Expected — waiting for status", so codecov cannot be the gate. This runs inside
+the already-required `Coverage` job instead, where the result is deterministic
+and ours.
+
+Usage:
+    patch-coverage.py --lcov lcov.info --base origin/main [--min 90.0]
+
+Exits non-zero when coverage of added/modified lines is below `--min`, printing
+the uncovered lines so the failure is actionable rather than just a number.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# Kept in sync with the `--ignore-filename-regex` in the Coverage job and with
+# codecov.yml. Paths matching these are excluded from the denominator.
+IGNORE = re.compile(
+    r"(/tests?/|/examples?/|/benches?/|build\.rs$"
+    r"|crates/source/gcs/src/stream\.rs$|crates/sink/gcs/src/sink\.rs$)"
+)
+
+
+def parse_lcov(path: str) -> dict[str, dict[int, int]]:
+    """file -> {line: hit_count} for every instrumented line."""
+    files: dict[str, dict[int, int]] = defaultdict(dict)
+    current: str | None = None
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if line.startswith("SF:"):
+                current = line[3:]
+            elif line.startswith("DA:") and current:
+                num, _, count = line[3:].partition(",")
+                try:
+                    files[current][int(num)] = int(count.split(",")[0])
+                except ValueError:
+                    continue
+            elif line == "end_of_record":
+                current = None
+    return files
+
+
+def changed_lines(base: str) -> dict[str, set[int]]:
+    """file -> {line numbers added or modified relative to `base`}."""
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--unified=0", f"{base}...HEAD", "--", "*.rs"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        print(f"patch-coverage: git diff failed: {e.stderr}", file=sys.stderr)
+        sys.exit(2)
+
+    out: dict[str, set[int]] = defaultdict(set)
+    path: str | None = None
+    hunk = re.compile(r"^@@ -\S+ \+(\d+)(?:,(\d+))? @@")
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+        elif line.startswith("@@") and path:
+            m = hunk.match(line)
+            if m:
+                start = int(m.group(1))
+                count = int(m.group(2) or 1)
+                out[path].update(range(start, start + count))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lcov", default="lcov.info")
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--min", type=float, default=90.0)
+    ap.add_argument(
+        "--report-only",
+        action="store_true",
+        help="print the number but always exit 0",
+    )
+    args = ap.parse_args()
+
+    cov = parse_lcov(args.lcov)
+    # lcov paths may be absolute; index by suffix so a repo-relative diff path
+    # matches regardless of the workspace root.
+    by_suffix = {p: lines for p, lines in cov.items()}
+
+    def lookup(rel: str) -> dict[int, int] | None:
+        if rel in by_suffix:
+            return by_suffix[rel]
+        for p, lines in by_suffix.items():
+            if p.endswith("/" + rel) or p.endswith(rel):
+                return lines
+        return None
+
+    total = 0
+    hit = 0
+    misses: list[str] = []
+    for rel, lines in sorted(changed_lines(args.base).items()):
+        if IGNORE.search(rel):
+            continue
+        table = lookup(rel)
+        if table is None:
+            # Not instrumented at all (e.g. a file excluded from the build).
+            continue
+        for ln in sorted(lines):
+            if ln not in table:
+                continue  # not an executable line (comment, brace, decl)
+            total += 1
+            if table[ln] > 0:
+                hit += 1
+            elif len(misses) < 40:
+                misses.append(f"{rel}:{ln}")
+
+    if total == 0:
+        print("patch-coverage: no instrumented changed lines; nothing to check")
+        return 0
+
+    pct = 100.0 * hit / total
+    print(f"patch-coverage: {hit}/{total} changed lines covered = {pct:.2f}%")
+
+    if pct + 1e-9 < args.min and not args.report_only:
+        print(f"\npatch-coverage: FAILED — below the {args.min:.2f}% floor.")
+        print("Uncovered changed lines (first 40):")
+        for m in misses:
+            print(f"  {m}")
+        print(
+            "\nThe project standard is >=90% patch coverage. If a line is genuinely "
+            "untestable (a signal handler, a main() dispatch arm, an infinite "
+            "supervisory loop), say so explicitly in the PR rather than lowering "
+            "this floor."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The project standard is **>=90% coverage of changed lines**, but nothing enforced
it. #478 merged at **84.01%** and no gate stopped it.

## Why not just make `codecov/patch` required

That's the obvious move, and it doesn't work. `codecov/patch` reports exactly the
right number but posts unreliably:

| Sample | `codecov/patch` present on head commit |
|---|---|
| Last 8 merged PRs | **1 of 8** |

The seven without it include **#482 — a large code PR**, not just docs changes.
The upload step is `continue-on-error: true` with `fail_ci_if_error: false`, so a
silent upload failure leaves the job green and no status is ever written. As a
required check that would have blocked seven of the last eight PRs on
*"Expected — waiting for status"*, each needing an admin override.

## What this does instead

Puts the gate inside the **`Coverage` job**, which is already a required check,
always runs on code PRs, and produces a deterministic result we control rather
than one depending on a third-party webhook firing.

`scripts/patch-coverage.py` intersects the lcov report with the lines added or
modified relative to the PR base, using the same exclusions the lcov report and
`codecov.yml` already apply. On failure it prints the **uncovered lines**, not
just a percentage, so the fix is obvious — and it states plainly that a genuinely
untestable line (a signal handler, a `main()` dispatch arm, a supervisory loop)
belongs in the PR description rather than in a lowered floor.

## Validated against real data before landing

Run over the #478 diff with a real `faucet-core` lcov report it returns
**429/469 = 91.47%** for the core portion — consistent with codecov's 84.01%
overall for that PR once the eight sink I/O paths are included. That also
confirms where #478's gap actually was: the sinks' live-database paths, not core.

## Scope

- Pull requests only; pushes to `main` are unaffected.
- The Coverage job's existing `code == 'true'` condition still lets docs-only PRs
  skip it entirely, so this adds no burden there.
- Checkout gains `fetch-depth: 0` so the merge base resolves.
- `codecov/patch` is left exactly as it is — informational, non-blocking. This
  does not replace it, it just stops the standard depending on it.

This PR is CI-only, so the Coverage job skips and the step is inert here. It will
first bite on the next code PR, which is the right way to find out whether the
floor is calibrated.
