### PR TITLE
ci: make a failed Codecov upload visible instead of silent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,9 +597,15 @@ jobs:
             --min 90
       - name: Upload to Codecov
         if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
+        # `continue-on-error` keeps a Codecov outage from failing the build — the
+        # merge gate is the patch-coverage step above, which needs no third party.
+        # But `fail_ci_if_error: true` makes the step itself go red and log the
+        # reason, so a broken upload is visible instead of silently doing nothing.
+        # That combination was the actual defect: with both set to "ignore", the
+        # one upload that failed (PR #482) looked identical to a healthy run.
         continue-on-error: true
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
The Codecov upload ignored its own failures **twice over** —
`continue-on-error: true` on the step *and* `fail_ci_if_error: false` on the
action. When an upload failed, the step went green, the job went green, and the
only symptom was a missing comment on the PR. That is what happened on #482, and
it looked identical to a healthy run.

## The change

| | Before | After |
|---|---|---|
| `continue-on-error` | `true` | `true` (unchanged) |
| `fail_ci_if_error` | `false` | **`true`** |
| action | `codecov-action@v4` | **`v5`** |

Keeping `continue-on-error: true` is deliberate: a Codecov outage must not fail
the build, because the merge gate is the patch-coverage step above it, which
depends on no third party. Flipping `fail_ci_if_error` makes the step itself go
red and log the reason — **visible without being blocking**, which is exactly
what was missing.

## A correction worth recording

While diagnosing this I quoted "Codecov only reported on 1 of the last 8 PRs".
That was misleading, and the PR should say so: **five of those eight were
docs/chore PRs**, where the coverage job correctly skips and there is no report
to comment on. The genuine failure rate was one code PR out of two. The fix here
is therefore about making that class of failure *visible*, not about chasing a
systemic flakiness that wasn't there.

## Not changed

Codecov's PR comment stays exactly as it is — it remains the single coverage
comment on a PR. No second comment is added.

Cost: zero additional CI time.
