### PR TITLE
test(sinks): integration coverage for the scoped-cleanup delete paths

### DIFF
--- a/crates/sink/mongodb/tests/cleanup.rs
+++ b/crates/sink/mongodb/tests/cleanup.rs
@@ -1,0 +1,196 @@
+//! Integration tests for the MongoDB sink's scoped-cleanup path (#478).
+//!
+//! The filter construction is unit-tested in the crate; what only a real server
+//! shows is whether that filter actually selects the right documents. The
+//! important one is the `$and` wrapping: a scope field can also be a key field,
+//! and as sibling keys the duplicate entry would drop the scope predicate and
+//! widen the delete from one parent's documents to **the whole collection**.
+//!
+//! Requires Docker. Each test boots its own container. Note the cleanup path
+//! uses a single `delete_many` with no session, so unlike the exactly-once tests
+//! these need no replica set.
+
+use faucet_core::{CleanupPolicy, Sink, WriteMode, WriteSpec};
+use faucet_sink_mongodb::{MongoSink, MongoSinkConfig};
+use mongodb::Client;
+use mongodb::bson::{Document, doc};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mongo::Mongo;
+
+async fn start_mongo() -> (ContainerAsync<Mongo>, String) {
+    let container: ContainerAsync<Mongo> = Mongo::default()
+        .start()
+        .await
+        .expect("mongo container start");
+    let port = container
+        .get_host_port_ipv4(27017)
+        .await
+        .expect("mongo port");
+    (container, format!("mongodb://127.0.0.1:{port}"))
+}
+
+fn config(uri: &str, key: Vec<String>) -> MongoSinkConfig {
+    let mut config = MongoSinkConfig::new(uri, "testdb", "assoc");
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key,
+        delete_marker: None,
+    };
+    config
+}
+
+/// Contact 7 owns three documents, contact 8 owns two. Contact 8 must never be
+/// touched — that is what makes the delete scoped rather than a collection wipe.
+async fn seed(uri: &str) {
+    let client = Client::with_uri_str(uri).await.expect("client");
+    let coll = client.database("testdb").collection::<Document>("assoc");
+    for (id, contact) in [(1, 7), (2, 7), (3, 7), (10, 8), (11, 8)] {
+        coll.insert_one(doc! { "_id": id, "contact_id": contact, "label": "seed" })
+            .await
+            .expect("seed");
+    }
+}
+
+async fn remaining(uri: &str) -> Vec<i64> {
+    use futures::TryStreamExt;
+    let client = Client::with_uri_str(uri).await.expect("client");
+    let coll = client.database("testdb").collection::<Document>("assoc");
+    let docs: Vec<Document> = coll
+        .find(doc! {})
+        .await
+        .expect("find")
+        .try_collect()
+        .await
+        .expect("collect");
+    // Read `_id` type-agnostically: seeded docs are Int32, but a doc written
+    // through the sink round-trips from JSON as Int64. A helper that only read
+    // one of the two would silently drop exactly the rows under test.
+    let mut ids: Vec<i64> = docs
+        .iter()
+        .map(|d| match d.get("_id") {
+            Some(mongodb::bson::Bson::Int32(v)) => i64::from(*v),
+            Some(mongodb::bson::Bson::Int64(v)) => *v,
+            other => panic!("unexpected _id type: {other:?}"),
+        })
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+async fn write_then_cleanup(
+    sink: &MongoSink,
+    page: &[Value],
+    scope: BTreeMap<String, Value>,
+    key: Vec<String>,
+) -> u64 {
+    let p = CleanupPolicy::new(scope, key, 1000).expect("policy");
+    if !page.is_empty() {
+        sink.write_batch(page).await.expect("write");
+    }
+    let mut seen = faucet_core::SeenKeys::new();
+    seen.record_page(page, &p.key, p.max_keys);
+    sink.cleanup_scope(&p.scope, &seen).await.expect("cleanup")
+}
+
+fn scope7() -> BTreeMap<String, Value> {
+    BTreeMap::from([("contact_id".to_string(), json!(7))])
+}
+
+#[tokio::test]
+async fn deletes_only_unwritten_documents_inside_the_scope() {
+    let (_c, uri) = start_mongo().await;
+    seed(&uri).await;
+    let sink = MongoSink::new(config(&uri, vec!["_id".into()]))
+        .await
+        .expect("sink");
+
+    let deleted = write_then_cleanup(
+        &sink,
+        &[json!({"_id": 3, "contact_id": 7, "label": "kept"})],
+        scope7(),
+        vec!["_id".into()],
+    )
+    .await;
+
+    assert_eq!(deleted, 2, "the two stale documents");
+    assert_eq!(
+        remaining(&uri).await,
+        vec![3, 10, 11],
+        "the written doc survives and contact 8 is untouched"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_page_clears_the_scope_and_only_the_scope() {
+    // The motivating case: contact 7's documents were all removed upstream, so
+    // the fetch returns nothing.
+    let (_c, uri) = start_mongo().await;
+    seed(&uri).await;
+    let sink = MongoSink::new(config(&uri, vec!["_id".into()]))
+        .await
+        .expect("sink");
+
+    let deleted = write_then_cleanup(&sink, &[], scope7(), vec!["_id".into()]).await;
+
+    assert_eq!(deleted, 3);
+    assert_eq!(
+        remaining(&uri).await,
+        vec![10, 11],
+        "contact 8 must survive an empty page for contact 7"
+    );
+}
+
+#[tokio::test]
+async fn a_scope_field_that_is_also_a_key_field_does_not_widen_the_delete() {
+    // THE regression. With sibling filter fields rather than `$and`, the
+    // duplicate `contact_id` entry would overwrite the scope predicate and the
+    // delete would take out the entire collection, contact 8 included.
+    let (_c, uri) = start_mongo().await;
+    seed(&uri).await;
+    let key = vec!["contact_id".to_string(), "_id".to_string()];
+    let sink = MongoSink::new(config(&uri, key.clone()))
+        .await
+        .expect("sink");
+
+    let deleted = write_then_cleanup(
+        &sink,
+        &[json!({"_id": 3, "contact_id": 7, "label": "kept"})],
+        scope7(),
+        key,
+    )
+    .await;
+
+    assert_eq!(deleted, 2, "only contact 7's stale documents");
+    assert_eq!(
+        remaining(&uri).await,
+        vec![3, 10, 11],
+        "contact 8's documents must still be present — a widened delete would have \
+         removed them"
+    );
+}
+
+#[tokio::test]
+async fn a_scope_with_no_stale_documents_deletes_nothing() {
+    let (_c, uri) = start_mongo().await;
+    seed(&uri).await;
+    let sink = MongoSink::new(config(&uri, vec!["_id".into()]))
+        .await
+        .expect("sink");
+
+    let deleted = write_then_cleanup(
+        &sink,
+        &[
+            json!({"_id": 1, "contact_id": 7, "label": "a"}),
+            json!({"_id": 2, "contact_id": 7, "label": "b"}),
+            json!({"_id": 3, "contact_id": 7, "label": "c"}),
+        ],
+        scope7(),
+        vec!["_id".into()],
+    )
+    .await;
+
+    assert_eq!(deleted, 0);
+    assert_eq!(remaining(&uri).await.len(), 5);
+}

--- a/crates/sink/postgres/tests/cleanup.rs
+++ b/crates/sink/postgres/tests/cleanup.rs
@@ -1,0 +1,262 @@
+//! Integration tests for [`PostgresSink`]'s scoped-cleanup path (#478) against a
+//! real Postgres instance via testcontainers.
+//!
+//! The SQL generation is unit-tested in the crate, but the parts that only a real
+//! server exercises are the ones most likely to be wrong: whether the temp table
+//! is actually created and dropped, whether the `NOT EXISTS` join matches across
+//! real column types, whether the transaction is genuinely all-or-nothing, and
+//! whether the scope predicate really confines the delete. Those are what these
+//! cover.
+//!
+//! Require Docker. Each test boots its own container, so they are isolated and
+//! parallel-safe.
+
+use faucet_core::{CleanupPolicy, Sink, WriteMode, WriteSpec};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+/// `assoc(id, contact_id, label)` — the shape the feature was built for: a child
+/// table whose rows belong to a parent scope.
+async fn create_assoc_table(url: &str) {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE assoc (id INT PRIMARY KEY, contact_id INT, label TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    // Contact 7 has three rows; contact 8 has two. Contact 8 must never be
+    // touched — that is what makes the delete *scoped* rather than a truncate.
+    for (id, contact, label) in [
+        (1, 7, "stale-a"),
+        (2, 7, "stale-b"),
+        (3, 7, "keep-me"),
+        (10, 8, "other"),
+        (11, 8, "other-2"),
+    ] {
+        sqlx::query("INSERT INTO assoc (id, contact_id, label) VALUES ($1, $2, $3)")
+            .bind(id)
+            .bind(contact)
+            .bind(label)
+            .execute(&pool)
+            .await
+            .expect("seed");
+    }
+    pool.close().await;
+}
+
+async fn ids(url: &str) -> Vec<(i32, i32)> {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let rows: Vec<(i32, i32)> = sqlx::query_as("SELECT id, contact_id FROM assoc ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .expect("read back");
+    pool.close().await;
+    rows
+}
+
+/// Whether a table exists in any schema — used to prove the temp table does not
+/// leak past its transaction.
+async fn table_exists(url: &str, name: &str) -> bool {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let found: Option<i32> = sqlx::query_scalar("SELECT 1 FROM pg_class WHERE relname = $1")
+        .bind(name)
+        .fetch_optional(&pool)
+        .await
+        .expect("lookup");
+    pool.close().await;
+    found.is_some()
+}
+
+fn sink_config(url: &str) -> PostgresSinkConfig {
+    let mut config =
+        PostgresSinkConfig::new(url, "assoc").column_mapping(PostgresColumnMapping::AutoMap);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    };
+    config
+}
+
+fn scope(contact_id: i64) -> BTreeMap<String, Value> {
+    BTreeMap::from([("contact_id".to_string(), json!(contact_id))])
+}
+
+fn policy(contact_id: i64, max_keys: usize) -> CleanupPolicy {
+    CleanupPolicy::new(scope(contact_id), vec!["id".to_string()], max_keys).expect("policy")
+}
+
+/// Drive a page through the sink, then run the cleanup with exactly that page's
+/// keys — the sequence `run_stream` performs.
+async fn write_then_cleanup(sink: &PostgresSink, page: &[Value], contact_id: i64) -> u64 {
+    let p = policy(contact_id, 1000);
+    if !page.is_empty() {
+        sink.write_batch(page).await.expect("write");
+    }
+    let mut seen = faucet_core::SeenKeys::new();
+    seen.record_page(page, &p.key, p.max_keys);
+    sink.cleanup_scope(&p.scope, &seen).await.expect("cleanup")
+}
+
+#[tokio::test]
+async fn deletes_only_unwritten_rows_inside_the_scope() {
+    let (_c, url) = start_postgres().await;
+    create_assoc_table(&url).await;
+    let sink = PostgresSink::new(sink_config(&url)).await.expect("sink");
+
+    // The source now reports only id=3 for contact 7 — ids 1 and 2 were deleted
+    // upstream, which an incremental upsert alone could never notice.
+    let deleted = write_then_cleanup(
+        &sink,
+        &[json!({"id": 3, "contact_id": 7, "label": "keep-me"})],
+        7,
+    )
+    .await;
+
+    assert_eq!(deleted, 2, "exactly the two stale rows");
+    assert_eq!(
+        ids(&url).await,
+        vec![(3, 7), (10, 8), (11, 8)],
+        "the written row survives and contact 8 is untouched"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_page_clears_the_whole_scope_but_nothing_else() {
+    // The motivating case: every association for contact 7 was removed upstream,
+    // so the fetch returns nothing. Upsert alone writes nothing and the stale
+    // rows live forever.
+    let (_c, url) = start_postgres().await;
+    create_assoc_table(&url).await;
+    let sink = PostgresSink::new(sink_config(&url)).await.expect("sink");
+
+    let deleted = write_then_cleanup(&sink, &[], 7).await;
+
+    assert_eq!(deleted, 3, "all three of contact 7's rows");
+    assert_eq!(
+        ids(&url).await,
+        vec![(10, 8), (11, 8)],
+        "contact 8's rows must survive an empty page for contact 7"
+    );
+}
+
+#[tokio::test]
+async fn a_scope_with_no_stale_rows_deletes_nothing() {
+    // The steady state a healthy mirror shows: everything in the scope was
+    // written this run, so there is nothing to remove.
+    let (_c, url) = start_postgres().await;
+    create_assoc_table(&url).await;
+    let sink = PostgresSink::new(sink_config(&url)).await.expect("sink");
+
+    let deleted = write_then_cleanup(
+        &sink,
+        &[
+            json!({"id": 1, "contact_id": 7, "label": "a"}),
+            json!({"id": 2, "contact_id": 7, "label": "b"}),
+            json!({"id": 3, "contact_id": 7, "label": "c"}),
+        ],
+        7,
+    )
+    .await;
+
+    assert_eq!(deleted, 0);
+    assert_eq!(ids(&url).await.len(), 5, "nothing removed");
+}
+
+#[tokio::test]
+async fn the_temp_table_does_not_outlive_its_transaction() {
+    // `ON COMMIT DROP` is what lets concurrent cleanups on other pooled
+    // connections use the same table name without colliding. If it leaked, the
+    // second cleanup on a reused connection would fail on "already exists".
+    let (_c, url) = start_postgres().await;
+    create_assoc_table(&url).await;
+    let sink = PostgresSink::new(sink_config(&url)).await.expect("sink");
+
+    write_then_cleanup(&sink, &[json!({"id": 3, "contact_id": 7, "label": "x"})], 7).await;
+    assert!(
+        !table_exists(&url, "faucet_cleanup_keys").await,
+        "the temp table must be gone after the transaction commits"
+    );
+
+    // Running a second cleanup on the same pool proves it in the way that
+    // matters: a leaked table would make this fail.
+    let deleted = write_then_cleanup(&sink, &[], 8).await;
+    assert_eq!(deleted, 2, "contact 8's rows, on a reused connection");
+}
+
+#[tokio::test]
+async fn a_scope_column_that_does_not_exist_is_a_clear_error() {
+    let (_c, url) = start_postgres().await;
+    create_assoc_table(&url).await;
+    let sink = PostgresSink::new(sink_config(&url)).await.expect("sink");
+
+    let bad = CleanupPolicy::new(
+        BTreeMap::from([("contactid".to_string(), json!(7))]), // typo
+        vec!["id".to_string()],
+        1000,
+    )
+    .unwrap();
+    let err = sink
+        .cleanup_scope(&bad.scope, &faucet_core::SeenKeys::new())
+        .await
+        .expect_err("a non-existent column must be refused");
+    let msg = err.to_string();
+    assert!(msg.contains("contactid"), "names the column: {msg}");
+    assert!(msg.contains("assoc"), "names the table: {msg}");
+    assert_eq!(
+        ids(&url).await.len(),
+        5,
+        "nothing deleted on the error path"
+    );
+}
+
+#[tokio::test]
+async fn a_large_key_set_is_loaded_in_chunks_and_still_matches() {
+    // The written-key set is loaded into the temp table in parameter-bounded
+    // chunks. This crosses that boundary in miniature: many keys, only some of
+    // which exist, with a stale row that must still be found.
+    let (_c, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+    sqlx::query("CREATE TABLE assoc (id INT PRIMARY KEY, contact_id INT, label TEXT)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    for id in 0..500 {
+        sqlx::query("INSERT INTO assoc (id, contact_id, label) VALUES ($1, 7, 'x')")
+            .bind(id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    pool.close().await;
+
+    let sink = PostgresSink::new(sink_config(&url)).await.expect("sink");
+    // Re-write every even id; the odd ones become stale.
+    let page: Vec<Value> = (0..500)
+        .filter(|i| i % 2 == 0)
+        .map(|i| json!({"id": i, "contact_id": 7, "label": "kept"}))
+        .collect();
+    let deleted = write_then_cleanup(&sink, &page, 7).await;
+
+    assert_eq!(deleted, 250, "every odd id was stale");
+    let remaining = ids(&url).await;
+    assert_eq!(remaining.len(), 250);
+    assert!(
+        remaining.iter().all(|(id, _)| id % 2 == 0),
+        "only the written (even) ids survive"
+    );
+}


### PR DESCRIPTION
#478 merged at **84% patch coverage**, under the project's 90% standard. Nothing
blocked it, because `codecov/patch` is informational — which is exactly why the
gate that landed in #485 now exists.

The gap was the sinks' `cleanup_scope` implementations. Their SQL and filter
*construction* is unit-tested; the parts only a real server exercises had no
coverage at all, and those are the parts most likely to be wrong.

## Postgres — 6 tests

The reference implementation and the largest cleanup body. Covers what unit tests
structurally cannot:

- the temp table is really created **and really dropped** — a leak would break the
  next cleanup on a reused pooled connection, so a second cleanup on the same
  pool is asserted rather than just checking `pg_class`
- the `NOT EXISTS` join matches across real column types
- the scope predicate genuinely confines the delete to one parent
- a non-existent scope column errors **without deleting anything**
- the chunked key load still matches across a 500-row set where every odd id is
  stale

## MongoDB — 4 tests

Most importantly **the `$and` regression**. With sibling filter fields instead of
`$and`, a scope field that is also a key field has its scope predicate overwritten
by the duplicate entry — widening the delete from one parent's documents to the
entire collection. That was previously asserted only on the filter's *shape*; it
is now proven against a real server, with a neighbouring parent's documents
checked for survival.

Both suites cover the motivating case explicitly: an empty page clears the scope
and nothing outside it.

## Verified against real servers, not compile-checked

All 10 tests were run locally against real Postgres and MongoDB containers, not
just compiled. That mattered — see below.

## A note for whoever writes the next one

The MongoDB assertion helper originally read `_id` with `get_i32`, which silently
dropped every document written *through the sink*, because those round-trip from
JSON as `Int64` while seeded documents are `Int32`. The symptom was indistinguishable
from the cleanup deleting rows it had just written, and I briefly believed I had
found a data-loss bug in merged code. There was none — the sink was correct
throughout. The helper now reads both widths and **panics on anything else**, so a
future type surprise is loud instead of a phantom.

## Not covered here

`mssql` (SQL Server containers do not run on this machine, CI-only) and
`elasticsearch`. `mysql`, `sqlite`, `bigquery` and `spanner` already gained cleanup
tests in #484.
