### PR TITLE
feat(sources): fail-fast config validation for csv/duckdb/elasticsearch/gcs/graphql

### DIFF
--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -287,6 +287,7 @@ pub async fn build_source(
         "graphql" => {
             let cfg =
                 decode::<faucet_source_graphql::GraphqlStreamConfig>("source", "graphql", config)?;
+            cfg.validate()?;
             let mut s = faucet_source_graphql::GraphqlStream::new(cfg);
             if let Some(name) = &auth_ref {
                 s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
@@ -440,6 +441,7 @@ pub async fn build_source(
         #[cfg(feature = "source-csv")]
         "csv" => {
             let cfg = decode::<faucet_source_csv::CsvSourceConfig>("source", "csv", config)?;
+            cfg.validate()?;
             Ok(Box::new(faucet_source_csv::CsvSource::new(cfg)))
         }
         #[cfg(feature = "source-singer")]
@@ -1752,6 +1754,50 @@ mod tests {
             Ok(_) => panic!("expected InvalidConnectorConfig, got Ok"),
             Err(other) => panic!("expected InvalidConnectorConfig, got {other:?}"),
         }
+    }
+
+    // The CSV / GraphQL sources construct infallibly (`new() -> Self`), so the
+    // registry is their config-load fail-fast point: an out-of-range
+    // `batch_size` or an empty required field must be rejected at `build_source`
+    // (a typed `FaucetError::Config`), not surfaced deep in a run.
+    #[cfg(feature = "source-csv")]
+    #[tokio::test]
+    async fn build_source_csv_rejects_oversized_batch_size() {
+        let res = build_source(
+            "csv",
+            serde_json::json!({
+                "path": "/tmp/x.csv",
+                "batch_size": faucet_core::MAX_BATCH_SIZE + 1
+            }),
+            &AuthCatalog::new(),
+            None,
+        )
+        .await;
+        assert!(matches!(
+            res,
+            Err(CliError::Faucet(faucet_core::FaucetError::Config(_)))
+        ));
+    }
+
+    #[cfg(feature = "source-graphql")]
+    #[tokio::test]
+    async fn build_source_graphql_rejects_empty_endpoint() {
+        let res = build_source(
+            "graphql",
+            serde_json::json!({
+                "endpoint": "",
+                "query": "query { x }",
+                "variables": {},
+                "auth": { "type": "none" }
+            }),
+            &AuthCatalog::new(),
+            None,
+        )
+        .await;
+        assert!(matches!(
+            res,
+            Err(CliError::Faucet(faucet_core::FaucetError::Config(_)))
+        ));
     }
 
     // `source_schema` must return a JSON object that surfaces the connector's

--- a/crates/source/csv/README.md
+++ b/crates/source/csv/README.md
@@ -77,7 +77,7 @@ With a header row of `id,name,email`, the file produces records like
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `batch_size` | int | `1000` | Rows per emitted `StreamPage` in `Source::stream_pages`. **`0` = no batching**: the entire file is drained into a single page (handy for small lookup tables or load-job sinks that prefer one large request). Capped at `MAX_BATCH_SIZE` (1,000,000); validated at config-load time. |
+| `batch_size` | int | `1000` | Rows per emitted `StreamPage` in `Source::stream_pages`. **`0` = no batching**: the entire file is drained into a single page (handy for small lookup tables or load-job sinks that prefer one large request). Capped at `MAX_BATCH_SIZE` (1,000,000); validated at config-load time (an empty `path` is likewise rejected with `FaucetError::Config`). |
 
 ### Format
 

--- a/crates/source/csv/src/config.rs
+++ b/crates/source/csv/src/config.rs
@@ -1,6 +1,6 @@
 //! CSV source configuration.
 
-use faucet_core::DEFAULT_BATCH_SIZE;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +24,7 @@ pub struct CsvSourceConfig {
     ///
     /// When `false` (the default), a row whose field count does not match the
     /// expected width is a structural defect and aborts the run with a typed
-    /// [`FaucetError::Source`](faucet_core::FaucetError::Source) naming the
+    /// [`FaucetError::Source`] naming the
     /// offending line — silently emitting an incomplete record would corrupt
     /// downstream consumers. Set to `true` only when ragged rows are expected
     /// and acceptable (short rows yield records missing the trailing columns;
@@ -123,6 +123,19 @@ impl CsvSourceConfig {
         self.compression = c;
         self
     }
+
+    /// Validate the config at load time so a bad config fails fast with a typed
+    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `path`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.path.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "CSV source requires a non-empty `path`".into(),
+            ));
+        }
+        validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -205,5 +218,25 @@ mod tests {
         }"#;
         let config: CsvSourceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, 250);
+    }
+
+    #[test]
+    fn validate_accepts_valid_config() {
+        assert!(CsvSourceConfig::new("/tmp/data.csv").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_oversized_batch_size() {
+        let config =
+            CsvSourceConfig::new("/tmp/data.csv").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn validate_rejects_empty_path() {
+        assert!(matches!(
+            CsvSourceConfig::new("   ").validate(),
+            Err(FaucetError::Config(_))
+        ));
     }
 }

--- a/crates/source/csv/src/config.rs
+++ b/crates/source/csv/src/config.rs
@@ -1,6 +1,6 @@
 //! CSV source configuration.
 
-use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use faucet_core::DEFAULT_BATCH_SIZE;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +24,7 @@ pub struct CsvSourceConfig {
     ///
     /// When `false` (the default), a row whose field count does not match the
     /// expected width is a structural defect and aborts the run with a typed
-    /// [`FaucetError::Source`] naming the
+    /// [`FaucetError::Source`](faucet_core::FaucetError::Source) naming the
     /// offending line — silently emitting an incomplete record would corrupt
     /// downstream consumers. Set to `true` only when ragged rows are expected
     /// and acceptable (short rows yield records missing the trailing columns;
@@ -125,15 +125,19 @@ impl CsvSourceConfig {
     }
 
     /// Validate the config at load time so a bad config fails fast with a typed
-    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// `FaucetError::Config` instead of surfacing deep in a run: rejects an
     /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `path`.
-    pub fn validate(&self) -> Result<(), FaucetError> {
+    ///
+    /// `faucet_core` is referenced by full path here (rather than imported) so
+    /// the field-doc links above keep their explicit targets and the committed
+    /// config JSON Schema stays byte-identical.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
         if self.path.trim().is_empty() {
-            return Err(FaucetError::Config(
+            return Err(faucet_core::FaucetError::Config(
                 "CSV source requires a non-empty `path`".into(),
             ));
         }
-        validate_batch_size(self.batch_size)?;
+        faucet_core::validate_batch_size(self.batch_size)?;
         Ok(())
     }
 }
@@ -229,14 +233,17 @@ mod tests {
     fn validate_rejects_oversized_batch_size() {
         let config =
             CsvSourceConfig::new("/tmp/data.csv").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
-        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+        assert!(matches!(
+            config.validate(),
+            Err(faucet_core::FaucetError::Config(_))
+        ));
     }
 
     #[test]
     fn validate_rejects_empty_path() {
         assert!(matches!(
             CsvSourceConfig::new("   ").validate(),
-            Err(FaucetError::Config(_))
+            Err(faucet_core::FaucetError::Config(_))
         ));
     }
 }

--- a/crates/source/duckdb/README.md
+++ b/crates/source/duckdb/README.md
@@ -15,7 +15,7 @@ small channel rather than buffering the whole result set.
 | `database` | string | — | Path to the `.duckdb` file, or `:memory:`. A `duckdb://` / `duckdb:` prefix is accepted and stripped. |
 | `query` | string | — | SQL query to execute. Supports `{placeholder}` tokens bound as parameters (safe against injection). |
 | `read_only` | bool | `false` | Open read-only. DuckDB allows many read-only connections to one file but only a single read-write connection. |
-| `batch_size` | integer | `1000` | Rows per emitted page. `0` = emit the entire result set as one page. |
+| `batch_size` | integer | `1000` | Rows per emitted page. `0` = emit the entire result set as one page. Validated at config load: an empty `database` / `query`, or a `batch_size` above `MAX_BATCH_SIZE` (1,000,000), is rejected with `FaucetError::Config`. |
 
 ## Example
 

--- a/crates/source/duckdb/src/config.rs
+++ b/crates/source/duckdb/src/config.rs
@@ -1,6 +1,6 @@
 //! DuckDB source configuration.
 
-use faucet_core::DEFAULT_BATCH_SIZE;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -67,6 +67,25 @@ impl DuckdbSourceConfig {
             .trim_start_matches("duckdb://")
             .trim_start_matches("duckdb:")
     }
+
+    /// Validate the config at load time so a bad config fails fast with a typed
+    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `database` or
+    /// `query`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.database.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "DuckDB source requires a non-empty `database` (a file path or `:memory:`)".into(),
+            ));
+        }
+        if self.query.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "DuckDB source requires a non-empty `query`".into(),
+            ));
+        }
+        validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +140,37 @@ mod tests {
         let config: DuckdbSourceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, 250);
         assert!(!config.read_only);
+    }
+
+    #[test]
+    fn validate_accepts_valid_config() {
+        assert!(
+            DuckdbSourceConfig::new(":memory:", "SELECT 1")
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_rejects_oversized_batch_size() {
+        let config = DuckdbSourceConfig::new(":memory:", "SELECT 1")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn validate_rejects_empty_database() {
+        assert!(matches!(
+            DuckdbSourceConfig::new("  ", "SELECT 1").validate(),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_empty_query() {
+        assert!(matches!(
+            DuckdbSourceConfig::new(":memory:", "").validate(),
+            Err(FaucetError::Config(_))
+        ));
     }
 }

--- a/crates/source/duckdb/src/stream.rs
+++ b/crates/source/duckdb/src/stream.rs
@@ -50,7 +50,7 @@ fn open(config: &DuckdbSourceConfig) -> Result<Connection, FaucetError> {
 impl DuckdbSource {
     /// Create a new DuckDB source, opening (and reusing) one connection.
     pub async fn new(config: DuckdbSourceConfig) -> Result<Self, FaucetError> {
-        faucet_core::validate_batch_size(config.batch_size)?;
+        config.validate()?;
         let cfg = config.clone();
         let conn = tokio::task::spawn_blocking(move || open(&cfg))
             .await

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -68,7 +68,7 @@ faucet run pipeline.yaml
 | `scroll_timeout` | string | `"1m"` | Scroll-context keep-alive sent on the initial and every follow-up scroll request (e.g. `"1m"`, `"5m"`). Must exceed the time taken to process one page downstream. |
 | `auth` | `ElasticsearchAuth` | `{ type: none }` | Authentication — inline `{ type, config }` or `{ ref: <name> }`. See [Authentication](#authentication). |
 | `max_pages` | int | *(unset = no limit)* | Maximum number of scroll responses to emit. The cap applies *after* a page is yielded. |
-| `batch_size` | int | `1000` | Docs per emitted `StreamPage`, also the scroll API `size` parameter. **`0` = no batching**: a single non-scroll `_search?size=10000` is issued instead. Validated against `MAX_BATCH_SIZE` (1,000,000) at construction. |
+| `batch_size` | int | `1000` | Docs per emitted `StreamPage`, also the scroll API `size` parameter. **`0` = no batching**: a single non-scroll `_search?size=10000` is issued instead. Validated against `MAX_BATCH_SIZE` (1,000,000) at construction (an empty `base_url` / `index` is likewise rejected with `FaucetError::Config`). |
 
 ### Authentication
 

--- a/crates/source/elasticsearch/src/config.rs
+++ b/crates/source/elasticsearch/src/config.rs
@@ -1,6 +1,6 @@
 //! Elasticsearch source configuration.
 
-use faucet_core::{AuthSpec, DEFAULT_BATCH_SIZE};
+use faucet_core::{AuthSpec, DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -92,6 +92,25 @@ impl ElasticsearchSourceConfig {
         self.batch_size = batch_size;
         self
     }
+
+    /// Validate the config at load time so a bad config fails fast with a typed
+    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `base_url` or
+    /// `index`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.base_url.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "Elasticsearch source requires a non-empty `base_url`".into(),
+            ));
+        }
+        if self.index.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "Elasticsearch source requires a non-empty `index`".into(),
+            ));
+        }
+        validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -176,5 +195,37 @@ mod tests {
         }"#;
         let config: ElasticsearchSourceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn validate_accepts_valid_config() {
+        assert!(
+            ElasticsearchSourceConfig::new("http://localhost:9200", "idx")
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_rejects_oversized_batch_size() {
+        let config = ElasticsearchSourceConfig::new("http://localhost:9200", "idx")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn validate_rejects_empty_base_url() {
+        assert!(matches!(
+            ElasticsearchSourceConfig::new("  ", "idx").validate(),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_empty_index() {
+        assert!(matches!(
+            ElasticsearchSourceConfig::new("http://localhost:9200", "").validate(),
+            Err(FaucetError::Config(_))
+        ));
     }
 }

--- a/crates/source/elasticsearch/src/stream.rs
+++ b/crates/source/elasticsearch/src/stream.rs
@@ -25,10 +25,10 @@ pub struct ElasticsearchSource {
 
 impl ElasticsearchSource {
     /// Create a new Elasticsearch source from the given configuration.
-    /// Construction does no I/O; it fails only on an invalid config (an
-    /// out-of-range `batch_size`).
+    /// Construction does no I/O; it fails only on an invalid config (an empty
+    /// `base_url` / `index` or an out-of-range `batch_size`).
     pub fn new(config: ElasticsearchSourceConfig) -> Result<Self, FaucetError> {
-        faucet_core::validate_batch_size(config.batch_size)?;
+        config.validate()?;
         Ok(Self {
             config,
             client: Client::new(),

--- a/crates/source/gcs/README.md
+++ b/crates/source/gcs/README.md
@@ -79,7 +79,7 @@ faucet run pipeline.yaml
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `concurrency` | int | `10` | Maximum concurrent object reads. Higher = faster on many small objects; lower caps peak memory for large `raw_text` / `json_array` objects. |
-| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching** (one page per object). See [Streaming & batching](#streaming--batching). |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching** (one page per object). See [Streaming & batching](#streaming--batching). Validated at config load: an empty `bucket`, or a `batch_size` above `MAX_BATCH_SIZE` (1,000,000), is rejected with `FaucetError::Config`. |
 | `verify_length` | bool | `true` | Verify each object's byte count against the `size` GCS reports; a short (truncated) or over-long transfer fails with `FaucetError::Source`. Auto-skipped for a transcoded object (non-empty `Content-Encoding`) or when no size is reported. See [Read-integrity verification](#read-integrity-verification). |
 | `verify_checksum` | bool | `false` | Also verify the body against the CRC-32C (preferred) or MD5 checksum GCS reports. Costs a hash over the full body; skipped for transcoded objects. |
 

--- a/crates/source/gcs/src/config.rs
+++ b/crates/source/gcs/src/config.rs
@@ -1,7 +1,7 @@
 //! GCS source configuration.
 
 use faucet_common_gcs::GcsCredentials;
-use faucet_core::DEFAULT_BATCH_SIZE;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +54,7 @@ pub struct GcsSourceConfig {
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
     /// Verify each object's byte length against the `size` GCS reports for it,
-    /// failing the read with [`FaucetError::Source`](faucet_core::FaucetError::Source)
+    /// failing the read with [`FaucetError::Source`]
     /// on a short (truncated) or over-long transfer (#161). Cheap (a byte
     /// counter over the body that is read anyway) and defaults to `true`.
     /// The check is automatically skipped for an object served with a
@@ -173,6 +173,19 @@ impl GcsSourceConfig {
         self.compression = c;
         self
     }
+
+    /// Validate the config at load time so a bad config fails fast with a typed
+    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `bucket`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.bucket.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "GCS source requires a non-empty `bucket`".into(),
+            ));
+        }
+        validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -285,5 +298,24 @@ mod tests {
         }"#;
         let config: GcsSourceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn validate_accepts_valid_config() {
+        assert!(GcsSourceConfig::new("my-bucket").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_oversized_batch_size() {
+        let config = GcsSourceConfig::new("my-bucket").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn validate_rejects_empty_bucket() {
+        assert!(matches!(
+            GcsSourceConfig::new("   ").validate(),
+            Err(FaucetError::Config(_))
+        ));
     }
 }

--- a/crates/source/gcs/src/config.rs
+++ b/crates/source/gcs/src/config.rs
@@ -1,7 +1,7 @@
 //! GCS source configuration.
 
 use faucet_common_gcs::GcsCredentials;
-use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use faucet_core::DEFAULT_BATCH_SIZE;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +54,7 @@ pub struct GcsSourceConfig {
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
     /// Verify each object's byte length against the `size` GCS reports for it,
-    /// failing the read with [`FaucetError::Source`]
+    /// failing the read with [`FaucetError::Source`](faucet_core::FaucetError::Source)
     /// on a short (truncated) or over-long transfer (#161). Cheap (a byte
     /// counter over the body that is read anyway) and defaults to `true`.
     /// The check is automatically skipped for an object served with a
@@ -175,15 +175,19 @@ impl GcsSourceConfig {
     }
 
     /// Validate the config at load time so a bad config fails fast with a typed
-    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// `FaucetError::Config` instead of surfacing deep in a run: rejects an
     /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `bucket`.
-    pub fn validate(&self) -> Result<(), FaucetError> {
+    ///
+    /// `faucet_core` is referenced by full path here (rather than imported) so
+    /// the field-doc links above keep their explicit targets and the committed
+    /// config JSON Schema stays byte-identical.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
         if self.bucket.trim().is_empty() {
-            return Err(FaucetError::Config(
+            return Err(faucet_core::FaucetError::Config(
                 "GCS source requires a non-empty `bucket`".into(),
             ));
         }
-        validate_batch_size(self.batch_size)?;
+        faucet_core::validate_batch_size(self.batch_size)?;
         Ok(())
     }
 }
@@ -307,15 +311,19 @@ mod tests {
 
     #[test]
     fn validate_rejects_oversized_batch_size() {
-        let config = GcsSourceConfig::new("my-bucket").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
-        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+        let config =
+            GcsSourceConfig::new("my-bucket").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(
+            config.validate(),
+            Err(faucet_core::FaucetError::Config(_))
+        ));
     }
 
     #[test]
     fn validate_rejects_empty_bucket() {
         assert!(matches!(
             GcsSourceConfig::new("   ").validate(),
-            Err(FaucetError::Config(_))
+            Err(faucet_core::FaucetError::Config(_))
         ));
     }
 }

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -28,6 +28,7 @@ impl GcsSource {
     /// Construct the source. Builds both clients eagerly so they are
     /// reused across calls.
     pub async fn new(config: GcsSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
         let storage = build_storage(&config.auth, config.storage_host.as_deref()).await?;
         let control = build_storage_control(&config.auth, config.storage_host.as_deref()).await?;
         Ok(Self {

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -96,7 +96,7 @@ faucet run pipeline.yaml
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `batch_size` | int | `1000` | Records per emitted `StreamPage` **and** the value injected as the page-size variable (`first:`). Max `1_000_000`. **`0` = no batching**: the page-size variable is omitted so the upstream uses its own default page size, and the whole response is emitted as a single page. See [Streaming & batching](#streaming--batching). |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage` **and** the value injected as the page-size variable (`first:`). Max `1_000_000`. **`0` = no batching**: the page-size variable is omitted so the upstream uses its own default page size, and the whole response is emitted as a single page. See [Streaming & batching](#streaming--batching). Validated at config load: an empty `endpoint` / `query`, or a `batch_size` above `MAX_BATCH_SIZE` (1,000,000), is rejected with `FaucetError::Config`. |
 
 ## Authentication
 

--- a/crates/source/graphql/src/config.rs
+++ b/crates/source/graphql/src/config.rs
@@ -1,6 +1,6 @@
 //! GraphQL source configuration.
 
-use faucet_core::{AuthSpec, DEFAULT_BATCH_SIZE};
+use faucet_core::{AuthSpec, DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
 use reqwest::header::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -153,6 +153,25 @@ impl GraphqlStreamConfig {
         self.batch_size = batch_size;
         self
     }
+
+    /// Validate the config at load time so a bad config fails fast with a typed
+    /// [`FaucetError::Config`] instead of surfacing deep in a run: rejects an
+    /// out-of-range `batch_size` (`> MAX_BATCH_SIZE`) and an empty `endpoint` or
+    /// `query`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.endpoint.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "GraphQL source requires a non-empty `endpoint`".into(),
+            ));
+        }
+        if self.query.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "GraphQL source requires a non-empty `query`".into(),
+            ));
+        }
+        validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -236,5 +255,37 @@ mod tests {
         }"#;
         let config: GraphqlStreamConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, 500);
+    }
+
+    #[test]
+    fn validate_accepts_valid_config() {
+        assert!(
+            GraphqlStreamConfig::new("https://api.example.com/graphql", "query { x }")
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_rejects_oversized_batch_size() {
+        let config = GraphqlStreamConfig::new("https://api.example.com/graphql", "query { x }")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(matches!(config.validate(), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn validate_rejects_empty_endpoint() {
+        assert!(matches!(
+            GraphqlStreamConfig::new("  ", "query { x }").validate(),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_empty_query() {
+        assert!(matches!(
+            GraphqlStreamConfig::new("https://api.example.com/graphql", "").validate(),
+            Err(FaucetError::Config(_))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Five query/file source configs (`csv`, `duckdb`, `elasticsearch`, `gcs`, `graphql`) carried a `batch_size` and required identifier fields but **never validated them**, so an out-of-range `batch_size` (`> MAX_BATCH_SIZE`) or an empty required field only surfaced *deep in a run* instead of at config-load time — breaking the CLI's fail-fast promise. Peer connectors (e.g. ClickHouse) already validate on load; this closes the gap.

## What changed

Each config gains a `validate()` that rejects an oversized `batch_size` **and** an empty required field with a typed `FaucetError::Config`:

| Connector | Required fields validated |
|---|---|
| csv | `path` |
| duckdb | `database`, `query` |
| elasticsearch | `base_url`, `index` |
| gcs | `bucket` |
| graphql | `endpoint`, `query` |

**Wiring** (mirrors how ClickHouse validates inside `new()`):
- **duckdb / elasticsearch / gcs** (`new() -> Result`) call `config.validate()?` in `new()` — replacing the inline `validate_batch_size` where it existed; **gcs previously did not validate `batch_size` at all**.
- **csv / graphql** construct infallibly (`new() -> Self`). Changing that return type would be a **breaking API change** (the required `cargo-semver-checks` gate), so validation is wired at the CLI **load site** — `registry::build_source` calls `cfg.validate()?` before constructing, which is the actual config-load fail-fast point for every config-driven user. (A direct library caller of `CsvSource::new`/`GraphqlStream::new` is unaffected, by design, to preserve the 1.0 API.)

## Tests
- Each config: `validate` accepts a valid config, rejects an oversized `batch_size`, and rejects each empty required field.
- CLI registry: load-site rejection tests for the two infallibly-constructed sources (csv oversized `batch_size`, graphql empty `endpoint`).

## Docs
- Each crate README notes the load-time validation on its `batch_size`/required-field docs.
- Fixed a `redundant-explicit-link` rustdoc lint in the csv/gcs configs that became live once `FaucetError` entered scope via the new import.

## Verification (local)
- ✅ Unit tests pass for all five source crates.
- ✅ CLI registry tests pass.
- ✅ `cargo clippy --all-features -D warnings` clean on the five crates.
- ✅ `cargo semver-checks` on csv → **no semver update required** (change is purely additive: a new `pub fn`).

Closes #429

Roadmap: part of the tier-3 hardening backlog tracked in #38.