### PR TITLE
feat(cli): --json for list/validate, schema --list, connector labels, and validation & test hardening

### DIFF
--- a/cli/examples/mongodb_to_parquet.yaml
+++ b/cli/examples/mongodb_to_parquet.yaml
@@ -1,0 +1,60 @@
+# MongoDB collection → local Parquet files.
+#
+# Streams documents out of a MongoDB collection (with a filter, projection, and
+# sort) and writes them as columnar Parquet — the Arrow schema is inferred from
+# the first batch of records, so no schema declaration is needed. Ideal for
+# snapshotting an operational collection into an analytics-friendly file format.
+#
+# Infra: MongoDB from `examples/docker-compose.yml` (the `mongodb` service).
+# The Parquet sink writes to the local filesystem — no cloud credentials needed.
+#
+# Run:
+#   docker compose -f examples/docker-compose.yml up -d mongodb
+#   faucet validate cli/examples/mongodb_to_parquet.yaml
+#   faucet run      cli/examples/mongodb_to_parquet.yaml
+version: 1
+name: mongodb_to_parquet
+
+pipeline:
+  source:
+    type: mongodb
+    config:
+      # Standard MongoDB connection string. Point at your replica set / cluster.
+      connection_uri: mongodb://localhost:27017
+      database: shop
+      collection: orders
+      # Server-side filter — only completed orders are exported.
+      filter:
+        status: completed
+      # Return just the fields we care about (1 = include). Drop `_id` so the
+      # ObjectId doesn't need type handling downstream.
+      projection:
+        _id: 0
+        customer_id: 1
+        total: 1
+        currency: 1
+        created_at: 1
+      # Deterministic ordering makes re-runs reproducible.
+      sort:
+        created_at: 1
+      # Cap the export; remove for a full-collection dump.
+      limit: 500000
+      # Driver-side cursor batch size (network round-trip granularity).
+      cursor_batch_size: 1000
+
+  sink:
+    type: parquet
+    config:
+      # Local filesystem destination. A path ending in `.parquet` writes a single
+      # file; a directory path rolls over to `<uuid>.parquet` files instead.
+      destination:
+        type: local_path
+        path: ./out/orders/
+      # Codec applied to each column chunk: uncompressed | snappy | gzip | zstd | lz4.
+      compression: zstd
+      # Roll over to a new file every N rows (directory mode) to cap file size.
+      max_rows_per_file: 200000
+      # Rows per Arrow record batch handed to the writer. `0` = write whatever
+      # the source hands over as one batch (recommended for Parquet, which
+      # prefers fewer, larger row groups).
+      batch_size: 0

--- a/cli/src/backfill/metrics.rs
+++ b/cli/src/backfill/metrics.rs
@@ -39,17 +39,65 @@ pub(crate) fn record_unit(pipeline: &str, outcome: &'static str) {
     .increment(1);
 }
 
+/// Completed fraction of the planned units, clamped to `[0.0, 1.0]`.
+///
+/// Pure so the divide-by-zero guard and clamping are unit-testable without the
+/// metrics recorder: an empty plan (`planned == 0`) is treated as fully done
+/// (`1.0`), and `done > planned` (a resume double-count) never exceeds `1.0`.
+fn progress_ratio(done: usize, planned: usize) -> f64 {
+    if planned == 0 {
+        1.0
+    } else {
+        (done as f64 / planned as f64).min(1.0)
+    }
+}
+
 /// Publish the completed fraction of the planned units.
 pub(crate) fn set_progress(pipeline: &str, done: usize, planned: usize) {
     describe();
-    let ratio = if planned == 0 {
-        1.0
-    } else {
-        done as f64 / planned as f64
-    };
     gauge!(
         "faucet_backfill_progress_ratio",
         "pipeline" => pipeline.to_owned(),
     )
-    .set(ratio);
+    .set(progress_ratio(done, planned));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::progress_ratio;
+
+    #[test]
+    fn empty_plan_is_fully_done() {
+        // 0/0 must not be NaN — an empty plan is complete.
+        assert_eq!(progress_ratio(0, 0), 1.0);
+        assert_eq!(progress_ratio(5, 0), 1.0);
+    }
+
+    #[test]
+    fn none_done_is_zero() {
+        assert_eq!(progress_ratio(0, 4), 0.0);
+    }
+
+    #[test]
+    fn all_done_is_one() {
+        assert_eq!(progress_ratio(4, 4), 1.0);
+    }
+
+    #[test]
+    fn partial_is_the_fraction() {
+        assert_eq!(progress_ratio(1, 4), 0.25);
+        assert_eq!(progress_ratio(3, 4), 0.75);
+    }
+
+    #[test]
+    fn over_count_is_clamped_to_one() {
+        assert_eq!(progress_ratio(9, 4), 1.0);
+    }
+
+    #[test]
+    fn never_produces_nan() {
+        for (d, p) in [(0, 0), (0, 1), (1, 1), (3, 7), (100, 1)] {
+            assert!(!progress_ratio(d, p).is_nan(), "nan for {d}/{p}");
+        }
+    }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1270,13 +1270,21 @@ pub struct ValidateArgs {
     /// status/tags and whether the selection would run or skip it.
     #[command(flatten)]
     pub selection: SelectionArgs,
+
+    /// Emit a structured JSON validation summary instead of the prose report,
+    /// so CI can assert on it programmatically. Suppresses the human lines.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// `faucet schema` arguments.
 #[derive(Debug, Parser)]
 pub struct SchemaArgs {
     #[command(subcommand)]
-    pub target: SchemaTarget,
+    pub target: Option<SchemaTarget>,
+    /// List every valid schema target and exit, instead of printing a schema.
+    #[arg(long)]
+    pub list: bool,
 }
 
 /// Schema subcommand target — which connector or system component to describe.
@@ -1504,6 +1512,9 @@ pub struct ListArgs {
     /// Read a custom registry index instead of the built-in one.
     #[arg(long)]
     pub index: Option<PathBuf>,
+    /// Emit the listing as JSON instead of the human-readable columns.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// `faucet conformance` arguments.

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -373,3 +373,59 @@ fn render_pipeline(
     ));
     body
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_SINK, DEFAULT_SOURCE, resolve_kinds};
+    use crate::cli::InitArgs;
+    use crate::error::CliError;
+    use std::path::PathBuf;
+
+    fn args(source: Option<&str>, sink: Option<&str>) -> InitArgs {
+        InitArgs {
+            name: None,
+            source: source.map(String::from),
+            sink: sink.map(String::from),
+            output: PathBuf::from("pipeline.yaml"),
+            force: false,
+            interactive: false,
+            template: "default".into(),
+            discover: false,
+            executable: None,
+            stream: None,
+        }
+    }
+
+    #[test]
+    fn resolve_kinds_passes_valid_kinds_through() {
+        let (src, sink) = resolve_kinds(&args(Some("rest"), Some("jsonl"))).unwrap();
+        assert_eq!((src.as_str(), sink.as_str()), ("rest", "jsonl"));
+    }
+
+    #[test]
+    fn resolve_kinds_falls_back_to_defaults() {
+        let (src, sink) = resolve_kinds(&args(None, None)).unwrap();
+        assert_eq!(
+            (src.as_str(), sink.as_str()),
+            (DEFAULT_SOURCE, DEFAULT_SINK)
+        );
+    }
+
+    #[test]
+    fn resolve_kinds_rejects_unknown_source() {
+        let err = resolve_kinds(&args(Some("does-not-exist"), Some("jsonl"))).unwrap_err();
+        assert!(
+            matches!(err, CliError::UnknownConnector { kind: "source", ref name, .. } if name == "does-not-exist"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_kinds_rejects_unknown_sink() {
+        let err = resolve_kinds(&args(Some("rest"), Some("does-not-exist"))).unwrap_err();
+        assert!(
+            matches!(err, CliError::UnknownConnector { kind: "sink", ref name, .. } if name == "does-not-exist"),
+            "got: {err:?}"
+        );
+    }
+}

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -18,6 +18,9 @@ pub async fn run(args: ListArgs) -> CliResult<()> {
     if args.available {
         return list_available(args);
     }
+    if args.json {
+        return run_json();
+    }
     println!("Sources:");
     print_connectors(&source_descriptions(), true);
     println!();
@@ -39,6 +42,46 @@ pub async fn run(args: ListArgs) -> CliResult<()> {
     Ok(())
 }
 
+/// `faucet list --json` — the compiled-in connectors/transforms/state stores as
+/// a single JSON object, so tooling and CI can consume the listing directly.
+fn run_json() -> CliResult<()> {
+    let out = build_list_json();
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+    );
+    Ok(())
+}
+
+/// Pure builder for the `faucet list --json` document (no I/O), so its shape can
+/// be unit-tested.
+fn build_list_json() -> serde_json::Value {
+    let to_entries = |entries: &[(&'static str, &'static str)], is_source: Option<bool>| {
+        entries
+            .iter()
+            .map(|(name, desc)| {
+                let mut obj = serde_json::json!({ "name": name, "description": desc });
+                if let Some(is_source) = is_source {
+                    obj["tier"] = serde_json::json!(tier_for(name, is_source).label());
+                }
+                obj
+            })
+            .collect::<Vec<_>>()
+    };
+    #[allow(unused_mut)]
+    let mut out = serde_json::json!({
+        "sources": to_entries(&source_descriptions(), Some(true)),
+        "sinks": to_entries(&sink_descriptions(), Some(false)),
+        "transforms": to_entries(&transform_descriptions(), None),
+        "state_stores": available_state_kinds(),
+    });
+    #[cfg(feature = "quality")]
+    {
+        out["quality_checks"] = serde_json::json!(to_entries(&quality_descriptions(), None));
+    }
+    out
+}
+
 /// `faucet list --available` — every connector in the registry index, with a
 /// marker for those already compiled into this binary.
 fn list_available(args: ListArgs) -> CliResult<()> {
@@ -47,17 +90,38 @@ fn list_available(args: ListArgs) -> CliResult<()> {
     connectors.sort_by(|a, b| {
         (a.kind.as_str(), a.name.as_str()).cmp(&(b.kind.as_str(), b.name.as_str()))
     });
+    let compiled_for = |c: &crate::registry_index::ConnectorEntry| match c.kind.as_str() {
+        "source" => source_exists(&c.name),
+        "sink" => sink_exists(&c.name),
+        _ => false,
+    };
+    if args.json {
+        let rows: Vec<_> = connectors
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "kind": c.kind,
+                    "name": c.name,
+                    "description": c.description,
+                    "tier": c.tier,
+                    "verified": c.verified,
+                    "compiled": compiled_for(c),
+                })
+            })
+            .collect();
+        let out = serde_json::json!({ "connectors": rows });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+        );
+        return Ok(());
+    }
     println!(
         "Registry connectors ({} total). ● = compiled into this binary, ○ = available via `faucet install`:\n",
         connectors.len()
     );
     for c in connectors {
-        let compiled = match c.kind.as_str() {
-            "source" => source_exists(&c.name),
-            "sink" => sink_exists(&c.name),
-            _ => false,
-        };
-        let mark = if compiled { '●' } else { '○' };
+        let mark = if compiled_for(c) { '●' } else { '○' };
         let badge = if c.verified { "verified" } else { "community" };
         let tier = c.tier.as_deref().unwrap_or("-");
         println!(
@@ -96,6 +160,55 @@ fn print_connectors(entries: &[(&'static str, &'static str)], is_source: bool) {
             badge = tier.badge(),
             tier = tier.label(),
             width = width,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_list_json;
+
+    #[test]
+    fn list_json_has_expected_sections_and_builtins() {
+        let v = build_list_json();
+        // The four documented sections are present and are arrays.
+        for key in ["sources", "sinks", "transforms", "state_stores"] {
+            assert!(v[key].is_array(), "section `{key}` missing or not an array");
+        }
+        // Each connector entry carries name/description; sources/sinks add tier.
+        let names = |key: &str| -> Vec<String> {
+            v[key]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|e| e["name"].as_str().unwrap_or_default().to_string())
+                .collect()
+        };
+        // Default CLI build compiles in the `rest` source and `jsonl` sink.
+        assert!(
+            names("sources").iter().any(|n| n == "rest"),
+            "sources: {:?}",
+            names("sources")
+        );
+        assert!(
+            names("sinks").iter().any(|n| n == "jsonl"),
+            "sinks: {:?}",
+            names("sinks")
+        );
+        assert!(
+            v["sources"][0].get("tier").is_some(),
+            "source entries should carry a tier"
+        );
+        // State stores always include the built-in memory + file backends.
+        let stores: Vec<String> = v["state_stores"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s.as_str().unwrap_or_default().to_string())
+            .collect();
+        assert!(
+            stores.iter().any(|s| s == "memory"),
+            "state_stores: {stores:?}"
         );
     }
 }

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -1,13 +1,70 @@
 //! `faucet schema` — print the JSON Schema for a connector's config.
 
 use crate::cli::{SchemaArgs, SchemaTarget};
-use crate::error::CliResult;
+use crate::error::{CliError, CliResult};
 use crate::registry::{sink_schema, source_schema};
 use crate::transforms::transform_schema;
 
+/// Every valid `faucet schema <target>` keyword compiled into this binary, in a
+/// stable order. Feature-gated targets appear only when their feature is on, so
+/// the listing matches what this build can actually emit. `source`, `sink`, and
+/// `transform` additionally take a connector/transform NAME argument.
+pub fn schema_targets() -> Vec<&'static str> {
+    let mut targets = vec![
+        "config",
+        "source",
+        "sink",
+        "transform",
+        "dlq",
+        "replication",
+        "backfill",
+        "partition",
+        "execution",
+        "resilience",
+        "sla",
+    ];
+    #[cfg(feature = "quality")]
+    targets.push("quality");
+    #[cfg(feature = "contract")]
+    targets.push("contract");
+    #[cfg(feature = "masking")]
+    targets.push("masking");
+    targets.push("test");
+    targets.push("secrets");
+    #[cfg(feature = "schedule")]
+    targets.push("schedule");
+    #[cfg(feature = "lineage")]
+    targets.push("lineage");
+    #[cfg(feature = "triggers")]
+    targets.push("triggers");
+    #[cfg(feature = "notify")]
+    targets.push("notifications");
+    #[cfg(feature = "catalog")]
+    targets.push("catalog");
+    targets.push("params");
+    targets
+}
+
 /// Execute the `schema` subcommand.
 pub async fn run(args: SchemaArgs) -> CliResult<()> {
-    let schema = match args.target {
+    if args.list {
+        println!("Valid `faucet schema <target>` targets:");
+        for t in schema_targets() {
+            match t {
+                "source" | "sink" | "transform" => println!("  {t} <name>"),
+                _ => println!("  {t}"),
+            }
+        }
+        return Ok(());
+    }
+    let target = args.target.ok_or_else(|| {
+        CliError::Config(
+            "no schema target given — pass one (e.g. `faucet schema source rest`) or \
+             `faucet schema --list` to see them all"
+                .to_owned(),
+        )
+    })?;
+    let schema = match target {
         SchemaTarget::Config => crate::schema_compose::config_schema(),
         SchemaTarget::Source { name } => source_schema(&name)?,
         SchemaTarget::Sink { name } => sink_schema(&name)?,
@@ -130,12 +187,56 @@ mod tests {
         assert!(v["properties"].get("namespace").is_some());
     }
 
+    #[test]
+    fn schema_targets_includes_known_targets() {
+        let targets = super::schema_targets();
+        for known in ["config", "source", "sink", "dlq", "params"] {
+            assert!(
+                targets.contains(&known),
+                "missing target {known}: {targets:?}"
+            );
+        }
+        // No duplicates.
+        let mut sorted = targets.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            targets.len(),
+            "duplicate targets: {targets:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_list_flag_returns_ok() {
+        let r = super::run(SchemaArgs {
+            target: None,
+            list: true,
+        })
+        .await;
+        assert!(r.is_ok(), "{r:?}");
+    }
+
+    #[tokio::test]
+    async fn schema_no_target_without_list_errors() {
+        let r = super::run(SchemaArgs {
+            target: None,
+            list: false,
+        })
+        .await;
+        assert!(
+            r.is_err(),
+            "expected an error when neither target nor --list given"
+        );
+    }
+
     #[tokio::test]
     async fn schema_replication_target_ok() {
         // Covers the `SchemaTarget::Replication` arm — it serializes the
         // ReplicationSpec JSON Schema to stdout and returns Ok.
         let r = super::run(SchemaArgs {
-            target: SchemaTarget::Replication,
+            target: Some(SchemaTarget::Replication),
+            list: false,
         })
         .await;
         assert!(r.is_ok(), "{r:?}");
@@ -144,7 +245,8 @@ mod tests {
     #[tokio::test]
     async fn schema_execution_target_ok() {
         let r = super::run(SchemaArgs {
-            target: SchemaTarget::Execution,
+            target: Some(SchemaTarget::Execution),
+            list: false,
         })
         .await;
         assert!(r.is_ok(), "{r:?}");
@@ -160,7 +262,8 @@ mod tests {
     #[tokio::test]
     async fn schema_sla_target_ok() {
         let r = super::run(SchemaArgs {
-            target: SchemaTarget::Sla,
+            target: Some(SchemaTarget::Sla),
+            list: false,
         })
         .await;
         assert!(r.is_ok(), "{r:?}");
@@ -178,7 +281,8 @@ mod tests {
     #[tokio::test]
     async fn schema_resilience_target_ok() {
         let r = super::run(SchemaArgs {
-            target: SchemaTarget::Resilience,
+            target: Some(SchemaTarget::Resilience),
+            list: false,
         })
         .await;
         assert!(r.is_ok(), "{r:?}");

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -59,12 +59,14 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         let refs = crate::secrets::scan_path_refs_with(&path, args.profile.as_deref(), &inputs)?;
         let cfg =
             PipelineConfig::from_path_async_with(&path, args.profile.as_deref(), &inputs).await?;
-        for (scheme, reference) in &refs {
-            println!("secret: {scheme}:{reference} → resolved");
+        if !args.json {
+            for (scheme, reference) in &refs {
+                println!("secret: {scheme}:{reference} → resolved");
+            }
         }
         cfg
     };
-    if !cfg.params.is_empty() {
+    if !cfg.params.is_empty() && !args.json {
         let required: Vec<&str> = cfg
             .params
             .iter()
@@ -92,6 +94,29 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     if crate::topology::is_topology(&cfg) {
         let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
         let topo = crate::topology::build_topology(&cfg, &auth).await?;
+        let inert: Vec<(&str, &str)> = crate::topology::inert_blocks(&cfg);
+        if args.json {
+            let out = serde_json::json!({
+                "valid": true,
+                "mode": "topology",
+                "name": cfg.name.as_deref().unwrap_or("unnamed"),
+                "node_count": topo.nodes().len(),
+                "edge_count": topo.edges().len(),
+                "nodes": topo.nodes().iter()
+                    .map(|n| serde_json::json!({ "id": n.id, "kind": n.kind.kind_str() }))
+                    .collect::<Vec<_>>(),
+                "warnings": inert.iter()
+                    .map(|(block, consequence)| serde_json::json!({
+                        "block": block, "consequence": consequence,
+                    }))
+                    .collect::<Vec<_>>(),
+            });
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+            );
+            return Ok(());
+        }
         println!(
             "topology '{}': {} node(s), {} edge(s) — valid",
             cfg.name.as_deref().unwrap_or("unnamed"),
@@ -104,7 +129,7 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         // Say what topology mode will *not* do. Printing "valid" while silently
         // ignoring a declared block is how an operator ends up believing a policy
         // is enforced when it is not (#456 M2).
-        for (block, consequence) in crate::topology::inert_blocks(&cfg) {
+        for (block, consequence) in &inert {
             println!("  WARNING: `{block}:` is ignored in topology mode — {consequence}");
         }
         return Ok(());
@@ -126,7 +151,7 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
 
     let nodes = expand(&cfg)?;
 
-    if !unprobed.is_empty() {
+    if !unprobed.is_empty() && !args.json {
         println!(
             "partition: {} row(s) discover their bound at run time ({}) — the chunk count \
              cannot be planned offline, so it is not validated here",
@@ -139,7 +164,9 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     // `faucet validate` catches misconfiguration without running.
     if let Some(spec) = &cfg.replication {
         crate::replication::compiled::CompiledReplication::compile(spec, &cfg)?;
-        println!("replication: mode={:?} — valid", spec.mode);
+        if !args.json {
+            println!("replication: mode={:?} — valid", spec.mode);
+        }
     }
 
     // Validate the backfill defaults block (window / concurrency / timezone)
@@ -153,7 +180,9 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
             .map(|n| n.source.config.to_string())
             .collect();
         spec.validate(&source_configs)?;
-        println!("backfill: defaults valid");
+        if !args.json {
+            println!("backfill: defaults valid");
+        }
     }
 
     // Validate the schedule block (cron / timezone / bounds) so `faucet validate`
@@ -161,10 +190,12 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     #[cfg(feature = "schedule")]
     if let Some(spec) = &cfg.schedule {
         crate::schedule::compiled::CompiledSchedule::compile(spec)?;
-        println!(
-            "schedule: cron '{}' tz '{}' — valid",
-            spec.cron, spec.timezone
-        );
+        if !args.json {
+            println!(
+                "schedule: cron '{}' tz '{}' — valid",
+                spec.cron, spec.timezone
+            );
+        }
     }
 
     // Validate the notifications block (unique names, non-empty channel fields)
@@ -172,13 +203,17 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     #[cfg(feature = "notify")]
     if !cfg.notifications.is_empty() {
         crate::notify::validate_all(&cfg.notifications)?;
-        println!("notifications: {} rule(s) — valid", cfg.notifications.len());
+        if !args.json {
+            println!("notifications: {} rule(s) — valid", cfg.notifications.len());
+        }
     }
 
     // Lineage transport reachability — best-effort. A failure here is only a
     // warning: lineage emission never blocks a pipeline run.
     #[cfg(feature = "lineage")]
-    if let Some(lc) = cfg.lineage.as_ref() {
+    if let Some(lc) = cfg.lineage.as_ref()
+        && !args.json
+    {
         match crate::lineage_glue::check_transport(lc).await {
             Ok(msg) => println!("lineage: {msg}"),
             Err(msg) => println!("lineage: WARNING — {msg} (lineage never blocks a run)"),
@@ -216,6 +251,89 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         .filter(|n| matches!(n.role, NodeRole::Root))
         .count();
     let children = nodes.len() - roots;
+
+    // Runtime row-selection (#370/#371/#376/#377). The selection is computed the
+    // same way `faucet run` computes it, so the run/skip decision here matches
+    // what a run would do; a selection error (empty run set, missing ancestor,
+    // unknown token) is surfaced after the report so `validate` catches it in CI
+    // without a run.
+    let selection = RunSelection::from_args(&args.selection, cfg.selection.as_ref())?;
+    let uses_selection_model = nodes
+        .iter()
+        .any(|n| n.status != SourceStatus::Active || !n.tags.is_empty());
+    let selection_active = selection.narrows() || uses_selection_model;
+    let has_matrix = !cfg.matrix.is_empty();
+    let selected = if selection_active {
+        Some(crate::select::select_nodes(
+            nodes.clone(),
+            &selection,
+            has_matrix,
+        ))
+    } else {
+        None
+    };
+    let run_ids: HashSet<String> = match &selected {
+        Some(Ok(sel)) => sel.iter().map(|n| n.id.clone()).collect(),
+        _ => HashSet::new(),
+    };
+    let decision_for = |node: &crate::expand::ExpandedNode| -> Option<&'static str> {
+        selection_active.then(|| {
+            if run_ids.contains(&node.id) {
+                "run"
+            } else {
+                "skip"
+            }
+        })
+    };
+
+    if args.json {
+        let rows: Vec<serde_json::Value> = nodes
+            .iter()
+            .map(|node| {
+                let (role, parent_id, parent_key) = match &node.role {
+                    NodeRole::Root => ("root", None, None),
+                    NodeRole::Child {
+                        parent_id,
+                        parent_key,
+                    } => ("child", Some(parent_id.clone()), Some(parent_key.clone())),
+                };
+                serde_json::json!({
+                    "id": node.id,
+                    "source": node.source.kind,
+                    "sink": node.sink.kind,
+                    "role": role,
+                    "parent_id": parent_id,
+                    "parent_key": parent_key,
+                    "depends_on": &node.depends_on,
+                    "delivery": node.delivery_guarantee.to_string(),
+                    "status": node.status.as_str(),
+                    "tags": &node.tags,
+                    "decision": decision_for(node),
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "valid": true,
+            "mode": "matrix",
+            "name": cfg.name.as_deref().unwrap_or("(unnamed)"),
+            "row_count": nodes.len(),
+            "roots": roots,
+            "children": children,
+            "selection_active": selection_active,
+            "rows": rows,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+        );
+        // Propagate any selection error after emitting the summary so the exit
+        // code still reflects an invalid selection.
+        if let Some(sel) = selected {
+            sel?;
+        }
+        return Ok(());
+    }
+
     println!(
         "ok: '{}' rows={} (roots={}, children={}) execution={}",
         cfg.name.as_deref().unwrap_or("(unnamed)"),
@@ -235,24 +353,10 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         println!("{}", row_line(node));
     }
 
-    // Runtime row-selection report (#370/#371/#376/#377). Only printed when the
-    // config actually uses the readiness ladder / tags, or a selector was
-    // passed — so a plain config's `validate` output is unchanged. The
-    // selection is computed the same way `faucet run` computes it, so the
-    // run/skip decision here matches what a run would do; a selection error
-    // (empty run set, missing ancestor, unknown token) is surfaced after the
-    // report so `validate` catches it in CI without a run.
-    let selection = RunSelection::from_args(&args.selection, cfg.selection.as_ref())?;
-    let uses_selection_model = nodes
-        .iter()
-        .any(|n| n.status != SourceStatus::Active || !n.tags.is_empty());
-    if selection.narrows() || uses_selection_model {
-        let has_matrix = !cfg.matrix.is_empty();
-        let selected = crate::select::select_nodes(nodes.clone(), &selection, has_matrix);
-        let run_ids: HashSet<String> = match &selected {
-            Ok(sel) => sel.iter().map(|n| n.id.clone()).collect(),
-            Err(_) => HashSet::new(),
-        };
+    // The selection report is only printed when the config actually uses the
+    // readiness ladder / tags, or a selector was passed — so a plain config's
+    // `validate` output is unchanged.
+    if selection_active {
         println!(
             "run selection (include_parents={}):",
             selection.include_parents.as_str()
@@ -278,7 +382,9 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         }
         // Propagate any selection error (empty run set / missing ancestor /
         // unknown token) now that the report has been printed.
-        selected?;
+        if let Some(sel) = selected {
+            sel?;
+        }
     }
     Ok(())
 }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -1631,9 +1631,9 @@ mod tests {
         )
         .await
         .expect("csv source should build without I/O");
-        // The CSV source uses the default `connector_name()` (stripped type
-        // name) rather than overriding it with a friendly label.
-        assert_eq!(src.connector_name(), "CsvSource");
+        // The CSV source overrides `connector_name()` with its friendly,
+        // YAML-`type`-matching label (#61).
+        assert_eq!(src.connector_name(), "csv");
     }
 
     // The JSONL sink's `new()` is also pure (it opens the file lazily on first
@@ -1658,9 +1658,9 @@ mod tests {
         let sink = build_sink("stdout", serde_json::json!({}), &AuthCatalog::new())
             .await
             .expect("stdout sink should build without I/O");
-        // The stdout sink uses the default `connector_name()` (stripped type
-        // name) rather than overriding it with a friendly label.
-        assert_eq!(sink.connector_name(), "StdoutSink");
+        // The stdout sink overrides `connector_name()` with its friendly,
+        // YAML-`type`-matching label (#61).
+        assert_eq!(sink.connector_name(), "stdout");
     }
 
     // Exercise the Delta source+sink registry arms end to end: build both via

--- a/cli/src/topology.rs
+++ b/cli/src/topology.rs
@@ -1117,6 +1117,28 @@ pipeline:
         assert!(inert_blocks(&c).is_empty());
     }
 
+    /// `is_topology` is the load-bearing predicate that branches run/validate/
+    /// preview between matrix mode and topology mode: a non-empty `pipeline.nodes`
+    /// selects topology mode, its absence keeps matrix mode.
+    #[test]
+    fn is_topology_true_only_with_nodes() {
+        assert!(
+            is_topology(&cfg(LINEAR)),
+            "a config with nodes is topology mode"
+        );
+
+        let matrix = cfg(r#"version: 1
+name: p
+pipeline:
+  source: { type: csv, config: { path: /tmp/a.csv } }
+  sink:   { type: jsonl, config: { path: /tmp/o.jsonl } }
+"#);
+        assert!(
+            !is_topology(&matrix),
+            "a plain source/sink config is matrix mode, not topology"
+        );
+    }
+
     /// Kind precedence: an inline `type` on the node wins over its template, so
     /// the exactly-once gate classifies the connector the run will actually build.
     #[test]

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -1433,6 +1433,93 @@ fn list_json_emits_structured_listing() {
 }
 
 #[test]
+fn list_available_human_and_json() {
+    // Human path: the registry index renders with the header + the compiled
+    // marker legend.
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["list", "--available"])
+        .assert()
+        .success()
+        .stdout(contains("Registry connectors"));
+
+    // JSON path: a `connectors` array whose entries carry kind/name/compiled.
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["list", "--available", "--json"])
+        .assert()
+        .success();
+    let out: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid JSON output");
+    let rows = out["connectors"].as_array().expect("connectors array");
+    assert!(!rows.is_empty(), "registry index should list connectors");
+    let first = &rows[0];
+    for key in ["kind", "name", "description", "compiled"] {
+        assert!(
+            first.get(key).is_some(),
+            "connector entry missing `{key}`: {first}"
+        );
+    }
+    assert!(
+        first["compiled"].is_boolean(),
+        "`compiled` should be a bool"
+    );
+    // `rest` is a built-in source and is compiled into this binary.
+    let rest = rows
+        .iter()
+        .find(|c| c["kind"] == "source" && c["name"] == "rest")
+        .expect("rest source in the registry index");
+    assert_eq!(rest["compiled"], true, "rest should be marked compiled");
+}
+
+#[test]
+fn validate_json_topology_mode() {
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("topo.yaml");
+    // A minimal linear topology (source node → sink node) exercises the
+    // topology-mode `--json` branch of `faucet validate`.
+    fs::write(
+        &cfg,
+        r#"version: 1
+name: topo_smoke
+pipeline:
+  sources:
+    a: { type: csv, config: { path: ./in.csv } }
+  sinks:
+    o: { type: jsonl, config: { path: ./out.jsonl } }
+  nodes:
+    s: { kind: source, ref: a }
+    w: { kind: sink, ref: o }
+  edges:
+    - { from: s, to: w }
+"#,
+    )
+    .unwrap();
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate", cfg.to_str().unwrap(), "--json"])
+        .assert()
+        .success();
+    let out: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid JSON output");
+    assert_eq!(out["valid"], true);
+    assert_eq!(out["mode"], "topology");
+    assert_eq!(out["name"], "topo_smoke");
+    assert_eq!(out["node_count"], 2);
+    assert_eq!(out["edge_count"], 1);
+    let node_ids: Vec<&str> = out["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_str().unwrap())
+        .collect();
+    assert!(
+        node_ids.contains(&"s") && node_ids.contains(&"w"),
+        "nodes: {node_ids:?}"
+    );
+}
+
+#[test]
 fn schema_list_enumerates_targets() {
     let assert = Command::cargo_bin("faucet")
         .unwrap()

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -1404,3 +1404,71 @@ fn schema_contract_prints_contract_spec_schema() {
     assert!(schema["properties"].get("fields").is_some());
     assert!(schema["properties"].get("on_breach").is_some());
 }
+
+#[test]
+fn list_json_emits_structured_listing() {
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["list", "--json"])
+        .assert()
+        .success();
+    let out: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid JSON output");
+    let source_names: Vec<&str> = out["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
+    let sink_names: Vec<&str> = out["sinks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
+    assert!(source_names.contains(&"rest"), "sources: {source_names:?}");
+    assert!(sink_names.contains(&"jsonl"), "sinks: {sink_names:?}");
+    assert!(out["transforms"].is_array());
+    assert!(out["state_stores"].is_array());
+}
+
+#[test]
+fn schema_list_enumerates_targets() {
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["schema", "--list"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("source"), "{stdout}");
+    assert!(stdout.contains("sink"), "{stdout}");
+    assert!(stdout.contains("dlq"), "{stdout}");
+}
+
+#[test]
+fn validate_json_emits_summary() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    // `validate` is offline, so the CSV need not exist; still write it so the
+    // config is fully realistic.
+    fs::write(&csv, "id\n1\n").unwrap();
+    let cfg = dir.path().join("faucet.yaml");
+    fs::write(&cfg, csv_to_jsonl_yaml(&csv, &out)).unwrap();
+
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate", cfg.to_str().unwrap(), "--json"])
+        .assert()
+        .success();
+    let summary: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid JSON output");
+    assert_eq!(summary["valid"], true);
+    assert_eq!(summary["name"], "csv_to_jsonl_smoke");
+    assert_eq!(summary["row_count"], 1);
+    let rows = summary["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["source"], "csv");
+    assert_eq!(rows[0]["sink"], "jsonl");
+    assert_eq!(rows[0]["role"], "root");
+}

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -161,3 +161,78 @@ impl RunStreamOptions {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RunStreamOptions;
+    use crate::idempotency::{DeliveryMode, ReplayGuarantee};
+    use crate::state::MemoryStateStore;
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn default_is_empty_at_least_once() {
+        let o = RunStreamOptions::new();
+        assert!(o.pipeline_name.is_none());
+        assert!(o.row.is_none());
+        assert!(o.run_id.is_none());
+        assert!(o.state_store.is_none());
+        assert!(o.state_key.is_none());
+        assert!(o.cancel.is_none());
+        assert_eq!(o.delivery, DeliveryMode::AtLeastOnce);
+        assert_eq!(o.start_seq, 0);
+        assert!(o.replay.is_none());
+        assert!(o.resilience.is_none());
+    }
+
+    #[test]
+    fn each_builder_sets_only_its_own_field() {
+        let o = RunStreamOptions::new().with_name("p");
+        assert_eq!(o.pipeline_name.as_deref(), Some("p"));
+        assert!(o.row.is_none(), "with_name must not touch row");
+
+        let o = RunStreamOptions::new().with_row("r1");
+        assert_eq!(o.row.as_deref(), Some("r1"));
+        assert!(o.pipeline_name.is_none());
+
+        let o = RunStreamOptions::new().with_run_id("run-42");
+        assert_eq!(o.run_id.as_deref(), Some("run-42"));
+
+        let o = RunStreamOptions::new().with_state(Arc::new(MemoryStateStore::new()), "k");
+        assert!(o.state_store.is_some());
+        assert_eq!(o.state_key.as_deref(), Some("k"));
+
+        let o = RunStreamOptions::new().with_cancel(CancellationToken::new());
+        assert!(o.cancel.is_some());
+
+        let o = RunStreamOptions::new().with_delivery(DeliveryMode::ExactlyOnce);
+        assert_eq!(o.delivery, DeliveryMode::ExactlyOnce);
+
+        let o = RunStreamOptions::new().with_start_seq(7);
+        assert_eq!(o.start_seq, 7);
+
+        let o = RunStreamOptions::new().with_replay_guarantee(ReplayGuarantee::Deterministic);
+        assert_eq!(o.replay, Some(ReplayGuarantee::Deterministic));
+
+        let o = RunStreamOptions::new().with_resilience(Default::default());
+        assert!(o.resilience.is_some());
+    }
+
+    #[test]
+    fn chaining_composes_all_set_fields() {
+        let o = RunStreamOptions::new()
+            .with_name("pipe")
+            .with_row("row0")
+            .with_run_id("rid")
+            .with_state(Arc::new(MemoryStateStore::new()), "state-key")
+            .with_delivery(DeliveryMode::ExactlyOnce)
+            .with_start_seq(3);
+        assert_eq!(o.pipeline_name.as_deref(), Some("pipe"));
+        assert_eq!(o.row.as_deref(), Some("row0"));
+        assert_eq!(o.run_id.as_deref(), Some("rid"));
+        assert!(o.state_store.is_some());
+        assert_eq!(o.state_key.as_deref(), Some("state-key"));
+        assert_eq!(o.delivery, DeliveryMode::ExactlyOnce);
+        assert_eq!(o.start_seq, 3);
+    }
+}

--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -7,7 +7,7 @@
 
 CSV / TSV file sink for the [faucet-stream](https://github.com/faucet-hq/faucet-stream) ecosystem. Writes JSON records to a delimited text file — comma, tab, semicolon, pipe, or any other single-byte delimiter — with an optional header row and RFC 4180 quoting handled automatically.
 
-Reach for it whenever the destination is a spreadsheet, a BI import, a data-exchange handoff, or anything that consumes plain delimited text. All file I/O runs inside `tokio::task::spawn_blocking` and flows through a buffered `csv::Writer`, so it stays off the async runtime and doesn't bottleneck on per-record syscalls.
+Reach for it whenever the destination is a spreadsheet, a BI import, a data-exchange handoff, or anything that consumes plain delimited text. All file I/O runs inside `tokio::task::spawn_blocking` and flows through a buffered `csv::Writer`, so it stays off the async runtime and doesn't bottleneck on per-record syscalls. This connector reports metrics under the observability label `connector="csv"`.
 
 ## Feature highlights
 

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -86,6 +86,10 @@ impl CsvSink {
 
 #[async_trait]
 impl faucet_core::Sink for CsvSink {
+    fn connector_name(&self) -> &'static str {
+        "csv"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(CsvSinkConfig)).expect("schema serialization")
     }

--- a/crates/sink/csv/tests/conformance.rs
+++ b/crates/sink/csv/tests/conformance.rs
@@ -34,6 +34,7 @@ fn conformance_connector_name_nonempty() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "csv");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/crates/sink/gcs/src/config.rs
+++ b/crates/sink/gcs/src/config.rs
@@ -133,6 +133,20 @@ impl GcsSinkConfig {
         self.compression = c;
         self
     }
+
+    /// Validate the config at construction time. Rejects an empty `bucket`
+    /// (a typo or an unset `${env:…}`) with a typed `FaucetError::Config`
+    /// rather than letting it surface as an opaque cloud-API failure on the
+    /// first upload, and validates `batch_size`.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        if self.bucket.trim().is_empty() {
+            return Err(faucet_core::FaucetError::Config(
+                "GCS sink `bucket` must not be empty".to_owned(),
+            ));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -150,6 +164,22 @@ mod tests {
         assert_eq!(c.concurrency, 10);
         assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
         assert!(c.storage_host.is_none());
+    }
+
+    #[test]
+    fn validate_accepts_a_normal_config() {
+        assert!(GcsSinkConfig::new("b").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_bucket() {
+        for bucket in ["", "   "] {
+            let err = GcsSinkConfig::new(bucket).validate().unwrap_err();
+            assert!(
+                matches!(err, faucet_core::FaucetError::Config(msg) if msg.contains("bucket")),
+                "expected a Config error naming `bucket` for {bucket:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/sink/gcs/src/sink.rs
+++ b/crates/sink/gcs/src/sink.rs
@@ -19,7 +19,7 @@ pub struct GcsSink {
 
 impl GcsSink {
     pub async fn new(config: GcsSinkConfig) -> Result<Self, FaucetError> {
-        faucet_core::validate_batch_size(config.batch_size)?;
+        config.validate()?;
         let storage = build_storage(&config.auth, config.storage_host.as_deref()).await?;
         Ok(Self { config, storage })
     }

--- a/crates/sink/http/README.md
+++ b/crates/sink/http/README.md
@@ -7,7 +7,7 @@
 
 HTTP POST sink connector for the [faucet-stream](https://github.com/faucet-hq/faucet-stream) ecosystem. Sends JSON records to any HTTP(S) endpoint — a webhook, an ingest API, a serverless function, another faucet pipeline's webhook source.
 
-Reach for it when the destination speaks HTTP but isn't one of the first-class warehouse/database/queue sinks: a SaaS ingest endpoint, an internal microservice, a Lambda/Cloud Function URL, or a fan-out webhook. It reuses a single `reqwest::Client`, sends records concurrently, and retries transient failures so it stays fast and resilient under load.
+Reach for it when the destination speaks HTTP but isn't one of the first-class warehouse/database/queue sinks: a SaaS ingest endpoint, an internal microservice, a Lambda/Cloud Function URL, or a fan-out webhook. It reuses a single `reqwest::Client`, sends records concurrently, and retries transient failures so it stays fast and resilient under load. This connector reports metrics under the observability label `connector="http"`.
 
 ## Feature highlights
 

--- a/crates/sink/http/src/sink.rs
+++ b/crates/sink/http/src/sink.rs
@@ -164,6 +164,10 @@ impl HttpSink {
 
 #[async_trait]
 impl faucet_core::Sink for HttpSink {
+    fn connector_name(&self) -> &'static str {
+        "http"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(HttpSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/http/tests/conformance.rs
+++ b/crates/sink/http/tests/conformance.rs
@@ -28,6 +28,7 @@ fn conformance_connector_name_nonempty() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "http");
 }
 
 #[tokio::test]

--- a/crates/sink/kafka/README.md
+++ b/crates/sink/kafka/README.md
@@ -7,7 +7,7 @@
 
 Apache **Kafka** producer sink for the [faucet-stream](https://github.com/faucet-hq/faucet-stream) ecosystem. Publishes each record to one or more Kafka topics over [`rdkafka`](https://crates.io/crates/rdkafka)'s `FutureProducer`, with an idempotent producer, configurable compression, per-record topic/key/partition/header routing, and `QueueFull` retry.
 
-Reach for it when you want to land any faucet-stream source — a REST API, a database, a CDC stream, a file — onto Kafka with one declarative config and no glue code. Sends inside each batch fly concurrently through a `FuturesUnordered` window, so a single pipeline saturates the producer instead of round-tripping one message at a time.
+Reach for it when you want to land any faucet-stream source — a REST API, a database, a CDC stream, a file — onto Kafka with one declarative config and no glue code. Sends inside each batch fly concurrently through a `FuturesUnordered` window, so a single pipeline saturates the producer instead of round-tripping one message at a time. This connector reports metrics under the observability label `connector="kafka"`.
 
 ## Feature highlights
 

--- a/crates/sink/kafka/src/encode.rs
+++ b/crates/sink/kafka/src/encode.rs
@@ -44,7 +44,11 @@ pub async fn encode(
         #[cfg(feature = "schema-registry")]
         KafkaValueFormat::ConfluentAvro { .. } => {
             let client = sr_client.ok_or_else(|| {
-                FaucetError::Config("ConfluentAvro selected but no SchemaRegistryClient".into())
+                FaucetError::Config(
+                    "value format 'confluent_avro' requires a Schema Registry client — set \
+                     `schema_registry.url` (and any auth) in the Kafka sink config"
+                        .into(),
+                )
             })?;
             let schema_text = schema_ctx
                 .schema_text
@@ -55,7 +59,11 @@ pub async fn encode(
         #[cfg(feature = "schema-registry")]
         KafkaValueFormat::ConfluentProtobuf { .. } => {
             let client = sr_client.ok_or_else(|| {
-                FaucetError::Config("ConfluentProtobuf selected but no SchemaRegistryClient".into())
+                FaucetError::Config(
+                    "value format 'confluent_protobuf' requires a Schema Registry client — set \
+                     `schema_registry.url` (and any auth) in the Kafka sink config"
+                        .into(),
+                )
             })?;
             let schema_text = schema_ctx.schema_text.as_deref().ok_or_else(|| {
                 FaucetError::Config("ConfluentProtobuf requires schema_text".into())
@@ -66,7 +74,9 @@ pub async fn encode(
         KafkaValueFormat::ConfluentJsonSchema { .. } => {
             let client = sr_client.ok_or_else(|| {
                 FaucetError::Config(
-                    "ConfluentJsonSchema selected but no SchemaRegistryClient".into(),
+                    "value format 'confluent_json_schema' requires a Schema Registry client — set \
+                     `schema_registry.url` (and any auth) in the Kafka sink config"
+                        .into(),
                 )
             })?;
             let schema_text = schema_ctx.schema_text.as_deref().ok_or_else(|| {
@@ -201,8 +211,9 @@ mod tests {
             .await
             .unwrap_err();
             match err {
+                // The message now names the wire format and the fix (#431).
                 FaucetError::Config(msg) => assert!(
-                    msg.contains("ConfluentAvro") && msg.contains("no SchemaRegistryClient"),
+                    msg.contains("confluent_avro") && msg.contains("schema_registry.url"),
                     "unexpected message: {msg}"
                 ),
                 other => panic!("expected Config error, got {other:?}"),
@@ -221,7 +232,7 @@ mod tests {
             .unwrap_err();
             match err {
                 FaucetError::Config(msg) => assert!(
-                    msg.contains("ConfluentProtobuf") && msg.contains("no SchemaRegistryClient"),
+                    msg.contains("confluent_protobuf") && msg.contains("schema_registry.url"),
                     "unexpected message: {msg}"
                 ),
                 other => panic!("expected Config error, got {other:?}"),
@@ -240,7 +251,7 @@ mod tests {
             .unwrap_err();
             match err {
                 FaucetError::Config(msg) => assert!(
-                    msg.contains("ConfluentJsonSchema") && msg.contains("no SchemaRegistryClient"),
+                    msg.contains("confluent_json_schema") && msg.contains("schema_registry.url"),
                     "unexpected message: {msg}"
                 ),
                 other => panic!("expected Config error, got {other:?}"),

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -434,6 +434,10 @@ impl Sink for KafkaSink {
         Ok(produced)
     }
 
+    fn connector_name(&self) -> &'static str {
+        "kafka"
+    }
+
     fn config_schema(&self) -> Value {
         let schema = schemars::schema_for!(KafkaSinkConfig);
         serde_json::to_value(&schema).unwrap_or(Value::Null)

--- a/crates/sink/kafka/tests/conformance.rs
+++ b/crates/sink/kafka/tests/conformance.rs
@@ -147,6 +147,7 @@ mod idempotent {
             sink.connector_name(),
             sink.connector_name(),
         );
+        assert_eq!(sink.connector_name(), "kafka");
         // Check 11: preflight check() is well-formed against the live broker
         // (`fetch_metadata` → a Pass probe inside Ok(report); nothing produced).
         faucet_conformance::assert_sink_preflight_check_wellformed(

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -297,6 +297,8 @@ println!("Transferred {} records", result.records_written);
 
 `mongodb://<host>:<port>/<database>/<collection>` (credentials stripped) — e.g. `mongodb://host:27017/analytics/events`.
 
+This connector reports observability metrics under the label `connector="mongodb"`.
+
 ## Feature flags
 
 This crate has no optional features of its own; enable it in the CLI / umbrella via the `sink-mongodb` feature.

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -638,6 +638,10 @@ impl MongoSink {
 
 #[async_trait]
 impl faucet_core::Sink for MongoSink {
+    fn connector_name(&self) -> &'static str {
+        "mongodb"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MongoSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/mongodb/tests/conformance.rs
+++ b/crates/sink/mongodb/tests/conformance.rs
@@ -39,6 +39,7 @@ async fn conformance_connector_name_nonempty() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "mongodb");
 }
 
 mod idempotent {

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -374,6 +374,8 @@ Drive it end-to-end via `Pipeline::new(source, sink).run()`.
 
 `mysql://<host>:<port>/<db>?table=<table>` (credentials stripped) — e.g. `mysql://host:3306/app?table=orders`.
 
+This connector reports observability metrics under the label `connector="mysql"`.
+
 ## Feature flags
 
 This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-mysql` feature.

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -927,6 +927,10 @@ impl MysqlSink {
 
 #[async_trait]
 impl faucet_core::Sink for MysqlSink {
+    fn connector_name(&self) -> &'static str {
+        "mysql"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MysqlSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/mysql/tests/conformance.rs
+++ b/crates/sink/mysql/tests/conformance.rs
@@ -102,6 +102,7 @@ async fn conformance_idempotent_replay() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "mysql");
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }

--- a/crates/sink/parquet/README.md
+++ b/crates/sink/parquet/README.md
@@ -295,6 +295,8 @@ Files produced by this sink are standard Apache Parquet and read back with any P
 
 `file://<path>` (local) or `s3://<bucket>/<prefix>` (S3) — e.g. `file:///tmp/output/` or `s3://my-bucket/data/`.
 
+This connector reports observability metrics under the label `connector="parquet"`.
+
 ## Feature flags
 
 This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-parquet` feature.

--- a/crates/sink/parquet/src/sink.rs
+++ b/crates/sink/parquet/src/sink.rs
@@ -458,6 +458,10 @@ where
 
 #[async_trait]
 impl faucet_core::Sink for ParquetSink {
+    fn connector_name(&self) -> &'static str {
+        "parquet"
+    }
+
     fn config_schema(&self) -> Value {
         serde_json::to_value(faucet_core::schema_for!(ParquetSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/parquet/tests/conformance.rs
+++ b/crates/sink/parquet/tests/conformance.rs
@@ -61,6 +61,7 @@ async fn conformance_connector_name_nonempty() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "parquet");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -193,6 +193,8 @@ The sink re-chunks each incoming `StreamPage` so individual multi-row `INSERT` s
 
 `batch_size` is purely a chunk-size knob — connection pooling, identifier quoting, and JSONB vs AutoMap behaviour are unchanged.
 
+This connector reports observability metrics under the label `connector="postgres"`.
+
 ## Bulk load (`write_method: copy`)
 
 For **append-mode bulk loads**, set `write_method: copy` to ship rows via

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -740,6 +740,10 @@ impl PostgresSink {
 
 #[async_trait]
 impl faucet_core::Sink for PostgresSink {
+    fn connector_name(&self) -> &'static str {
+        "postgres"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(PostgresSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/postgres/tests/conformance.rs
+++ b/crates/sink/postgres/tests/conformance.rs
@@ -88,6 +88,7 @@ async fn conformance_idempotent_replay() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "postgres");
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }

--- a/crates/sink/redis/README.md
+++ b/crates/sink/redis/README.md
@@ -188,6 +188,8 @@ The sink follows the workspace streaming contract: `Pipeline::run` drives the so
 
 This sink writes **append/insert-only** (`RPUSH` / `XADD` / `SET`) and does not implement upsert/delete write modes — see [Limitations](#limitations). It **does** support effectively-once delivery — see the next section.
 
+This connector reports observability metrics under the label `connector="redis"`.
+
 ## Effectively-once delivery
 
 `RedisSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:

--- a/crates/sink/redis/src/sink.rs
+++ b/crates/sink/redis/src/sink.rs
@@ -34,6 +34,10 @@ impl RedisSink {
 
 #[async_trait]
 impl faucet_core::Sink for RedisSink {
+    fn connector_name(&self) -> &'static str {
+        "redis"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(RedisSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/redis/tests/conformance.rs
+++ b/crates/sink/redis/tests/conformance.rs
@@ -96,6 +96,7 @@ mod idempotent {
             sink.connector_name(),
             sink.connector_name(),
         );
+        assert_eq!(sink.connector_name(), "redis");
         // Check 11: preflight check() is well-formed against the live server
         // (Redis `PING` → a Pass probe inside Ok(report); nothing written).
         faucet_conformance::assert_sink_preflight_check_wellformed(

--- a/crates/sink/s3/README.md
+++ b/crates/sink/s3/README.md
@@ -173,6 +173,8 @@ The pipeline calls `Sink::write_batch` once per upstream page. Inside a call, `b
 
 **Recommended: `batch_size: 0`.** S3 is the canonical case where one large object beats many small ones — per-request overhead, slower downstream scans, and LIST/PUT cost all compound with tiny objects. Most sources already size each page via their own `batch_size` (REST page, sqlx cursor chunk, Kafka poll, …), so let that drive object sizing.
 
+This connector reports observability metrics under the label `connector="s3"`.
+
 > **Memory ceiling.** Each object's body is buffered fully in memory before a single-shot `PutObject` (and, with compression on, briefly held as both raw and compressed). Up to `concurrency` objects upload at once, so peak memory is roughly **`concurrency` × object-size × ~2**. Pair `batch_size: 0` with a *streaming* source that sizes its own pages, or cap memory via `max_records_per_file` / lower `concurrency`. Streaming multipart upload for very large objects is a future enhancement.
 
 ## Arrow columnar (Parquet) mode

--- a/crates/sink/s3/src/config.rs
+++ b/crates/sink/s3/src/config.rs
@@ -158,6 +158,20 @@ impl S3SinkConfig {
         self.compression = c;
         self
     }
+
+    /// Validate the config at construction time. Rejects an empty `bucket`
+    /// (a typo or an unset `${env:…}`) with a typed `FaucetError::Config`
+    /// rather than letting it surface as an opaque cloud-API failure on the
+    /// first upload, and validates `batch_size`.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        if self.bucket.trim().is_empty() {
+            return Err(faucet_core::FaucetError::Config(
+                "S3 sink `bucket` must not be empty".to_owned(),
+            ));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -199,6 +213,22 @@ mod tests {
     fn batch_size_defaults_to_default_batch_size() {
         let config = S3SinkConfig::new("my-bucket");
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn validate_accepts_a_normal_config() {
+        assert!(S3SinkConfig::new("my-bucket").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_bucket() {
+        for bucket in ["", "   "] {
+            let err = S3SinkConfig::new(bucket).validate().unwrap_err();
+            assert!(
+                matches!(err, faucet_core::FaucetError::Config(msg) if msg.contains("bucket")),
+                "expected a Config error naming `bucket` for {bucket:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/sink/s3/src/sink.rs
+++ b/crates/sink/s3/src/sink.rs
@@ -21,7 +21,7 @@ impl S3Sink {
     ///
     /// Builds the S3 client eagerly so it is reused across calls.
     pub async fn new(config: S3SinkConfig) -> Result<Self, FaucetError> {
-        faucet_core::validate_batch_size(config.batch_size)?;
+        config.validate()?;
         let client = Self::build_client(&config).await?;
         Ok(Self { config, client })
     }
@@ -132,6 +132,10 @@ impl S3Sink {
 
 #[async_trait]
 impl faucet_core::Sink for S3Sink {
+    fn connector_name(&self) -> &'static str {
+        "s3"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(S3SinkConfig)).expect("schema serialization")
     }

--- a/crates/sink/s3/tests/conformance.rs
+++ b/crates/sink/s3/tests/conformance.rs
@@ -99,6 +99,7 @@ async fn conformance_connector_name_nonempty() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "s3");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/sink/snowflake/README.md
+++ b/crates/sink/snowflake/README.md
@@ -313,6 +313,8 @@ To drive it end-to-end, pair it with any source via `Pipeline::new(source, sink)
 
 `snowflake://<account>/<database>/<schema>?table=<table>` — e.g. `snowflake://xy12345.us-east-1/ANALYTICS_DB/PUBLIC?table=events`.
 
+This connector reports metrics under the label `connector="snowflake"`.
+
 ## Feature flags
 
 This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-snowflake` feature.

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -409,6 +409,10 @@ impl SnowflakeSink {
 
 #[async_trait]
 impl faucet_core::Sink for SnowflakeSink {
+    fn connector_name(&self) -> &'static str {
+        "snowflake"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(SnowflakeSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/snowflake/tests/conformance.rs
+++ b/crates/sink/snowflake/tests/conformance.rs
@@ -23,4 +23,5 @@ fn conformance_connector_name_nonempty() {
     ))
     .expect("sink builds lazily");
     assert_connector_name_nonempty_value(sink.connector_name(), sink.connector_name());
+    assert_eq!(sink.connector_name(), "snowflake");
 }

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -370,6 +370,8 @@ let sink = SqliteSink::new(config).await?;
 
 `sqlite://<path>?table=<table>` — e.g. `sqlite:///tmp/test.db?table=events`.
 
+This connector reports metrics under the label `connector="sqlite"`.
+
 ## Feature flags
 
 This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-sqlite` feature.

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -748,6 +748,10 @@ impl SqliteSink {
 
 #[async_trait]
 impl faucet_core::Sink for SqliteSink {
+    fn connector_name(&self) -> &'static str {
+        "sqlite"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(SqliteSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/sqlite/tests/conformance.rs
+++ b/crates/sink/sqlite/tests/conformance.rs
@@ -98,6 +98,7 @@ async fn conformance_idempotent_replay() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "sqlite");
     faucet_conformance::assert_idempotent_replay(&sink, || {
         let url = url.clone();
         async move { count_rows(&url).await }

--- a/crates/sink/stdout/README.md
+++ b/crates/sink/stdout/README.md
@@ -198,6 +198,8 @@ sink.flush().await?;
 
 `stdout://` or `stderr://`, depending on the configured destination.
 
+This connector reports metrics under the label `connector="stdout"`.
+
 ## Feature flags
 
 This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-stdout` feature.

--- a/crates/sink/stdout/src/sink.rs
+++ b/crates/sink/stdout/src/sink.rs
@@ -136,6 +136,10 @@ fn csv_cell(value: &Value) -> Result<String, FaucetError> {
 
 #[async_trait]
 impl faucet_core::Sink for StdoutSink {
+    fn connector_name(&self) -> &'static str {
+        "stdout"
+    }
+
     fn config_schema(&self) -> Value {
         serde_json::to_value(faucet_core::schema_for!(StdoutSinkConfig))
             .expect("schema serialization")

--- a/crates/sink/stdout/tests/conformance.rs
+++ b/crates/sink/stdout/tests/conformance.rs
@@ -70,6 +70,7 @@ fn conformance_connector_name_nonempty() {
         sink.connector_name(),
         sink.connector_name(),
     );
+    assert_eq!(sink.connector_name(), "stdout");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/crates/source/csv/README.md
+++ b/crates/source/csv/README.md
@@ -286,3 +286,7 @@ The connector itself is enabled in the CLI/umbrella via the `source-csv` feature
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="csv"`.

--- a/crates/source/csv/src/stream.rs
+++ b/crates/source/csv/src/stream.rs
@@ -220,6 +220,10 @@ impl faucet_core::Source for CsvSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "csv"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(CsvSourceConfig))
             .expect("schema serialization")

--- a/crates/source/csv/tests/conformance.rs
+++ b/crates/source/csv/tests/conformance.rs
@@ -6,6 +6,7 @@
 
 use std::io::Write;
 
+use faucet_core::Source;
 use faucet_source_csv::{CsvSource, CsvSourceConfig};
 
 /// Write a small CSV with `total` `(id, name)` rows and return the temp file.
@@ -30,6 +31,7 @@ fn conformance_config_schema_valid() {
 fn conformance_connector_name_nonempty() {
     let source = CsvSource::new(CsvSourceConfig::new("/tmp/does-not-matter.csv"));
     faucet_conformance::assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "csv");
 }
 
 // ── Check 9: batch_size=0 yields a single page ────────────────────────────────

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -338,3 +338,7 @@ This crate has no optional features of its own; enable it in the CLI/umbrella vi
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="elasticsearch"`.

--- a/crates/source/elasticsearch/src/stream.rs
+++ b/crates/source/elasticsearch/src/stream.rs
@@ -396,6 +396,10 @@ impl faucet_core::Source for ElasticsearchSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "elasticsearch"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(ElasticsearchSourceConfig))
             .expect("schema serialization")

--- a/crates/source/elasticsearch/tests/conformance.rs
+++ b/crates/source/elasticsearch/tests/conformance.rs
@@ -18,6 +18,7 @@ use faucet_conformance::{
     assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
     assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
+use faucet_core::Source;
 use faucet_source_elasticsearch::{ElasticsearchSource, ElasticsearchSourceConfig};
 use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
@@ -202,6 +203,7 @@ async fn conformance_errors_not_panics() {
 #[test]
 fn conformance_connector_name_nonempty() {
     assert_connector_name_nonempty(&unreachable_source());
+    assert_eq!(unreachable_source().connector_name(), "elasticsearch");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -334,3 +334,7 @@ This crate has no optional features of its own; enable it in the CLI/umbrella vi
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="graphql"`.

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -471,6 +471,10 @@ impl faucet_core::Source for GraphqlStream {
         self.stream_pages_inner(context)
     }
 
+    fn connector_name(&self) -> &'static str {
+        "graphql"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(GraphqlStreamConfig))
             .expect("schema serialization")

--- a/crates/source/graphql/tests/conformance.rs
+++ b/crates/source/graphql/tests/conformance.rs
@@ -9,6 +9,7 @@ use faucet_conformance::{
     assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
     assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
+use faucet_core::Source;
 use faucet_source_graphql::config::GraphqlPagination;
 use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
 use serde_json::{Value, json};
@@ -168,6 +169,7 @@ async fn conformance_batch_size_zero_single_page() {
 #[test]
 fn conformance_connector_name_nonempty() {
     assert_connector_name_nonempty(&unreachable_source());
+    assert_eq!(unreachable_source().connector_name(), "graphql");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -380,3 +380,7 @@ This crate has no optional features of its own. Enable it in the CLI/umbrella vi
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="grpc"`.

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -487,6 +487,10 @@ impl faucet_core::Source for GrpcStream {
         }
     }
 
+    fn connector_name(&self) -> &'static str {
+        "grpc"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(GrpcStreamConfig))
             .expect("schema serialization")

--- a/crates/source/grpc/tests/conformance.rs
+++ b/crates/source/grpc/tests/conformance.rs
@@ -17,6 +17,7 @@ use faucet_conformance::{
     assert_bounded_memory, assert_config_schema_valid_value, assert_connector_name_nonempty,
     assert_errors_not_panics, assert_preflight_check_wellformed,
 };
+use faucet_core::Source;
 use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, RpcKind};
 use serde_json::json;
 
@@ -84,6 +85,7 @@ async fn conformance_errors_not_panics() {
 #[test]
 fn conformance_connector_name_nonempty() {
     assert_connector_name_nonempty(&unreachable_source());
+    assert_eq!(unreachable_source().connector_name(), "grpc");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/crates/source/mongodb/README.md
+++ b/crates/source/mongodb/README.md
@@ -372,3 +372,7 @@ This crate has no optional features of its own. Enable it in the CLI / umbrella 
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="mongodb"`.

--- a/crates/source/mongodb/src/stream.rs
+++ b/crates/source/mongodb/src/stream.rs
@@ -258,6 +258,10 @@ impl faucet_core::Source for MongoSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "mongodb"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MongoSourceConfig))
             .expect("schema serialization")

--- a/crates/source/mongodb/tests/conformance.rs
+++ b/crates/source/mongodb/tests/conformance.rs
@@ -7,6 +7,7 @@
 //! path verbatim.
 
 use faucet_conformance::{assert_config_schema_valid_value, assert_connector_name_nonempty};
+use faucet_core::Source;
 use faucet_source_mongodb::{MongoSource, MongoSourceConfig};
 use mongodb::Client;
 use mongodb::bson::{Document, doc};
@@ -128,6 +129,7 @@ async fn conformance_errors_not_panics() {
 
     // Check 10: connector_name is non-empty (pure — runs offline, no Docker).
     assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "mongodb");
 
     faucet_conformance::assert_errors_not_panics(&source).await;
 }

--- a/crates/source/mysql/README.md
+++ b/crates/source/mysql/README.md
@@ -379,3 +379,7 @@ Outside the cluster coordinator the `shard` config has **no effect** — a plain
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="mysql"`.

--- a/crates/source/mysql/src/stream.rs
+++ b/crates/source/mysql/src/stream.rs
@@ -361,6 +361,10 @@ impl faucet_core::Source for MysqlSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "mysql"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MysqlSourceConfig))
             .expect("schema serialization")

--- a/crates/source/mysql/tests/conformance.rs
+++ b/crates/source/mysql/tests/conformance.rs
@@ -5,6 +5,7 @@
 //! requires Docker — it runs in CI alongside the other integration tests.
 
 use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::Source;
 use faucet_source_mysql::{MysqlSource, MysqlSourceConfig};
 use std::sync::OnceLock;
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
@@ -95,6 +96,7 @@ async fn conformance_bounded_memory() {
 
     // Check 10: connector_name is non-empty.
     faucet_conformance::assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "mysql");
 
     // Check 11: preflight check() returns Ok(report) with well-formed probes.
     faucet_conformance::assert_preflight_check_wellformed(

--- a/crates/source/parquet/README.md
+++ b/crates/source/parquet/README.md
@@ -210,3 +210,7 @@ cluster coordinator a run reads every file, unchanged.
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="parquet"`.

--- a/crates/source/parquet/src/stream.rs
+++ b/crates/source/parquet/src/stream.rs
@@ -516,6 +516,10 @@ impl faucet_core::Source for ParquetSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "parquet"
+    }
+
     fn config_schema(&self) -> Value {
         serde_json::to_value(faucet_core::schema_for!(ParquetSourceConfig))
             .expect("schema serialization")

--- a/crates/source/parquet/tests/conformance.rs
+++ b/crates/source/parquet/tests/conformance.rs
@@ -22,6 +22,7 @@ use faucet_conformance::{
     assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
     assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
+use faucet_core::Source;
 use faucet_source_parquet::{ParquetSource, ParquetSourceConfig};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
@@ -100,6 +101,7 @@ async fn conformance_connector_name_nonempty() {
         .await
         .unwrap();
     assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "parquet");
 }
 
 // ── Check 9: batch_size=0 yields a single page ────────────────────────────────

--- a/crates/source/postgres/README.md
+++ b/crates/source/postgres/README.md
@@ -340,3 +340,7 @@ Outside the cluster coordinator the `shard` config has **no effect** — a plain
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="postgres"`.

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -363,6 +363,10 @@ impl faucet_core::Source for PostgresSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "postgres"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(PostgresSourceConfig))
             .expect("schema serialization")

--- a/crates/source/postgres/tests/conformance.rs
+++ b/crates/source/postgres/tests/conformance.rs
@@ -5,6 +5,7 @@
 //! PostgreSQL query is full-table (no bookmark), so check 3 does not apply;
 //! checks 4/5 are sink-only.
 
+use faucet_core::Source;
 use faucet_source_postgres::{PostgresSource, PostgresSourceConfig};
 use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
 use testcontainers_modules::postgres::Postgres;
@@ -61,6 +62,7 @@ async fn conformance_bounded_memory() {
 
     // Check 10: connector_name is non-empty.
     faucet_conformance::assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "postgres");
 
     // Check 11: preflight check() returns Ok(report) with well-formed probes.
     faucet_conformance::assert_preflight_check_wellformed(

--- a/crates/source/redis/README.md
+++ b/crates/source/redis/README.md
@@ -326,3 +326,7 @@ This crate has no optional features of its own. Enable it in the CLI / umbrella 
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="redis"`.

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -396,6 +396,10 @@ impl faucet_core::Source for RedisSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "redis"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(RedisSourceConfig))
             .expect("schema serialization")

--- a/crates/source/redis/tests/conformance.rs
+++ b/crates/source/redis/tests/conformance.rs
@@ -7,6 +7,7 @@
 //! integration test's container boot + seeding path verbatim.
 
 use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::Source;
 use faucet_source_redis::{RedisSource, RedisSourceConfig, RedisSourceType};
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::redis::{REDIS_PORT, Redis};
@@ -136,6 +137,7 @@ async fn conformance_errors_not_panics() {
 
     // Check 10: connector_name is non-empty (metric-cardinality contract).
     faucet_conformance::assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "redis");
     faucet_conformance::assert_errors_not_panics(&source).await;
     // Check 11: the default page-pull check() surfaces the connect failure as a
     // Fail probe inside Ok(report) — never an Err from check() itself.

--- a/crates/source/s3/README.md
+++ b/crates/source/s3/README.md
@@ -410,3 +410,7 @@ cluster coordinator a run reads every object, unchanged.
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="s3"`.

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -644,6 +644,10 @@ impl faucet_core::Source for S3Source {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "s3"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(S3SourceConfig))
             .expect("schema serialization")

--- a/crates/source/s3/tests/conformance.rs
+++ b/crates/source/s3/tests/conformance.rs
@@ -10,6 +10,7 @@ use aws_sdk_s3::config::Credentials;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config as S3Config};
 use faucet_conformance::{assert_config_schema_valid_value, assert_errors_not_panics};
+use faucet_core::Source;
 use faucet_source_s3::{S3Source, S3SourceConfig};
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::minio::MinIO;
@@ -35,6 +36,7 @@ async fn conformance_connector_name_nonempty() {
         .region(REGION.to_string());
     let source = S3Source::new(config).await.expect("source builds lazily");
     faucet_conformance::assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "s3");
 }
 
 // ── Check 2: bounded-memory streaming (Docker) ──────────────────────────────

--- a/crates/source/sftp/src/config.rs
+++ b/crates/source/sftp/src/config.rs
@@ -196,4 +196,32 @@ mod tests {
         assert!(glob_match("a*b*c", "axxbyyc"));
         assert!(!glob_match("a*b*c", "axxbyy"));
     }
+
+    /// Off-by-one boundary cases a backtracking matcher classically gets wrong
+    /// (empty inputs, exhausted input against a trailing `?`, pattern longer
+    /// than the name). Pure test hardening — the current matcher already passes.
+    #[test]
+    fn glob_boundary_cases() {
+        assert!(glob_match("", ""), "empty pattern matches empty name");
+        assert!(
+            !glob_match("", "x"),
+            "empty pattern must not match a non-empty name"
+        );
+        assert!(!glob_match("a?", "a"), "trailing `?` needs one more char");
+        assert!(
+            !glob_match("abc", "ab"),
+            "pattern longer than name, no star"
+        );
+        assert!(glob_match("*", ""), "a lone star matches the empty name");
+        assert!(glob_match("a*", "a"), "trailing star may match nothing");
+        assert!(
+            glob_match("**", ""),
+            "consecutive stars collapse and match empty"
+        );
+        assert!(
+            glob_match("?", "x"),
+            "a single `?` matches exactly one char"
+        );
+        assert!(!glob_match("?", ""), "a single `?` needs a char");
+    }
 }

--- a/crates/source/sqlite/README.md
+++ b/crates/source/sqlite/README.md
@@ -330,3 +330,7 @@ Outside the cluster coordinator the `shard` config has **no effect** — a plain
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="sqlite"`.

--- a/crates/source/sqlite/src/stream.rs
+++ b/crates/source/sqlite/src/stream.rs
@@ -328,6 +328,10 @@ impl faucet_core::Source for SqliteSource {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "sqlite"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(SqliteSourceConfig))
             .expect("schema serialization")

--- a/crates/source/sqlite/tests/conformance.rs
+++ b/crates/source/sqlite/tests/conformance.rs
@@ -9,6 +9,7 @@
 //! SQLite query is full-table (no bookmark), so check 3 does not apply; checks
 //! 4/5 are sink-only.
 
+use faucet_core::Source;
 use faucet_source_sqlite::{SqliteSource, SqliteSourceConfig};
 use sqlx::sqlite::SqlitePoolOptions;
 use tempfile::TempDir;
@@ -46,6 +47,7 @@ async fn conformance_config_schema_valid() {
     faucet_conformance::assert_config_schema_valid(&source);
     // Check 10: connector_name is non-empty.
     faucet_conformance::assert_connector_name_nonempty(&source);
+    assert_eq!(source.connector_name(), "sqlite");
 }
 
 #[tokio::test]

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -381,3 +381,7 @@ This crate has no optional features of its own. Enable it in the CLI / umbrella 
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+## Observability
+
+Metrics emitted by this source are labelled `connector="xml"`.

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -559,6 +559,10 @@ impl faucet_core::Source for XmlStream {
         })
     }
 
+    fn connector_name(&self) -> &'static str {
+        "xml"
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(XmlStreamConfig))
             .expect("schema serialization")

--- a/crates/source/xml/tests/conformance.rs
+++ b/crates/source/xml/tests/conformance.rs
@@ -9,6 +9,7 @@ use faucet_conformance::{
     assert_batch_size_zero_single_page, assert_bounded_memory, assert_config_schema_valid_value,
     assert_connector_name_nonempty, assert_errors_not_panics, assert_preflight_check_wellformed,
 };
+use faucet_core::Source;
 use faucet_source_xml::{XmlStream, XmlStreamConfig};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -108,6 +109,7 @@ async fn conformance_errors_not_panics() {
 #[test]
 fn conformance_connector_name_nonempty() {
     assert_connector_name_nonempty(&unreachable_source());
+    assert_eq!(unreachable_source().connector_name(), "xml");
 }
 
 // ── Check 11: preflight check() is well-formed ────────────────────────────────

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -120,6 +120,48 @@ Pass `--param NAME=VALUE` (repeatable) to switch to strict binding and check one
 concrete invocation; `--param-env NAME[=VALUE]` overrides an environment variable
 for the validation only.
 
+### JSON output
+
+Pass `--json` to emit a structured summary instead of the prose report, so CI can
+assert on it programmatically. The prose lines (secret confirmations, per-block
+`valid` notes, the `ok:`/row lines) are suppressed and a single JSON object is
+printed:
+
+```bash
+faucet validate pipeline.yaml --json
+```
+
+```json
+{
+  "valid": true,
+  "mode": "matrix",
+  "name": "my-pipeline",
+  "row_count": 1,
+  "roots": 1,
+  "children": 0,
+  "selection_active": false,
+  "rows": [
+    {
+      "id": "default",
+      "source": "rest",
+      "sink": "jsonl",
+      "role": "root",
+      "parent_id": null,
+      "parent_key": null,
+      "depends_on": [],
+      "delivery": "at-least-once",
+      "status": "active",
+      "tags": [],
+      "decision": null
+    }
+  ]
+}
+```
+
+Each row's `decision` is `"run"`/`"skip"` when a selector or the readiness ladder
+is active, otherwise `null`. A topology-mode config emits `"mode": "topology"`
+with `nodes`/`edges` counts and any inert-block `warnings`.
+
 ### Composition flags
 
 When a config uses [composition](config.md#config-composition) (`extends:` /
@@ -260,6 +302,7 @@ watcher with `--debounce-ms`.
 ## `schema`
 
 ```bash
+faucet schema --list          # enumerate every valid target in this binary
 faucet schema config          # the WHOLE config document (top-level grammar)
 faucet schema source rest
 faucet schema sink bigquery
@@ -276,6 +319,11 @@ faucet schema catalog
 faucet schema params
 faucet schema partition
 ```
+
+`faucet schema --list` prints every valid `<target>` compiled into this binary
+(feature-gated targets appear only when their feature is on), so you can discover
+the set without reading the docs — `source`, `sink`, and `transform` are shown
+with a `<name>` placeholder because they take a connector/transform name.
 
 `faucet schema config` prints a composed JSON Schema for the **entire**
 `faucet.yaml` / `faucet.json` document — the top-level grammar (`version`,
@@ -382,6 +430,12 @@ faucet install my-connector --index ./my-registry.json
 `--index <path>` points any of these at a custom/mirror index instead of the
 built-in one. Ambiguous names (a connector that is both a source and a sink,
 e.g. `postgres`) need `--kind source|sink`.
+
+Both `faucet list` and `faucet list --available` accept `--json` for a
+machine-readable listing — `list --json` emits `{ sources, sinks, transforms,
+state_stores }` (each connector entry carries `name`, `description`, and a
+maturity `tier`), and `list --available --json` emits the registry rows with a
+`compiled` flag per connector.
 
 ## `conformance`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,7 +107,7 @@ The service column lists what each example touches; all are provided by
 | `mongodb_to_elasticsearch.yaml`, `postgres_to_elasticsearch.yaml`, `grpc_to_elasticsearch.yaml` | elasticsearch (+ source) |
 | `elasticsearch_to_s3.yaml`, `postgres_to_s3.yaml`, `rest_to_s3.yaml`, `xml_to_s3.yaml` | minio (S3) (+ source) |
 | `s3_to_postgres.yaml`, `s3_to_mongodb.yaml` | minio (S3), target |
-| `mongodb_to_redis.yaml`, `xml_to_mongodb.yaml` | mongodb (single-node replica set; query mode connects to the primary) |
+| `mongodb_to_redis.yaml`, `xml_to_mongodb.yaml`, `mongodb_to_parquet.yaml` | mongodb (single-node replica set; query mode connects to the primary); `mongodb_to_parquet` writes local Parquet files (no cloud infra) |
 | `webhook_to_csv.yaml`, `webhook_to_http.yaml`, `grpc_to_http.yaml` | none external beyond the source/HTTP target |
 | `dag_users_posts.yaml`, `rest_users_posts_dag.yaml`, `rest_to_bigquery_matrix.yaml`, `templates_*.yaml` | demonstrate matrix / DAG / template syntax (REST source) |
 | `matrix_depends_on.yaml` | demonstrates `depends_on` completion ordering between matrix rows (local CSV/JSONL, no infra) |


### PR DESCRIPTION
## Summary

Clears a batch of open **`good first issue`** items in one PR. Each is independent; grouped for a single review pass.

| Issue | Change |
|------|--------|
| #427 | `faucet list --json` — structured listing of sources/sinks/transforms/state stores (also `list --available --json`). |
| #428 | `faucet validate --json` — structured validation summary for CI (matrix **and** topology modes); prose report suppressed under `--json`. |
| #432 | `faucet schema --list` — enumerate the valid schema targets compiled into the binary. |
| #61  | Friendly snake-case `connector_name()` overrides for the **24 remaining** built-in connectors (matching the YAML `type:`), each with a specific-value test + a README observability note. |
| #430 | Fail-fast validation rejecting an empty `bucket` on the S3 / GCS sinks (typed `FaucetError::Config` at construction). |
| #431 | Actionable Kafka Schema-Registry encode errors — name the wire format and `schema_registry.url`. |
| #437 | Extract a pure, unit-tested `progress_ratio(done, planned)` in backfill metrics (0/0, over-count clamping). |
| #436 | Tests for the `RunStreamOptions` builder methods. |
| #435 | Boundary-case tests for the SFTP `glob_match` matcher (empty inputs, trailing `?`, over-long pattern). |
| #434 | Tests for `faucet init` `resolve_kinds` / `unknown_kind_err`. |
| #433 | Test for the `is_topology()` predicate. |
| #415 | Runnable `cli/examples/mongodb_to_parquet.yaml` (MongoDB → local Parquet) + `examples/README.md` mapping. |

## Notes

- **#61** deliberately changes `connector_name()` from the default stripped type name (e.g. `"CsvSource"`) to the friendly label (`"csv"`); the two registry tests that asserted the old default were updated accordingly. Two sinks (postgres, mysql) place their specific-value assertion in a testcontainer-gated conformance test (matching the pre-existing placement), so those two one-line methods are only exercised under Docker.
- **`--json` for `validate`** keeps the human report byte-identical when the flag is absent.
- Docs: `docs/book/src/reference/cli.md` documents all three new flags.

## Testing

- `cargo test -p faucet-core --lib` (RunStreamOptions builders), `-p faucet-cli --lib` (schema/list/init/topology/backfill/registry), `-p faucet-cli --test cli_end_to_end` (new `list --json` / `schema --list` / `validate --json` tests), `-p faucet-sink-kafka --features schema-registry` (encode messages), `-p faucet-sink-s3` / `-p faucet-sink-gcs` (bucket validation), `-p faucet-source-sftp` (glob).
- `cargo check --tests` across all 24 connector crates (conformance edits compile).
- `cargo fmt --all --check` clean; `cargo clippy -p faucet-core --all-features` clean.

Closes #427
Closes #428
Closes #432
Closes #61
Closes #430
Closes #431
Closes #437
Closes #436
Closes #435
Closes #434
Closes #433
Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
