### PR TITLE
feat(cli): discovery-driven request matrix (discover + for_each cross-product)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -647,7 +647,7 @@ pipeline:
 
 ### Matrix mode — run many invocations from one config
 
-Add a `matrix:` block to run multiple invocations from the same base. Each row is **deep-merged** into `pipeline:` (objects merge recursively, arrays replace wholesale, scalars replace). Rows with `parent:` become children that fan out one invocation per record produced by the parent row. Rows with `depends_on:` wait for other rows to finish before starting (pure ordering, no record hand-off).
+Add a `matrix:` block to run multiple invocations from the same base. Each row is **deep-merged** into `pipeline:` (objects merge recursively, arrays replace wholesale, scalars replace). Rows with `parent:` become children that fan out one invocation per record produced by the parent row. Rows with `depends_on:` wait for other rows to finish before starting (pure ordering, no record hand-off). Rows with `discover:` / `for_each:` fan out over the **cartesian product** of value-sets enumerated at run time (see below).
 
 ```yaml
 version: 1
@@ -691,6 +691,17 @@ execution:
   max_concurrent: 8
   on_error: continue   # or `stop`
 ```
+
+#### `discover:` / `for_each:` — discovery-driven fan-out (#501)
+
+A `discover:` row enumerates a **value-set at run time** (build source → drain →
+project `select` → dedup, no sink), and a `for_each: [dims]` row runs once per
+tuple of the **cartesian product** of those dimensions, with `${<dim>.<alias>}`
+substituted into its config — "sync this report once per `{subsidiary} ×
+{custom-field}`". The discovery source is a `{ ref }` to a `pipeline.sources`
+template or a standalone `{ type, config }`; the product is bounded by
+`MAX_MATRIX_PRODUCT` (10 000). See `docs/book/src/reference/config.md` and
+`cli/examples/discovery_matrix.yaml`.
 
 #### `depends_on:` — completion ordering between rows
 

--- a/cli/examples/discovery_matrix.yaml
+++ b/cli/examples/discovery_matrix.yaml
@@ -1,0 +1,66 @@
+# Discovery-driven request matrix (#501): fan a stream out over the CROSS
+# PRODUCT of value-sets enumerated from live discovery calls at run time —
+# "sync this report once per {subsidiary} × {custom-field}".
+#
+#   faucet validate cli/examples/discovery_matrix.yaml
+#
+# A `discover:` row runs its source once, projects `select` from each record,
+# dedups, and publishes the value-set under `as`. A `for_each: [dims]` row then
+# runs once per tuple of the cartesian product, with `${dim.alias}` substituted
+# into the source URL and sink path. Discovery + fan-out rows share one
+# `pipeline.sources` template (the `ref` path) and override only the deltas.
+version: 1
+name: reports_by_subsidiary_and_field
+
+pipeline:
+  # One complete REST template both the discovery calls and the report fan-out
+  # reference — same auth / base_url, different path per row.
+  sources:
+    api:
+      type: rest
+      config:
+        method: GET
+        base_url: https://api.example.com
+        path: /
+        auth:
+          type: bearer
+          config:
+            token: ${env:API_TOKEN}
+        query_params: {}
+        pagination: { type: None }
+        replication_method: { type: FullTable }
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/report-${subsidiaries.subsidiary_id}-${fields.field_id}.jsonl
+
+matrix:
+  # ── Discovery dimensions (run once each, deduped, cached) ──
+  - id: subsidiaries
+    discover:
+      source:
+        ref: api
+        config: { path: /subsidiaries, records_path: "$.subsidiaries[*]" }
+      select: "$.id"
+      as: subsidiary_id
+
+  - id: fields
+    discover:
+      source:
+        ref: api
+        config: { path: /custom-fields, records_path: "$.fields[*]" }
+      select: "$.id"
+      as: field_id
+
+  # ── Fan-out: one invocation per (subsidiary × field) tuple ──
+  - id: trial_balance
+    for_each: [subsidiaries, fields]
+    source:
+      ref: api
+      config:
+        path: /reports/trial-balance
+        records_path: "$.rows[*]"
+        query_params:
+          subsidiary_id: "${subsidiaries.subsidiary_id}"
+          field_id: "${fields.field_id}"

--- a/cli/src/commands/explain.rs
+++ b/cli/src/commands/explain.rs
@@ -141,6 +141,8 @@ fn row_explanation(node: &ExpandedNode) -> RowExplanation {
     let (role, parent) = match &node.role {
         NodeRole::Root => ("root".to_string(), None),
         NodeRole::Child { parent_id, .. } => ("child".to_string(), Some(parent_id.clone())),
+        NodeRole::Discovery { .. } => ("discovery".to_string(), None),
+        NodeRole::Product { dims } => (format!("product[{}]", dims.join(",")), None),
     };
     RowExplanation {
         id: node.id.clone(),

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -223,7 +223,11 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     for node in &nodes {
         // Verifying the schema lookup also catches unknown connector kinds.
         source_schema(&node.source.kind)?;
-        sink_schema(&node.sink.kind)?;
+        // A discovery row (#501) enumerates a value-set and has no sink — its
+        // `sink` field is a never-built placeholder, so skip the sink check.
+        if !matches!(node.role, NodeRole::Discovery { .. }) {
+            sink_schema(&node.sink.kind)?;
+        }
         for t in &node.transforms {
             if !available_transforms().contains(&t.kind.as_str()) {
                 return Err(CliError::UnknownTransform {
@@ -246,11 +250,13 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     // transform *config* fails validation too.
     check_transforms(&nodes)?;
 
-    let roots = nodes
+    // "children" = per-parent-record fan-out rows; discovery / product rows run
+    // independently (no parent), so they count as top-level like roots.
+    let children = nodes
         .iter()
-        .filter(|n| matches!(n.role, NodeRole::Root))
+        .filter(|n| matches!(n.role, NodeRole::Child { .. }))
         .count();
-    let children = nodes.len() - roots;
+    let roots = nodes.len() - children;
 
     // Runtime row-selection (#370/#371/#376/#377). The selection is computed the
     // same way `faucet run` computes it, so the run/skip decision here matches
@@ -296,6 +302,8 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
                         parent_id,
                         parent_key,
                     } => ("child", Some(parent_id.clone()), Some(parent_key.clone())),
+                    NodeRole::Discovery { .. } => ("discovery", None, None),
+                    NodeRole::Product { .. } => ("product", None, None),
                 };
                 serde_json::json!({
                     "id": node.id,
@@ -398,6 +406,12 @@ fn row_line(node: &crate::expand::ExpandedNode) -> String {
             parent_key,
         } => {
             format!("child of '{parent_id}' (parent_key={parent_key})")
+        }
+        NodeRole::Discovery { as_alias, .. } => {
+            format!("discovery (as={as_alias})")
+        }
+        NodeRole::Product { dims } => {
+            format!("product of [{}]", dims.join(", "))
         }
     };
     let deps = if node.depends_on.is_empty() {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -580,6 +580,46 @@ pub struct MatrixRow {
     /// connector configs. Inherits the top-level `partition:` block when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partition: Option<crate::partition::PartitionSpec>,
+
+    /// **Discovery dimension** (#501). When set, this row enumerates a value-set
+    /// at runtime: it builds `discover.source`, drains it, projects `select`
+    /// (JSONPath) from each record, and dedups (first-seen order). The row has
+    /// no sink and writes nothing — its value-set is exposed to `for_each` rows
+    /// as `${<id>.<as>}`. Runs once per pipeline run, cached across dependents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discover: Option<DiscoverSpec>,
+
+    /// Fan this row out over the **cartesian product** of the named discovery
+    /// dimensions (#501) — one invocation per tuple, with `${<dim>.<as>}`
+    /// resolved to that tuple's value in the source/sink config. Distinct from
+    /// `parent:` (fan-out over one real pipeline's emitted records — a tree, not
+    /// a product) and `depends_on:` (completion ordering only). Each id must name
+    /// a `discover:` row; the product is bounded by `MAX_MATRIX_PRODUCT`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub for_each: Vec<String>,
+}
+
+/// A discovery dimension's source + projection (#501). See [`MatrixRow::discover`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DiscoverSpec {
+    /// Source to enumerate. Either a `{ ref: <name> }` pointing at a
+    /// `pipeline.sources` template (recommended — reuses a complete connector
+    /// config), or a standalone `{ type, config }`. It is **not** merged over
+    /// the `default` template — a discovery step is independent of the
+    /// pipeline's data source (which typically carries `${dim}` tokens meant
+    /// for the fan-out rows, not the enumeration).
+    pub source: PartialConnector,
+
+    /// JSONPath projecting the dimension value from each discovered record
+    /// (e.g. `$.id`). `$` selects the whole record. Null / missing values are
+    /// skipped with a warning.
+    pub select: String,
+
+    /// Alias the projected value is exposed under: a `for_each` row references
+    /// it as `${<row_id>.<as>}`. Must match `^[a-z0-9][a-z0-9_-]*$`.
+    #[serde(rename = "as")]
+    pub as_alias: String,
 }
 
 /// Readiness ladder for a matrix row's source (#371). A single ordered axis

--- a/cli/src/discovery_matrix.rs
+++ b/cli/src/discovery_matrix.rs
@@ -1,0 +1,254 @@
+//! Pure planning logic for the discovery-driven request matrix (#501).
+//!
+//! A `discover:` row enumerates a value-set at runtime (build source → drain →
+//! project `select` → dedup); a `for_each: [dims]` row fans out over the
+//! **cartesian product** of those value-sets, one invocation per tuple.
+//!
+//! Everything here is pure (no I/O): projection, dedup, the cartesian product,
+//! the per-tuple interpolation context, and the tuple state-key suffix — so the
+//! fan-out semantics are unit-testable without a network. The only I/O (running
+//! the discovery source) lives in the executor and feeds [`Dim::values`].
+
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+/// Hard ceiling on the number of invocations a single `for_each` row may expand
+/// to. A cartesian product multiplies quickly; above this the run fails rather
+/// than silently spawning an unbounded fleet.
+pub const MAX_MATRIX_PRODUCT: usize = 10_000;
+
+/// One resolved discovery dimension: the discovery row id, the alias its
+/// projected value is exposed under, and the deduped value-set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Dim {
+    /// Discovery row id (the `${<id>.<alias>}` reference target).
+    pub id: String,
+    /// Alias the projected value is exposed under.
+    pub alias: String,
+    /// Projected, deduped values (first-seen order).
+    pub values: Vec<Value>,
+}
+
+/// Project `select` (a dot-path, optionally `$`-prefixed) from each record and
+/// dedup the results in first-seen order. `null` / missing projections are
+/// skipped. `$` (or `""`) selects the whole record. Pure.
+pub fn project_dedup(records: &[Value], select: &str) -> Vec<Value> {
+    let mut seen: Vec<Value> = Vec::new();
+    for rec in records {
+        let Some(v) = project_value(rec, select) else {
+            continue;
+        };
+        if v.is_null() {
+            continue;
+        }
+        if !seen.contains(&v) {
+            seen.push(v);
+        }
+    }
+    seen
+}
+
+/// Resolve a dot-path projection against one record. Supports a leading `$.` or
+/// bare `$` (whole record), then `a.b.c` segment walking into objects. Returns
+/// `None` if any segment is missing. Pure.
+fn project_value(record: &Value, select: &str) -> Option<Value> {
+    let path = select
+        .strip_prefix("$.")
+        .or_else(|| select.strip_prefix('$'))
+        .unwrap_or(select);
+    if path.is_empty() {
+        return Some(record.clone());
+    }
+    let mut cur = record;
+    for seg in path.split('.') {
+        cur = cur.get(seg)?;
+    }
+    Some(cur.clone())
+}
+
+/// The number of invocations `dims` expands to (the product of the value-set
+/// sizes). Returns `0` if any dimension is empty. Saturating, so it never
+/// overflows; compare against [`MAX_MATRIX_PRODUCT`]. Pure.
+pub fn product_size(dims: &[Dim]) -> usize {
+    if dims.is_empty() {
+        return 0;
+    }
+    dims.iter()
+        .map(|d| d.values.len())
+        .try_fold(1usize, |acc, n| acc.checked_mul(n))
+        .unwrap_or(usize::MAX)
+}
+
+/// Build the cartesian product of the dimensions as per-tuple interpolation
+/// contexts. Each context maps `dim_id -> { alias: value }`, so a token
+/// `${dim_id.alias}` resolves to that tuple's value via the same
+/// `interpolate_record` path the parent/child matrix uses. An empty dimension
+/// yields no tuples. Pure.
+pub fn cartesian(dims: &[Dim]) -> Vec<HashMap<String, Value>> {
+    if dims.is_empty() || dims.iter().any(|d| d.values.is_empty()) {
+        return Vec::new();
+    }
+    let mut out: Vec<HashMap<String, Value>> = vec![HashMap::new()];
+    for dim in dims {
+        let mut next = Vec::with_capacity(out.len() * dim.values.len());
+        for base in &out {
+            for v in &dim.values {
+                let mut ctx = base.clone();
+                let mut obj = Map::new();
+                obj.insert(dim.alias.clone(), v.clone());
+                ctx.insert(dim.id.clone(), Value::Object(obj));
+                next.push(ctx);
+            }
+        }
+        out = next;
+    }
+    out
+}
+
+/// Stable, collision-resistant state-key suffix for one product tuple, in
+/// declared dimension order: `alias=value&alias=value…`. `dims` supplies the
+/// order + aliases; `ctx` is one entry from [`cartesian`]. Pure.
+pub fn tuple_state_key_suffix(dims: &[Dim], ctx: &HashMap<String, Value>) -> String {
+    dims.iter()
+        .map(|d| {
+            let v = ctx
+                .get(&d.id)
+                .and_then(|o| o.get(&d.alias))
+                .map(value_brief)
+                .unwrap_or_else(|| "(missing)".to_string());
+            format!("{}={}", d.alias, v)
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Brief scalar rendering of a JSON value for a state-key segment.
+fn value_brief(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn project_dedup_dotpath_and_dollar() {
+        let recs = vec![
+            json!({"id": 1, "name": "a"}),
+            json!({"id": 2, "name": "b"}),
+            json!({"id": 1, "name": "c"}), // dup id
+        ];
+        assert_eq!(project_dedup(&recs, "$.id"), vec![json!(1), json!(2)]);
+        assert_eq!(project_dedup(&recs, "id"), vec![json!(1), json!(2)]);
+        // `$` selects whole records (all distinct here).
+        assert_eq!(project_dedup(&recs, "$").len(), 3);
+    }
+
+    #[test]
+    fn project_dedup_skips_null_and_missing() {
+        let recs = vec![
+            json!({"id": 1}),
+            json!({"id": null}),
+            json!({"other": 9}), // missing `id`
+            json!({"id": 2}),
+        ];
+        assert_eq!(project_dedup(&recs, "$.id"), vec![json!(1), json!(2)]);
+    }
+
+    #[test]
+    fn project_nested_path() {
+        let recs = vec![
+            json!({"meta": {"code": "X"}}),
+            json!({"meta": {"code": "Y"}}),
+        ];
+        assert_eq!(
+            project_dedup(&recs, "$.meta.code"),
+            vec![json!("X"), json!("Y")]
+        );
+    }
+
+    fn dim(id: &str, alias: &str, vals: Vec<Value>) -> Dim {
+        Dim {
+            id: id.into(),
+            alias: alias.into(),
+            values: vals,
+        }
+    }
+
+    #[test]
+    fn cartesian_two_dims_is_product() {
+        let dims = vec![
+            dim("subs", "subsidiary_id", vec![json!(1), json!(2)]),
+            dim(
+                "fields",
+                "field_id",
+                vec![json!("a"), json!("b"), json!("c")],
+            ),
+        ];
+        let ctxs = cartesian(&dims);
+        assert_eq!(ctxs.len(), 6);
+        // First tuple pairs the first value of each dim.
+        assert_eq!(ctxs[0]["subs"]["subsidiary_id"], json!(1));
+        assert_eq!(ctxs[0]["fields"]["field_id"], json!("a"));
+        // Product covers every combination.
+        let pairs: Vec<(Value, Value)> = ctxs
+            .iter()
+            .map(|c| {
+                (
+                    c["subs"]["subsidiary_id"].clone(),
+                    c["fields"]["field_id"].clone(),
+                )
+            })
+            .collect();
+        assert!(pairs.contains(&(json!(2), json!("c"))));
+    }
+
+    #[test]
+    fn cartesian_single_dim() {
+        let dims = vec![dim("d", "v", vec![json!(1), json!(2)])];
+        let ctxs = cartesian(&dims);
+        assert_eq!(ctxs.len(), 2);
+        assert_eq!(ctxs[1]["d"]["v"], json!(2));
+    }
+
+    #[test]
+    fn cartesian_empty_dim_yields_nothing() {
+        let dims = vec![dim("a", "x", vec![json!(1)]), dim("b", "y", vec![])];
+        assert!(cartesian(&dims).is_empty());
+        assert!(cartesian(&[]).is_empty());
+    }
+
+    #[test]
+    fn product_size_math() {
+        assert_eq!(product_size(&[]), 0);
+        assert_eq!(
+            product_size(&[
+                dim("a", "x", vec![json!(1), json!(2)]),
+                dim("b", "y", vec![json!(1)])
+            ]),
+            2
+        );
+        assert_eq!(
+            product_size(&[dim("a", "x", vec![]), dim("b", "y", vec![json!(1)])]),
+            0
+        );
+    }
+
+    #[test]
+    fn tuple_state_key_is_stable_and_ordered() {
+        let dims = vec![
+            dim("subs", "subsidiary_id", vec![json!(1)]),
+            dim("fields", "field_id", vec![json!("a")]),
+        ];
+        let ctxs = cartesian(&dims);
+        assert_eq!(
+            tuple_state_key_suffix(&dims, &ctxs[0]),
+            "subsidiary_id=1&field_id=a"
+        );
+    }
+}

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -44,6 +44,10 @@ use tokio::sync::{Mutex, Semaphore};
 /// so the per-level snapshot and per-child-unit hand-off are pointer bumps, not
 /// deep clones of the JSON tree (#160).
 type CapturedRecords = Arc<Mutex<HashMap<String, Vec<Arc<Value>>>>>;
+
+/// Enumerated discovery dimensions (#501), keyed by discovery row id. Populated
+/// by discovery invocations, read when building the `for_each` cross-product.
+type DiscoveredDims = Arc<Mutex<HashMap<String, crate::discovery_matrix::Dim>>>;
 use tokio_util::sync::CancellationToken;
 
 /// Knobs passed to [`run_expanded`].
@@ -246,6 +250,9 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
     // as `Arc<Value>` so the per-level snapshot clone and the per-child-unit
     // hand-off are pointer bumps, not deep clones of the JSON tree (#160).
     let captured: CapturedRecords = Arc::new(Mutex::new(HashMap::new()));
+    // Discovery dimensions (#501): value-sets enumerated by `discover:` rows,
+    // read when a `for_each` row builds its cross-product.
+    let discovered: DiscoveredDims = Arc::new(Mutex::new(HashMap::new()));
 
     let mut outcomes: Vec<InvocationOutcome> = Vec::new();
     let mut skipped_subtrees: HashSet<String> = HashSet::new();
@@ -293,7 +300,9 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
             .filter(|id| {
                 let node = &nodes_by_id[*id];
                 let parent_done = match &node.role {
-                    NodeRole::Root => true,
+                    // Discovery/Product have no `parent:`; their prerequisites
+                    // (the `for_each` dims) are carried in `depends_on`.
+                    NodeRole::Root | NodeRole::Discovery { .. } | NodeRole::Product { .. } => true,
                     NodeRole::Child { parent_id, .. } => {
                         completed.contains(parent_id) || skipped_subtrees.contains(parent_id)
                     }
@@ -336,7 +345,7 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
                 .iter()
                 .filter_map(|id| match &nodes_by_id[id].role {
                     NodeRole::Child { parent_id, .. } => Some(parent_id.as_str()),
-                    NodeRole::Root => None,
+                    _ => None,
                 })
                 .collect();
             let mut cap = captured.lock().await;
@@ -382,7 +391,80 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
                         parent_record: None,
                         state_key,
                         parent_record_key: None,
+                        product_ctx: None,
                     });
+                }
+                NodeRole::Discovery { .. } => {
+                    // One invocation; run_unit intercepts it to enumerate the
+                    // dimension. State is unused, so the key is a placeholder.
+                    let state_key = build_state_key(&opts.pipeline_name, &node.id, None);
+                    units.push(Unit {
+                        node: node.clone(),
+                        parent_record: None,
+                        state_key,
+                        parent_record_key: None,
+                        product_ctx: None,
+                    });
+                }
+                NodeRole::Product { dims } => {
+                    // Gather the enumerated dimensions in declared order. They
+                    // are guaranteed present: each dim is in this row's
+                    // `depends_on`, so a skipped/failed dim already skipped this
+                    // row above. The `missing` guard is defensive.
+                    let resolved: Vec<crate::discovery_matrix::Dim> = {
+                        let dim_map = discovered.lock().await;
+                        let mut v = Vec::with_capacity(dims.len());
+                        let mut missing = None;
+                        for d in dims {
+                            match dim_map.get(d) {
+                                Some(dim) => v.push(dim.clone()),
+                                None => {
+                                    missing = Some(d.clone());
+                                    break;
+                                }
+                            }
+                        }
+                        if let Some(d) = missing {
+                            skipped_subtrees.insert(id.clone());
+                            tracing::warn!(row = %id, dimension = %d, "for_each dimension unavailable — row skipped");
+                            continue;
+                        }
+                        v
+                    };
+                    let size = crate::discovery_matrix::product_size(&resolved);
+                    if size == 0 {
+                        tracing::info!(row = %id, "for_each cross-product is empty — row skipped");
+                        continue;
+                    }
+                    if size > crate::discovery_matrix::MAX_MATRIX_PRODUCT {
+                        return Err(CliError::Config(format!(
+                            "matrix row '{id}': for_each cross-product is {size} invocations, over \
+                             the limit of {} — narrow the discovery dimensions",
+                            crate::discovery_matrix::MAX_MATRIX_PRODUCT
+                        )));
+                    }
+                    let uses_state = node.state.is_some() || opts.state_path_override.is_some();
+                    let mut seen_keys: HashSet<String> = HashSet::new();
+                    for ctx in crate::discovery_matrix::cartesian(&resolved) {
+                        let suffix =
+                            crate::discovery_matrix::tuple_state_key_suffix(&resolved, &ctx);
+                        let state_key =
+                            build_state_key(&opts.pipeline_name, &node.id, Some(&suffix));
+                        validate_unit_state_key(&node.id, uses_state, &state_key)?;
+                        if !seen_keys.insert(state_key.clone()) {
+                            return Err(CliError::DuplicateStateKey {
+                                id: node.id.clone(),
+                                state_key,
+                            });
+                        }
+                        units.push(Unit {
+                            node: node.clone(),
+                            parent_record: None,
+                            state_key,
+                            parent_record_key: Some(suffix),
+                            product_ctx: Some(ctx),
+                        });
+                    }
                 }
                 NodeRole::Child {
                     parent_id,
@@ -419,6 +501,7 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
                             parent_record: Some(record.clone()),
                             state_key,
                             parent_record_key: Some(pk_string),
+                            product_ctx: None,
                         });
                     }
                 }
@@ -450,12 +533,13 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
             let sem = Arc::clone(&semaphore);
             let opts2 = Arc::clone(&opts);
             let captured = Arc::clone(&captured);
+            let discovered = Arc::clone(&discovered);
             let capture = projections.get(&unit.node.id).cloned();
             let meta = (unit.node.id.clone(), unit.parent_record_key.clone());
             let unit_cancel = level_cancel.clone();
             let handle = joinset.spawn(async move {
                 let _permit = sem.acquire().await.expect("semaphore not closed");
-                run_unit(&unit, capture, &captured, &opts2, unit_cancel).await
+                run_unit(&unit, capture, &captured, &discovered, &opts2, unit_cancel).await
             });
             task_meta.insert(handle.id(), meta);
         }
@@ -574,20 +658,31 @@ struct Unit {
     parent_record: Option<Arc<Value>>,
     state_key: String,
     parent_record_key: Option<String>,
+    /// Per-tuple interpolation context for a discovery-driven `for_each` row
+    /// (#501): `{dim_id -> { alias: value }}`. `None` for roots/children.
+    product_ctx: Option<HashMap<String, Value>>,
 }
 
 async fn run_unit(
     unit: &Unit,
     capture: Option<Arc<Projection>>,
     captured: &CapturedRecords,
+    discovered: &DiscoveredDims,
     opts: &ExecuteOptions,
     cancel: CancellationToken,
 ) -> InvocationOutcome {
+    // A discovery row (#501) enumerates a value-set instead of running a
+    // source→sink pipeline: build its source, drain it, project + dedup, and
+    // publish the dimension for dependent `for_each` rows. No sink, no capture.
+    if let NodeRole::Discovery { select, as_alias } = &unit.node.role {
+        return run_discovery(&unit.node, select, as_alias, discovered, opts).await;
+    }
     let needs_capture = capture.is_some();
     let started = std::time::Instant::now();
     let result = run_one_invocation(
         &unit.node,
         unit.parent_record.as_deref(),
+        unit.product_ctx.as_ref(),
         &unit.state_key,
         capture,
         opts,
@@ -634,6 +729,73 @@ async fn run_unit(
             records_written: 0,
             error: Some(e.to_string()),
             metrics: Some(base_metrics()),
+        },
+    }
+}
+
+/// Run a discovery row (#501): build its source, drain it, project `select`,
+/// dedup, and publish the dimension for dependent `for_each` rows. No sink is
+/// built and nothing is written — the outcome records the enumerated count.
+async fn run_discovery(
+    node: &ExpandedNode,
+    select: &str,
+    as_alias: &str,
+    discovered: &DiscoveredDims,
+    opts: &ExecuteOptions,
+) -> InvocationOutcome {
+    let started = std::time::Instant::now();
+    let source_kind = node.source.kind.clone();
+    let result: CliResult<usize> = async {
+        let mut cfg = node.source.config.clone();
+        // `${now.*}` resolves for a discovery source like any other; `${vars}`
+        // and shared `auth: { ref }` are already handled by the registry build.
+        resolve_now_inplace(&mut cfg, opts.clock)?;
+        let source = build_source(
+            &source_kind,
+            cfg,
+            &opts.auth,
+            opts.resilience.as_ref().map(|r| &r.retry),
+        )
+        .await?;
+        let records = source.fetch_all().await?;
+        let values = crate::discovery_matrix::project_dedup(&records, select);
+        let n = values.len();
+        discovered.lock().await.insert(
+            node.id.clone(),
+            crate::discovery_matrix::Dim {
+                id: node.id.clone(),
+                alias: as_alias.to_string(),
+                values,
+            },
+        );
+        Ok(n)
+    }
+    .await;
+    let duration_ms = started.elapsed().as_millis() as u64;
+    let metrics = |records_read: usize| InvocationMetrics {
+        source_kind: source_kind.clone(),
+        sink_kind: String::new(),
+        duration_ms,
+        records_read: Some(records_read as u64),
+        ..Default::default()
+    };
+    match result {
+        Ok(n) => {
+            tracing::info!(row = %node.id, values = n, "discovery dimension enumerated");
+            InvocationOutcome {
+                row_id: node.id.clone(),
+                parent_record_key: None,
+                records_written: 0,
+                error: None,
+                metrics: Some(metrics(n)),
+            }
+        }
+        Err(e) => InvocationOutcome {
+            row_id: node.id.clone(),
+            parent_record_key: None,
+            records_written: 0,
+            error: Some(e.to_string()),
+            metrics: Some(metrics(0)),
         },
     }
 }
@@ -970,6 +1132,7 @@ async fn build_pipeline<'a>(
 async fn run_one_invocation(
     node: &ExpandedNode,
     parent_record: Option<&Value>,
+    product_ctx: Option<&HashMap<String, Value>>,
     state_key: &str,
     capture: Option<Arc<Projection>>,
     opts: &ExecuteOptions,
@@ -1034,12 +1197,26 @@ async fn run_one_invocation(
         reject_unresolved_backfill_tokens(scope, "complete_for")?;
     }
 
-    if let (Some(record), NodeRole::Child { parent_id, .. }) = (parent_record, &node.role) {
-        let ctx: HashMap<String, Value> = HashMap::from([(parent_id.clone(), record.clone())]);
-        resolve_inplace(&mut source_cfg, &ctx)?;
-        resolve_inplace(&mut sink_cfg, &ctx)?;
-        if let Some(scope) = cleanup_scope.as_mut() {
-            resolve_inplace(scope, &ctx)?;
+    // Runtime fan-out context. A `parent:` child sees `{parent_id: record}`;
+    // a discovery-driven `for_each` row (#501) sees `{dim_id: {alias: value}}`
+    // for each dimension in its product tuple. Both resolve `${id.path}` tokens
+    // through the same `interpolate_record` path.
+    {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        if let (Some(record), NodeRole::Child { parent_id, .. }) = (parent_record, &node.role) {
+            ctx.insert(parent_id.clone(), record.clone());
+        }
+        if let Some(pc) = product_ctx {
+            for (k, v) in pc {
+                ctx.insert(k.clone(), v.clone());
+            }
+        }
+        if !ctx.is_empty() {
+            resolve_inplace(&mut source_cfg, &ctx)?;
+            resolve_inplace(&mut sink_cfg, &ctx)?;
+            if let Some(scope) = cleanup_scope.as_mut() {
+                resolve_inplace(scope, &ctx)?;
+            }
         }
     }
 

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -122,6 +122,13 @@ pub enum NodeRole {
         parent_id: String,
         parent_key: String,
     },
+    /// Discovery dimension (#501) — runs its source once, projects `select`,
+    /// dedups, and publishes the value-set under `as_alias`. No sink.
+    Discovery { select: String, as_alias: String },
+    /// Discovery-driven fan-out (#501) — runs once per tuple of the cartesian
+    /// product of the named discovery dimensions. `dims` are discovery row ids
+    /// (also mirrored into `depends_on` for readiness/skip/cycle reuse).
+    Product { dims: Vec<String> },
 }
 
 #[derive(Debug, Clone)]
@@ -290,6 +297,8 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             delivery: None,
             tags: Vec::new(),
             partition: None,
+            discover: None,
+            for_each: Vec::new(),
         }];
         &synthetic_row
     } else {
@@ -313,6 +322,83 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
         ids.push(id);
     }
     let id_set: HashSet<&str> = ids.iter().map(String::as_str).collect();
+
+    // 1b) Discovery-driven matrix (#501): identify `discover:` rows and validate
+    // the `discover:` / `for_each:` shapes before the graph checks below, so
+    // `for_each` dims can be folded into the dependency graph.
+    let discovery_ids: HashSet<&str> = rows
+        .iter()
+        .zip(ids.iter())
+        .filter(|(row, _)| row.discover.is_some())
+        .map(|(_, id)| id.as_str())
+        .collect();
+    for (i, row) in rows.iter().enumerate() {
+        let id = ids[i].as_str();
+        if let Some(disc) = &row.discover {
+            if !row.for_each.is_empty() {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': a `discover:` row cannot also declare `for_each:`"
+                )));
+            }
+            if row.parent.is_some() {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': a `discover:` row cannot also declare `parent:`"
+                )));
+            }
+            if row.sink.is_some() {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': a `discover:` row has no sink — remove its `sink:` override"
+                )));
+            }
+            if row.transforms.is_some() {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': a `discover:` row does not run transforms"
+                )));
+            }
+            if disc.select.trim().is_empty() {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': `discover.select` must not be empty"
+                )));
+            }
+            if !is_ident(&disc.as_alias) {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': `discover.as` ('{}') must match ^[a-z0-9][a-z0-9_-]*$",
+                    disc.as_alias
+                )));
+            }
+        }
+        if !row.for_each.is_empty() {
+            if row.parent.is_some() {
+                return Err(CliError::Config(format!(
+                    "matrix row '{id}': `for_each:` and `parent:` cannot be combined (v1) — a row \
+                     fans out over the discovery cross-product OR a parent's records, not both"
+                )));
+            }
+            let mut seen_dims: HashSet<&str> = HashSet::new();
+            for dim in &row.for_each {
+                if dim.as_str() == id {
+                    return Err(CliError::Config(format!(
+                        "matrix row '{id}': `for_each` cannot reference itself"
+                    )));
+                }
+                if !id_set.contains(dim.as_str()) {
+                    return Err(CliError::Config(format!(
+                        "matrix row '{id}': `for_each` references unknown row '{dim}'"
+                    )));
+                }
+                if !discovery_ids.contains(dim.as_str()) {
+                    return Err(CliError::Config(format!(
+                        "matrix row '{id}': `for_each` row '{dim}' is not a `discover:` row"
+                    )));
+                }
+                if !seen_dims.insert(dim.as_str()) {
+                    return Err(CliError::Config(format!(
+                        "matrix row '{id}': `for_each` lists '{dim}' more than once"
+                    )));
+                }
+            }
+        }
+    }
 
     // 2) Validate parents + detect cycles.
     let mut parents: HashMap<&str, &str> = HashMap::new();
@@ -358,6 +444,14 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
             if !deps.contains(dep) {
                 deps.push(dep.clone());
+            }
+        }
+        // A `for_each` row (#501) waits for every discovery dimension it fans
+        // out over; model those as `depends_on` edges so readiness, the skip
+        // cascade, and cycle detection all reuse the existing machinery.
+        for dim in &row.for_each {
+            if !deps.contains(dim) {
+                deps.push(dim.clone());
             }
         }
         deps_by_row.push(deps);
@@ -421,6 +515,72 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
     for &i in &order {
         let row = &rows[i];
         let row_id = ids[i].as_str();
+
+        // Discovery row (#501): a value-enumeration step with no sink. Build a
+        // minimal node from `discover.source` and skip the entire source→sink
+        // pipeline (templates, write-mode, exactly-once, drift, cleanup) — none
+        // of it applies to an enumeration that writes nothing.
+        if let Some(disc) = &row.discover {
+            // Resolve the discovery source: a `{ ref }` merges over the named
+            // `pipeline.sources` template; a standalone `{ type, config }` is
+            // used verbatim (NOT merged over `default`, which would pollute the
+            // enumeration with the data source's `${dim}` tokens).
+            let src = if disc.source.r#ref.is_some() {
+                registry.resolve("source", row_id, Some(&disc.source))?
+            } else {
+                let kind = disc.source.kind.clone().ok_or_else(|| {
+                    CliError::Config(format!(
+                        "matrix row '{row_id}': `discover.source` needs a `type` (or a `ref` to a \
+                         pipeline.sources template)"
+                    ))
+                })?;
+                ConnectorSpec {
+                    kind,
+                    config: disc
+                        .source
+                        .config
+                        .clone()
+                        .unwrap_or_else(|| Value::Object(Default::default())),
+                    transforms: None,
+                    inherit_transforms: true,
+                    status: None,
+                    tags: Vec::new(),
+                    complete_for: None,
+                }
+            };
+            out.push(ExpandedNode {
+                id: ids[i].clone(),
+                row_index: i,
+                role: NodeRole::Discovery {
+                    select: disc.select.clone(),
+                    as_alias: disc.as_alias.clone(),
+                },
+                // `sink` is a never-built placeholder (run_discovery ignores it).
+                sink: src.clone(),
+                source: src,
+                transforms: Vec::new(),
+                state: None,
+                dlq: None,
+                delivery: faucet_core::DeliveryMode::AtLeastOnce,
+                delivery_guarantee: faucet_core::DeliveryGuarantee::AtLeastOnce,
+                #[cfg(feature = "quality")]
+                quality: None,
+                #[cfg(feature = "contract")]
+                contract: None,
+                #[cfg(feature = "masking")]
+                masking: None,
+                sink_ref: "default".to_string(),
+                schema: None,
+                depends_on: deps_by_row[i].clone(),
+                status: crate::config::SourceStatus::default(),
+                tags: Vec::new(),
+                deferred_refs: Vec::new(),
+                source_override: None,
+                cleanup_scope: None,
+            });
+            continue;
+        }
+
         let merged_source = registry.resolve("source", row_id, row.source.as_ref())?;
         let merged_sink = registry.resolve("sink", row_id, row.sink.as_ref())?;
         // The sink template name this row resolved (or the legacy `default`),
@@ -430,12 +590,20 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             .as_ref()
             .and_then(|s| s.r#ref.clone())
             .unwrap_or_else(|| "default".to_string());
-        let role = match &row.parent {
-            None => NodeRole::Root,
-            Some(p) => NodeRole::Child {
-                parent_id: p.clone(),
-                parent_key: row.parent_key.clone(),
-            },
+        let role = if !row.for_each.is_empty() {
+            // Discovery-driven fan-out (#501): runs once per cartesian-product
+            // tuple of the named dimensions (also mirrored into `depends_on`).
+            NodeRole::Product {
+                dims: row.for_each.clone(),
+            }
+        } else {
+            match &row.parent {
+                None => NodeRole::Root,
+                Some(p) => NodeRole::Child {
+                    parent_id: p.clone(),
+                    parent_key: row.parent_key.clone(),
+                },
+            }
         };
         let mut deferred = Vec::new();
         collect_deferred(&merged_source.config, &mut deferred);
@@ -1197,6 +1365,17 @@ fn resolve_tags(
     Ok(set.into_iter().collect())
 }
 
+/// True when `s` matches `^[a-z0-9][a-z0-9_-]*$` (a discovery alias, #501).
+fn is_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() || c.is_ascii_digit() => {
+            chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+        }
+        _ => false,
+    }
+}
+
 /// A tag must be lowercase kebab/snake: `^[a-z0-9][a-z0-9_-]*$`.
 fn validate_tag(tag: &str, row_id: &str) -> CliResult<()> {
     let ok = {
@@ -1527,6 +1706,141 @@ matrix:
         assert!(matches!(facts.role, NodeRole::Root));
         let dims = nodes.iter().find(|n| n.id == "dims").unwrap();
         assert!(dims.depends_on.is_empty());
+    }
+
+    // ── Discovery-driven request matrix (#501) ─────────────────────────────
+
+    fn disc_cfg(matrix: &str) -> String {
+        format!(
+            r#"
+version: 1
+pipeline: {{ source: {{ type: rest, config: {{}} }}, sink: {{ type: jsonl, config: {{ path: ./o }} }} }}
+matrix:
+{matrix}
+"#
+        )
+    }
+
+    #[test]
+    fn discovery_and_product_roles_are_assigned() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: subs
+    discover:
+      source: { type: rest, config: {} }
+      select: "$.id"
+      as: subsidiary_id
+  - id: report
+    for_each: [subs]"#,
+        ));
+        let nodes = expand(&c).unwrap();
+        let subs = nodes.iter().find(|n| n.id == "subs").unwrap();
+        match &subs.role {
+            NodeRole::Discovery { select, as_alias } => {
+                assert_eq!(select, "$.id");
+                assert_eq!(as_alias, "subsidiary_id");
+            }
+            other => panic!("expected Discovery, got {other:?}"),
+        }
+        let report = nodes.iter().find(|n| n.id == "report").unwrap();
+        match &report.role {
+            NodeRole::Product { dims } => assert_eq!(dims, &vec!["subs".to_string()]),
+            other => panic!("expected Product, got {other:?}"),
+        }
+        // The dim is folded into depends_on so readiness/skip/cycle reuse it.
+        assert_eq!(report.depends_on, vec!["subs".to_string()]);
+    }
+
+    #[test]
+    fn discover_with_for_each_is_rejected() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: a
+    discover: { source: { type: rest, config: {} }, select: "$.id", as: x }
+    for_each: [a]"#,
+        ));
+        let err = expand(&c).unwrap_err().to_string();
+        assert!(err.contains("cannot also declare"), "{err}");
+    }
+
+    #[test]
+    fn discover_with_sink_is_rejected() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: a
+    discover: { source: { type: rest, config: {} }, select: "$.id", as: x }
+    sink: { type: jsonl, config: { path: ./o } }"#,
+        ));
+        let err = expand(&c).unwrap_err().to_string();
+        assert!(err.contains("has no sink"), "{err}");
+    }
+
+    #[test]
+    fn for_each_on_non_discovery_row_is_rejected() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: plain
+  - id: report
+    for_each: [plain]"#,
+        ));
+        let err = expand(&c).unwrap_err().to_string();
+        assert!(err.contains("is not a `discover:` row"), "{err}");
+    }
+
+    #[test]
+    fn for_each_unknown_row_is_rejected() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: report
+    for_each: [ghost]"#,
+        ));
+        let err = expand(&c).unwrap_err().to_string();
+        assert!(err.contains("unknown row 'ghost'"), "{err}");
+    }
+
+    #[test]
+    fn for_each_with_parent_is_rejected() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: subs
+    discover: { source: { type: rest, config: {} }, select: "$.id", as: x }
+  - id: p
+  - id: report
+    parent: p
+    for_each: [subs]"#,
+        ));
+        let err = expand(&c).unwrap_err().to_string();
+        assert!(err.contains("cannot be combined"), "{err}");
+    }
+
+    #[test]
+    fn discover_bad_alias_is_rejected() {
+        let c = cfg(&disc_cfg(
+            r#"  - id: a
+    discover: { source: { type: rest, config: {} }, select: "$.id", as: "Bad Alias" }"#,
+        ));
+        let err = expand(&c).unwrap_err().to_string();
+        assert!(err.contains("must match"), "{err}");
+    }
+
+    #[test]
+    fn discovery_source_ref_resolves_named_template() {
+        let c = cfg(r#"
+version: 1
+pipeline:
+  sources:
+    api: { type: rest, config: { base_url: https://x, path: /list } }
+  sink: { type: jsonl, config: { path: ./o } }
+matrix:
+  - id: subs
+    discover:
+      source: { ref: api, config: { path: /subsidiaries } }
+      select: "$.id"
+      as: sid
+  - id: report
+    for_each: [subs]
+    source: { ref: api }
+"#);
+        let nodes = expand(&c).unwrap();
+        let subs = nodes.iter().find(|n| n.id == "subs").unwrap();
+        // The named template resolved (kind rest) and the override applied.
+        assert_eq!(subs.source.kind, "rest");
+        assert_eq!(subs.source.config["path"], "/subsidiaries");
+        assert_eq!(subs.source.config["base_url"], "https://x");
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod commands;
 pub mod compose;
 pub mod config;
 pub mod conformance;
+pub mod discovery_matrix;
 pub mod dlq_replay;
 pub mod env_config;
 pub mod env_loader;

--- a/cli/tests/discovery_matrix.rs
+++ b/cli/tests/discovery_matrix.rs
@@ -1,0 +1,264 @@
+//! End-to-end wiring for the discovery-driven request matrix (#501): a
+//! `discover:` row enumerates a value-set from a live endpoint, and a
+//! `for_each:` row fans out over the cartesian product of those dimensions —
+//! one invocation per tuple, with `${dim.alias}` resolved into the source URL
+//! and sink path. Discovery + fan-out rows share one `pipeline.sources`
+//! template (the `ref` path), overriding only path / records_path / query.
+
+use faucet_cli::config::PipelineConfig;
+use faucet_cli::executor::{ExecuteOptions, run_expanded};
+use faucet_cli::expand::expand;
+use std::path::Path;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn opts() -> ExecuteOptions {
+    ExecuteOptions {
+        pipeline_name: "disc_test".into(),
+        run_id: None,
+        execution: None,
+        dry_run: false,
+        limit: None,
+        state_path_override: None,
+        shard: None,
+        auth: Default::default(),
+        clock: chrono::Utc::now().fixed_offset(),
+        cancel: None,
+        resilience: None,
+        sla: None,
+        reconcile: None,
+        #[cfg(feature = "lineage")]
+        lineage: None,
+        #[cfg(feature = "lineage")]
+        lineage_cfg: None,
+        #[cfg(feature = "notify")]
+        notifier: None,
+        #[cfg(feature = "catalog")]
+        catalog: None,
+    }
+}
+
+fn read_ids(path: &Path) -> Vec<i64> {
+    let text = std::fs::read_to_string(path).unwrap_or_default();
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str::<serde_json::Value>(l).unwrap()["v"]
+                .as_i64()
+                .unwrap()
+        })
+        .collect()
+}
+
+/// A complete `pipeline.sources.api` rest template block (all rest-required
+/// fields), so discovery + fan-out rows can `ref: api` and override only the
+/// path / records_path / query_params deltas.
+fn api_template(uri: &str) -> String {
+    format!(
+        r#"  sources:
+    api:
+      type: rest
+      config:
+        method: GET
+        auth: {{ type: none }}
+        base_url: "{uri}"
+        path: "/"
+        query_params: {{}}
+        pagination: {{ type: None }}
+        max_retries: 0
+        retry_backoff: 1
+        tolerated_http_errors: []
+        replication_method: {{ type: FullTable }}
+        primary_keys: []
+        partitions: []
+        schema_sample_size: 100
+"#
+    )
+}
+
+#[tokio::test]
+async fn single_dimension_fan_out() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/subsidiaries"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "subsidiaries": [{"id": 10}, {"id": 20}]
+        })))
+        .mount(&server)
+        .await;
+    for sid in [10, 20] {
+        Mock::given(method("GET"))
+            .and(path("/report"))
+            .and(query_param("subsidiary_id", sid.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "rows": [{"v": sid}]
+            })))
+            .mount(&server)
+            .await;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let yaml = format!(
+        r#"version: 1
+name: disc_test
+pipeline:
+{template}  sink:
+    type: jsonl
+    config: {{ path: "{out}/${{subs.subsidiary_id}}.jsonl" }}
+matrix:
+  - id: subs
+    discover:
+      source:
+        ref: api
+        config: {{ path: "/subsidiaries", records_path: "$.subsidiaries[*]" }}
+      select: "$.id"
+      as: subsidiary_id
+  - id: report
+    for_each: [subs]
+    source:
+      ref: api
+      config:
+        path: "/report"
+        records_path: "$.rows[*]"
+        query_params: {{ subsidiary_id: "${{subs.subsidiary_id}}" }}
+"#,
+        template = api_template(&server.uri()),
+        out = out.display()
+    );
+
+    let cfg = PipelineConfig::from_text(&yaml, Path::new("disc.yaml")).unwrap();
+    let nodes = expand(&cfg).unwrap();
+    let summary = run_expanded(nodes, opts()).await.unwrap();
+    assert!(!summary.had_failures(), "run failed: {summary:?}");
+
+    assert_eq!(read_ids(&out.join("10.jsonl")), vec![10]);
+    assert_eq!(read_ids(&out.join("20.jsonl")), vec![20]);
+}
+
+#[tokio::test]
+async fn empty_discovery_skips_the_fan_out_row() {
+    let server = MockServer::start().await;
+    // Discovery returns no subsidiaries → the product has zero tuples.
+    Mock::given(method("GET"))
+        .and(path("/subsidiaries"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "subsidiaries": []
+        })))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let yaml = format!(
+        r#"version: 1
+name: disc_test
+pipeline:
+{template}  sink:
+    type: jsonl
+    config: {{ path: "{out}/${{subs.subsidiary_id}}.jsonl" }}
+matrix:
+  - id: subs
+    discover:
+      source: {{ ref: api, config: {{ path: "/subsidiaries", records_path: "$.subsidiaries[*]" }} }}
+      select: "$.id"
+      as: subsidiary_id
+  - id: report
+    for_each: [subs]
+    source:
+      ref: api
+      config: {{ path: "/report", records_path: "$.rows[*]" }}
+"#,
+        template = api_template(&server.uri()),
+        out = out.display()
+    );
+
+    let cfg = PipelineConfig::from_text(&yaml, Path::new("disc.yaml")).unwrap();
+    let nodes = expand(&cfg).unwrap();
+    let summary = run_expanded(nodes, opts()).await.unwrap();
+    // Discovery succeeded (0 values); the fan-out row produced no invocations
+    // and the run did not fail.
+    assert!(!summary.had_failures(), "run failed: {summary:?}");
+    assert!(
+        std::fs::read_dir(&out).unwrap().next().is_none(),
+        "no output expected"
+    );
+}
+
+#[tokio::test]
+async fn cross_product_of_two_dimensions() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/subsidiaries"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "subsidiaries": [{"id": 1}, {"id": 2}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "fields": [{"code": 100}, {"code": 200}]
+        })))
+        .mount(&server)
+        .await;
+    for sid in [1, 2] {
+        for fld in [100, 200] {
+            Mock::given(method("GET"))
+                .and(path("/report"))
+                .and(query_param("subsidiary_id", sid.to_string()))
+                .and(query_param("field", fld.to_string()))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "rows": [{"v": sid * 1000 + fld}]
+                })))
+                .mount(&server)
+                .await;
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let yaml = format!(
+        r#"version: 1
+name: disc_test
+pipeline:
+{template}  sink:
+    type: jsonl
+    config: {{ path: "{out}/${{subs.subsidiary_id}}-${{flds.field}}.jsonl" }}
+matrix:
+  - id: subs
+    discover:
+      source: {{ ref: api, config: {{ path: "/subsidiaries", records_path: "$.subsidiaries[*]" }} }}
+      select: "$.id"
+      as: subsidiary_id
+  - id: flds
+    discover:
+      source: {{ ref: api, config: {{ path: "/fields", records_path: "$.fields[*]" }} }}
+      select: "$.code"
+      as: field
+  - id: report
+    for_each: [subs, flds]
+    source:
+      ref: api
+      config:
+        path: "/report"
+        records_path: "$.rows[*]"
+        query_params: {{ subsidiary_id: "${{subs.subsidiary_id}}", field: "${{flds.field}}" }}
+"#,
+        template = api_template(&server.uri()),
+        out = out.display()
+    );
+
+    let cfg = PipelineConfig::from_text(&yaml, Path::new("disc.yaml")).unwrap();
+    let nodes = expand(&cfg).unwrap();
+    let summary = run_expanded(nodes, opts()).await.unwrap();
+    assert!(!summary.had_failures(), "run failed: {summary:?}");
+
+    assert_eq!(read_ids(&out.join("1-100.jsonl")), vec![1100]);
+    assert_eq!(read_ids(&out.join("1-200.jsonl")), vec![1200]);
+    assert_eq!(read_ids(&out.join("2-100.jsonl")), vec![2100]);
+    assert_eq!(read_ids(&out.join("2-200.jsonl")), vec![2200]);
+}

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -311,6 +311,68 @@ Semantics:
 - Ordering works identically under `faucet run`, `schedule`, and `serve` —
   they all execute the same expanded plan.
 
+### `discover:` / `for_each:` — discovery-driven fan-out (#501)
+
+A `discover:` row enumerates a **value-set at run time** from a live endpoint,
+and a `for_each:` row fans a stream out over the **cartesian product** of those
+value-sets — "sync this report once per `{subsidiary} × {custom-field}`
+returned by a discovery call". This is the first-class version of the
+"enumerate then fan out" shape common to report-style APIs.
+
+```yaml
+pipeline:
+  sources:
+    api:                      # one complete template both roles reference
+      type: rest
+      config: { method: GET, base_url: "https://api.example.com", path: "/", auth: { type: none },
+                query_params: {}, pagination: { type: None }, replication_method: { type: FullTable } }
+  sink: { type: jsonl, config: { path: "./out/${subs.subsidiary_id}-${flds.field_id}.jsonl" } }
+
+matrix:
+  - id: subs                  # discovery dimension
+    discover:
+      source: { ref: api, config: { path: "/subsidiaries", records_path: "$.subsidiaries[*]" } }
+      select: "$.id"          # JSONPath projecting the value from each record
+      as: subsidiary_id       # exposed as ${subs.subsidiary_id}
+  - id: flds
+    discover:
+      source: { ref: api, config: { path: "/fields", records_path: "$.fields[*]" } }
+      select: "$.id"
+      as: field_id
+  - id: report                # runs once per (subsidiary × field) tuple
+    for_each: [subs, flds]
+    source:
+      ref: api
+      config:
+        path: "/reports/trial-balance"
+        records_path: "$.rows[*]"
+        query_params: { subsidiary_id: "${subs.subsidiary_id}", field_id: "${flds.field_id}" }
+```
+
+Semantics:
+
+- A **`discover:` row** runs its source once, projects `select` (a dot-path,
+  optionally `$`-prefixed; `$` = whole record) from each record, and **dedups**
+  (first-seen order; null / missing values skipped). It has **no sink** and
+  writes nothing. It runs once per pipeline run, cached across all dependents.
+- The discovery `source` is either a `{ ref: <name> }` to a `pipeline.sources`
+  template (recommended — reuses a complete connector config) or a standalone
+  `{ type, config }`. It is **not** merged over the `default` template.
+- A **`for_each: [dims]` row** runs once per tuple of the cartesian product of
+  the listed dimensions, with `${<dim>.<alias>}` substituted into its source
+  and sink config. Time windows (`${now.*}`, `faucet backfill`) compose
+  per-invocation without multiplying the matrix.
+- Each dimension is folded into the row's `depends_on`, so readiness, the skip
+  cascade, and cycle detection reuse the ordering machinery. Per-tuple state
+  keys (`{name}::{row}::alias=value&…`) let every cell resume independently.
+- Guards (all at load time via `faucet validate`): `for_each` must name
+  `discover:` rows; a `discover:` row can't carry a sink, `parent:`, or
+  `for_each:`; `for_each` can't combine with `parent:` (v1). The product is
+  bounded by `MAX_MATRIX_PRODUCT` (10 000) — a larger cross-product fails
+  rather than spawning an unbounded fleet.
+
+See `cli/examples/discovery_matrix.yaml`.
+
 ## `pipeline.nodes` / `pipeline.edges` (topology mode)
 
 An alternative to `matrix:` for pipelines that need fan-out, fan-in, or joins:

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -2002,6 +2002,24 @@
               "type": "null"
             }
           ]
+        },
+        "discover": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiscoverSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**Discovery dimension** (#501). When set, this row enumerates a value-set\nat runtime: it builds `discover.source`, drains it, projects `select`\n(JSONPath) from each record, and dedups (first-seen order). The row has\nno sink and writes nothing — its value-set is exposed to `for_each` rows\nas `${<id>.<as>}`. Runs once per pipeline run, cached across dependents."
+        },
+        "for_each": {
+          "description": "Fan this row out over the **cartesian product** of the named discovery\ndimensions (#501) — one invocation per tuple, with `${<dim>.<as>}`\nresolved to that tuple's value in the source/sink config. Distinct from\n`parent:` (fan-out over one real pipeline's emitted records — a tree, not\na product) and `depends_on:` (completion ordering only). Each id must name\na `discover:` row; the product is bounded by `MAX_MATRIX_PRODUCT`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false
@@ -17309,6 +17327,30 @@
           "type": "string"
         }
       ]
+    },
+    "DiscoverSpec": {
+      "additionalProperties": false,
+      "description": "A discovery dimension's source + projection (#501). See [`MatrixRow::discover`].",
+      "properties": {
+        "as": {
+          "description": "Alias the projected value is exposed under: a `for_each` row references\nit as `${<row_id>.<as>}`. Must match `^[a-z0-9][a-z0-9_-]*$`.",
+          "type": "string"
+        },
+        "select": {
+          "description": "JSONPath projecting the dimension value from each discovered record\n(e.g. `$.id`). `$` selects the whole record. Null / missing values are\nskipped with a warning.",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/PartialConnector",
+          "description": "Source to enumerate. Either a `{ ref: <name> }` pointing at a\n`pipeline.sources` template (recommended — reuses a complete connector\nconfig), or a standalone `{ type, config }`. It is **not** merged over\nthe `default` template — a discovery step is independent of the\npipeline's data source (which typically carries `${dim}` tokens meant\nfor the fan-out rows, not the enumeration)."
+        }
+      },
+      "required": [
+        "source",
+        "select",
+        "as"
+      ],
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
Closes #501.

## What

Adds a **discovery-driven request matrix**: a `discover:` row enumerates a value-set at run time, and a `for_each: [dims]` row fans a stream out over the **cartesian product** of those dimensions — one invocation per tuple, with `${dim.alias}` substituted into the source/sink config. This is the first-class "enumerate then fan out" shape report-style APIs need (rillet: subsidiary × custom-field × month; Dynamics 365 BC: entity per company).

```yaml
matrix:
  - id: subs
    discover:
      source: { ref: api, config: { path: /subsidiaries, records_path: "$.subsidiaries[*]" } }
      select: "$.id"
      as: subsidiary_id
  - id: fields
    discover:
      source: { ref: api, config: { path: /custom-fields, records_path: "$.fields[*]" } }
      select: "$.id"
      as: field_id
  - id: trial_balance
    for_each: [subs, fields]        # |subs| × |fields| invocations
    source:
      ref: api
      config:
        path: /reports/trial-balance
        query_params: { subsidiary_id: "${subs.subsidiary_id}", field_id: "${fields.field_id}" }
```

## Design

- **`discovery_matrix` module** holds the pure planning logic — projection + dedup, cartesian product, per-tuple interpolation context, tuple state-key suffix — fully unit-tested (the acceptance criterion).
- **`NodeRole::Discovery` / `Product`** extend the executor. `for_each` dims are folded into `depends_on`, so readiness, the skip-cascade, and cycle detection all reuse the existing machinery — only the fan-out branch is new. `Unit` carries a multi-key product context resolved through the same `interpolate_record` path as parent/child. Discovery runs source-only via `run_discovery` (no sink).
- **Discovery source** is a `{ ref }` to a `pipeline.sources` template (recommended — reuses a complete connector config) or a standalone `{ type, config }`; it is **not** merged over the `default` template (which carries `${dim}` tokens meant for the fan-out rows — that would self-reference the enumeration).
- **Composition**: `${now.*}` / `faucet backfill` windows stay per-invocation, so "month × subsidiary × field" is a date window over the discovery cross-product for free.
- **Guards** (load-time, via `faucet validate`): `for_each` must name `discover:` rows; a discovery row has no sink and can't be `parent:`/`for_each:`; `for_each` + `parent:` is rejected (v1); the product is bounded by `MAX_MATRIX_PRODUCT` (10 000).

## Tests / docs

- Pure unit tests (projection/dedup/cartesian/product-size/state-key), expand-time validation + role assignment + `ref`-template resolution, and wiremock end-to-end (single dimension, two-dimension cross-product, empty-discovery skip). No regressions in the existing executor/expand suites.
- Committed config JSON schema (`MatrixRow.discover`/`for_each` + `DiscoverSpec`), `docs/book/src/reference/config.md`, `cli/README.md`, and a runnable `cli/examples/discovery_matrix.yaml`.

Scope chosen with the maintainer: **full cross-product** (multi-dimension), not single-dimension. Out of scope (v1): `for_each` + `parent:` on one row; report-tree flattening (a transform, tracked separately).

Part of the roadmap epic #38.