### PR TITLE
fix(transforms): drop dangling transform-unpivot cfg from CdcUnwrap match arms

### DIFF
--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -932,7 +932,6 @@ pub fn compile_stage(s: &TransformStage) -> Result<CompiledStage, FaucetError> {
         TransformStage::Explode(spec) => {
             Ok(CompiledStage::Explode(CompiledExplode::compile(spec)?))
         }
-        #[cfg(feature = "transform-unpivot")]
         #[cfg(feature = "transform-cdc-unwrap")]
         TransformStage::CdcUnwrap(spec) => {
             Ok(CompiledStage::CdcUnwrap(CompiledCdcUnwrap::compile(spec)?))
@@ -995,7 +994,6 @@ fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, Fauc
         }
         #[cfg(feature = "transform-explode")]
         CompiledStage::Explode(e) => e.apply(rec),
-        #[cfg(feature = "transform-unpivot")]
         #[cfg(feature = "transform-cdc-unwrap")]
         CompiledStage::CdcUnwrap(c) => c.apply(rec),
         CompiledStage::Custom(f) => Ok(f(rec)),


### PR DESCRIPTION
## Summary

Follow-up to #520. Removing the `Unpivot` match arms left a stray `#[cfg(feature = "transform-unpivot")]` attribute stacked onto the following `CdcUnwrap` arm in `compile_stage` and `apply_one_stage` (`crates/core/src/stage.rs`). Stacked `#[cfg]`s AND together, so the `CdcUnwrap` arm ended up requiring **both** `transform-unpivot` **and** `transform-cdc-unwrap`.

Under a feature set that enables `transform-cdc-unwrap` but not `transform-unpivot` — e.g. `faucet-stream --features full` (the `Feature isolation (full)` CI job) — the `CdcUnwrap` arm disappeared and the match became non-exhaustive:

```
error[E0004]: non-exhaustive patterns: `&TransformStage::CdcUnwrap(_)` not covered
error[E0004]: non-exhaustive patterns: `&CompiledStage::CdcUnwrap(_)` not covered
```

The local `--features transforms` build enabled both features, masking it; `Feature isolation` is a non-required check, so #520 merged with the break on `main`.

## Fix

Gate the `CdcUnwrap` arms on `transform-cdc-unwrap` only (2-line removal).

## Verification

- `cargo check -p faucet-core --features transform-cdc-unwrap` (the exact triggering combo, unpivot off): compiles.
- `cargo check -p faucet-core` with no transform features / with both: compile.
- `cargo check -p faucet-stream --no-default-features --features full`: **Finished** (previously E0004).
- Core tests + clippy `--all-features` clean.