### PR TITLE
feat(source): composable auth flows, OData mode + $metadata discovery, server-side incremental push-down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5789,6 +5789,7 @@ dependencies = [
  "futures-core",
  "httpdate",
  "jsonpath-rust",
+ "quick-xml 0.37.5",
  "reqwest 0.13.3",
  "schemars 1.2.1",
  "serde",

--- a/cli/examples/odata_to_jsonl.yaml
+++ b/cli/examples/odata_to_jsonl.yaml
@@ -1,0 +1,47 @@
+# OData source (#512) with server-side incremental push-down (#513).
+#
+# The `odata:` block makes the REST source speak OData natively — it follows
+# `@odata.nextLink` paging, unwraps the `$.value` envelope, and renders the
+# `$select` / `$filter` query options. `replication_bind` then pushes the stored
+# bookmark into the request as an OData `$filter` so the server returns only rows
+# changed since the last run.
+#
+#   faucet validate cli/examples/odata_to_jsonl.yaml
+#   faucet run      cli/examples/odata_to_jsonl.yaml
+#
+# Tip: `faucet discover cli/examples/odata_to_jsonl.yaml` reads the service's
+# `$metadata` (EDMX) and emits one matrix row per entity set, with typed schemas.
+version: 1
+name: odata_orders
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: "https://services.example.com/odata/v4"
+      auth:
+        type: bearer
+        config: { token: "${env:AUTH_TOKEN}" }
+
+      odata:
+        version: v4
+        entity: Orders
+        select: [OrderID, CustomerID, OrderDate, Total]
+        page_size: 500
+
+      # Server-side incremental push-down: the bookmark becomes an OData
+      # `$filter` (`OrderDate gt <bookmark>`). The client-side filter on
+      # `replication_key` stays on as a safety net.
+      replication_method: { type: incremental }
+      replication_key: OrderDate
+      start_replication_value: "2024-01-01T00:00:00Z"
+      replication_bind:
+        into: query
+        name: "$filter"
+        template: "OrderDate gt ${bookmark}"
+        format: iso8601
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/orders.jsonl

--- a/cli/examples/rest_flow_auth.yaml
+++ b/cli/examples/rest_flow_auth.yaml
@@ -1,0 +1,58 @@
+# Composable multi-step auth flow (#511) — a Bullhorn-style login chain.
+#
+# The `flow` provider runs a login/pre-flight chain, captures values from each
+# response by JSONPath, then places a captured token into every data request
+# (here as a query param) and redirects the source to a per-session base-URL
+# captured from the login response (`restUrl`). `reauth_on` re-runs the login
+# when the session expires mid-run.
+#
+#   faucet validate cli/examples/rest_flow_auth.yaml
+#   faucet run      cli/examples/rest_flow_auth.yaml
+version: 1
+name: bullhorn_style_flow
+
+# Shared auth catalog: built once, injected into every connector that
+# references it via `auth: { ref: session }`.
+auth:
+  session:
+    type: flow
+    config:
+      steps:
+        # 1) Exchange a refresh token for an access token.
+        - request:
+            method: POST
+            url: "https://auth.example.com/oauth/token"
+            form:
+              grant_type: refresh_token
+              refresh_token: "${env:AUTH_TOKEN}"
+          capture:
+            access_token: "$.access_token"
+        # 2) Log in with the access token; capture the session token and the
+        #    dynamic REST base-URL the API tells us to use.
+        - request:
+            method: GET
+            url: "https://login.example.com/rest-services/login"
+            query:
+              access_token: "${access_token}"
+          capture:
+            bh_rest_token: "$.BhRestToken"
+            base_url: "$.restUrl"
+      apply:
+        - { into: query, name: BhRestToken, value: "${bh_rest_token}" }
+      base_url_from: "${base_url}"
+      reauth_on: [401]
+
+pipeline:
+  source:
+    type: rest
+    config:
+      # Overridden per-session by the flow's `base_url_from` (`restUrl`).
+      base_url: "https://placeholder.example.com"
+      path: /entity/Candidate
+      auth: { ref: session }
+      records_path: "$.data[*]"
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/candidates.jsonl

--- a/cli/src/commands/discover.rs
+++ b/cli/src/commands/discover.rs
@@ -42,7 +42,8 @@ pub async fn run(args: DiscoverArgs) -> CliResult<()> {
         return Err(CliError::Config(format!(
             "source '{}' does not support dataset discovery — discovery is available for \
              catalog-backed sources (postgres, mysql, mssql, sqlite, mongodb, elasticsearch, \
-             bigquery, snowflake, spanner, s3, gcs)",
+             bigquery, snowflake, spanner, s3, gcs) and for `rest` sources with an `odata:` \
+             block (via OData `$metadata`)",
             spec.kind
         )));
     }

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -34,6 +34,7 @@ pub const RESERVED_IDS: &[&str] = &[
     "backfill",
     "param",
     "partition",
+    "bookmark",
 ];
 
 /// One fully-merged matrix row, ready for the executor.
@@ -1314,6 +1315,7 @@ fn check_refs(value: &Value, id_set: &HashSet<&str>, owner: &str) -> CliResult<(
                 && id != "now"
                 && id != "backfill"
                 && id != "partition"
+                && id != "bookmark"
                 && !id_set.contains(id)
             {
                 return Err(CliError::UnknownInterpolationId {
@@ -1403,8 +1405,10 @@ fn collect_deferred(value: &Value, out: &mut Vec<DeferredRef>) {
                 // `now` / `backfill` / `partition` are reserved built-ins
                 // resolved at run time, not parent-record dependencies — skip
                 // them so the executor doesn't treat them as deferred
-                // parent-record refs.
-                if id == "now" || id == "backfill" || id == "partition" {
+                // parent-record refs. `bookmark` is consumed *inside* a source's
+                // `replication_bind.template` (#513) — the connector renders it,
+                // so the CLI must pass it through untouched.
+                if id == "now" || id == "backfill" || id == "partition" || id == "bookmark" {
                     continue;
                 }
                 out.push(DeferredRef {

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -1595,6 +1595,25 @@ matrix:
     }
 
     #[test]
+    fn bookmark_token_is_reserved_and_passes_through() {
+        // `${bookmark}` is consumed inside a source's `replication_bind.template`
+        // (#513); expand must treat it as a reserved deferred id, not reject it
+        // as an unknown interpolation reference.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://x
+      replication_bind: { into: query, name: since, template: "gt ${bookmark}" }
+  sink: { type: jsonl, config: { path: ./o } }
+"#);
+        let nodes = expand(&c).unwrap();
+        assert_eq!(nodes.len(), 1);
+    }
+
+    #[test]
     fn errors_on_self_parent_cycle() {
         let c = cfg(r#"
 version: 1

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -19,16 +19,17 @@ tokio = { workspace = true, features = ["time", "sync"] }
 reqwest = { workspace = true, features = ["json", "form"] }
 jsonpath-rust.workspace = true
 tracing.workspace = true
-# OAuth1 request signing (#496): RFC 5849 base string + HMAC-SHA256. Optional so
-# the base crate stays crypto-free unless OAuth1 is used.
-hmac = { workspace = true, optional = true }
-sha2 = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
+# HMAC-SHA256 request signing, used by the always-available `flow` provider
+# (#511) and by OAuth1 (#496).
+hmac.workspace = true
+sha2.workspace = true
+base64.workspace = true
+# RFC 3986 percent-encoding — only OAuth1's signature base string needs it.
 percent-encoding = { workspace = true, optional = true }
 
 [features]
 # OAuth1 (one-legged, HMAC-SHA256) request-signing provider.
-oauth1 = ["dep:hmac", "dep:sha2", "dep:base64", "dep:percent-encoding"]
+oauth1 = ["dep:percent-encoding"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -53,6 +53,45 @@ The `faucet-cli` binary always links `faucet-auth` to power the top-level `auth:
 
 Every provider is built from a `{ type, config }` object — the project-wide adjacently-tagged auth shape. The fields below are the keys inside each provider's `config`.
 
+### `flow` (composable multi-step auth)
+
+A small declarative auth *program* (#511): an optional login / pre-flight
+request chain whose responses are captured by JSONPath, credential *placement*
+across header / query / cookie / body, a pluggable HMAC request *signer*, and a
+dynamic per-session base-URL — on top of the single-flight machinery. It's the
+single biggest source-side unlock for session-cookie / multi-step ERP APIs
+(Bullhorn, Acumatica, SAP, Sage/Intacct, SkySlope, …).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `steps` | array | `[]` | Login/pre-flight chain. Each: `request: { method, url, headers, query, form \| json }` + `capture: { name: <JSONPath> }`. Later steps and `apply` see captured values via `${name}`. |
+| `apply` | array | `[]` | Per-request placements: `{ into: header\|query\|cookie\|body, name, value: "${captured}" }`, or a signer `{ sign: { alg: hmac_sha256, key, template, encoding: hex\|base64, into: { header, format: "${sig}" } } }`. |
+| `base_url_from` | string / null | `null` | Template (over captured values) yielding a per-session base-URL that overrides the connector's configured one. |
+| `ttl_secs` | int / null | `null` | Re-run the login chain after this many seconds. |
+| `reauth_on` | array<int> | `[]` | HTTP statuses that trigger a re-login + one retry (honored by the REST source). |
+
+```yaml
+auth:
+  bullhorn:
+    type: flow
+    config:
+      steps:
+        - request: { method: POST, url: "https://auth/oauth/token",
+                     form: { grant_type: refresh_token, refresh_token: "${env:RT}" } }
+          capture: { access_token: "$.access_token" }
+        - request: { method: GET, url: "https://login/rest-services/login",
+                     query: { access_token: "${access_token}" } }
+          capture: { bh_rest_token: "$.BhRestToken", base_url: "$.restUrl" }
+      apply:
+        - { into: query, name: BhRestToken, value: "${bh_rest_token}" }
+      base_url_from: "${base_url}"
+      reauth_on: [401]
+```
+
+Header placements also apply to `xml` / `graphql` sources (via `credential()`);
+query / cookie / body placement and dynamic base-URL are consumed by the `rest`
+source (which reads the richer `request_auth`).
+
 ### `static`
 
 A fixed credential. Exactly one of the three shapes below must be present.

--- a/crates/auth/src/flow.rs
+++ b/crates/auth/src/flow.rs
@@ -605,10 +605,18 @@ mod tests {
         let c = ctx(&[("tok", "T"), ("sid", "S")]);
         let ra = build_request_auth(&apply, &None, &c);
         assert_eq!(ra.placements.len(), 4);
-        assert!(matches!(&ra.placements[0], CredentialPlacement::Header { name, value } if name=="X-Tok" && value=="T"));
-        assert!(matches!(&ra.placements[1], CredentialPlacement::Query { name, value } if name=="access_token" && value=="T"));
-        assert!(matches!(&ra.placements[2], CredentialPlacement::Cookie { name, value } if name=="sid" && value=="S"));
-        assert!(matches!(&ra.placements[3], CredentialPlacement::BodyField { name, value } if name=="auth" && value=="T"));
+        assert!(
+            matches!(&ra.placements[0], CredentialPlacement::Header { name, value } if name=="X-Tok" && value=="T")
+        );
+        assert!(
+            matches!(&ra.placements[1], CredentialPlacement::Query { name, value } if name=="access_token" && value=="T")
+        );
+        assert!(
+            matches!(&ra.placements[2], CredentialPlacement::Cookie { name, value } if name=="sid" && value=="S")
+        );
+        assert!(
+            matches!(&ra.placements[3], CredentialPlacement::BodyField { name, value } if name=="auth" && value=="T")
+        );
         assert!(ra.base_url.is_none());
     }
 
@@ -619,12 +627,18 @@ mod tests {
                         "encoding": "hex", "into": { "header": "Authorization", "format": "SS ${sig}" } } }
         ]))
         .unwrap();
-        let mut c = ctx(&[("client", "abc"), ("ts", "100"), ("base_url", "https://eu.host")]);
+        let mut c = ctx(&[
+            ("client", "abc"),
+            ("ts", "100"),
+            ("base_url", "https://eu.host"),
+        ]);
         c.insert("base_url".to_owned(), "https://eu.host".to_owned());
         let ra = build_request_auth(&apply, &Some("${base_url}".to_owned()), &c);
         assert_eq!(ra.placements.len(), 1);
         let expected = format!("SS {}", hmac_sign("secret", "abc:100", SigEncoding::Hex));
-        assert!(matches!(&ra.placements[0], CredentialPlacement::Header { name, value } if name=="Authorization" && *value==expected));
+        assert!(
+            matches!(&ra.placements[0], CredentialPlacement::Header { name, value } if name=="Authorization" && *value==expected)
+        );
         assert_eq!(ra.base_url.as_deref(), Some("https://eu.host"));
     }
 
@@ -706,16 +720,16 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/token"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({"access_token": "AT"})),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"access_token": "AT"})))
             .mount(&server)
             .await;
         Mock::given(method("GET"))
             .and(path("/login"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                json!({"BhRestToken": "BRT", "restUrl": "https://data.example"}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(
+                    json!({"BhRestToken": "BRT", "restUrl": "https://data.example"}),
+                ),
+            )
             .mount(&server)
             .await;
 
@@ -771,7 +785,9 @@ mod tests {
         let p = FlowProvider::from_config(&cfg).unwrap();
 
         let c1 = p.credential().await.unwrap();
-        assert!(matches!(&c1, Credential::Header { name, value } if name == "X-Session" && value == "S1"));
+        assert!(
+            matches!(&c1, Credential::Header { name, value } if name == "X-Session" && value == "S1")
+        );
         // Cached: no ttl → second call does not re-login.
         let _ = p.credential().await.unwrap();
         assert_eq!(hits.load(Ordering::SeqCst), 1);
@@ -868,7 +884,9 @@ mod tests {
         let p = FlowProvider::from_config(&cfg).unwrap();
         assert_eq!(p.provider_name(), "flow");
         let c = p.credential().await.unwrap();
-        assert!(matches!(&c, Credential::Header { name, value } if name == "Authorization" && value == "Bearer T"));
+        assert!(
+            matches!(&c, Credential::Header { name, value } if name == "Authorization" && value == "Bearer T")
+        );
     }
 
     #[tokio::test]
@@ -958,6 +976,8 @@ mod tests {
         let p = FlowProvider::from_config(&cfg).unwrap();
         let c = p.credential().await.unwrap();
         let expected = format!("HMAC {}", hmac_sign("k", "msg", SigEncoding::Hex));
-        assert!(matches!(&c, Credential::Header { name, value } if name == "Authorization" && *value == expected));
+        assert!(
+            matches!(&c, Credential::Header { name, value } if name == "Authorization" && *value == expected)
+        );
     }
 }

--- a/crates/auth/src/flow.rs
+++ b/crates/auth/src/flow.rs
@@ -675,6 +675,16 @@ mod tests {
     }
 
     #[test]
+    fn build_provider_dispatches_flow() {
+        let p = crate::build_provider(&json!({
+            "type": "flow",
+            "config": { "apply": [ { "into": "header", "name": "X", "value": "v" } ] }
+        }))
+        .unwrap();
+        assert_eq!(p.provider_name(), "flow");
+    }
+
+    #[test]
     fn debug_redacts_and_summarizes() {
         let p = FlowProvider::from_config(&json!({
             "apply": [ { "into": "header", "name": "X", "value": "${t}" } ]
@@ -688,7 +698,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
 
     #[tokio::test]
@@ -806,6 +816,135 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[test]
+    fn config_rejects_empty_step_url() {
+        let cfg: FlowConfig = serde_json::from_value(json!({
+            "steps": [ { "request": { "url": "  " } } ]
+        }))
+        .unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[tokio::test]
+    async fn session_ttl_caches_within_window() {
+        let server = MockServer::start().await;
+        let hits = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(CountingLogin(hits.clone()))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [ { "request": { "method": "POST", "url": format!("{}/login", server.uri()) },
+                         "capture": { "sid": "$.sid" } } ],
+            "apply": [ { "into": "header", "name": "X", "value": "${sid}" } ],
+            "ttl_secs": 3600
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        let _ = p.credential().await.unwrap();
+        // Within the TTL window the session is reused (Session::valid == true).
+        let _ = p.credential().await.unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn login_sends_headers_and_json_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .and(header("x-tenant", "acme"))
+            .and(body_json(json!({"scope": "read"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"tok": "T"})))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [ { "request": { "method": "POST", "url": format!("{}/login", server.uri()),
+                         "headers": {"X-Tenant": "acme"}, "json": {"scope": "read"} },
+                         "capture": { "t": "$.tok" } } ],
+            "apply": [ { "into": "header", "name": "Authorization", "value": "Bearer ${t}" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        assert_eq!(p.provider_name(), "flow");
+        let c = p.credential().await.unwrap();
+        assert!(matches!(&c, Credential::Header { name, value } if name == "Authorization" && value == "Bearer T"));
+    }
+
+    #[tokio::test]
+    async fn login_invalid_method_errors() {
+        let cfg = json!({
+            "steps": [ { "request": { "method": "BAD METHOD", "url": "https://x/login" } } ],
+            "apply": [ { "into": "header", "name": "X", "value": "static" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        assert!(
+            p.request_auth("GET", "https://x", &BTreeMap::new())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn login_send_failure_errors() {
+        // Port 1 is unassignable → the send fails at the transport layer.
+        let cfg = json!({
+            "steps": [ { "request": { "url": "http://127.0.0.1:1/x" }, "capture": { "t": "$.t" } } ],
+            "apply": [ { "into": "header", "name": "X", "value": "${t}" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        assert!(
+            p.request_auth("GET", "https://x", &BTreeMap::new())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn login_non_json_response_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [ { "request": { "url": format!("{}/x", server.uri()) }, "capture": { "t": "$.t" } } ],
+            "apply": [ { "into": "header", "name": "X", "value": "${t}" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        assert!(
+            p.request_auth("GET", "https://x", &BTreeMap::new())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn login_step_with_empty_capture_succeeds() {
+        // A pre-flight step that captures nothing (e.g. establishes a cookie);
+        // its non-JSON body is never parsed.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ping"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"t": "T"})))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [
+                { "request": { "url": format!("{}/ping", server.uri()) } },
+                { "request": { "url": format!("{}/token", server.uri()) }, "capture": { "t": "$.t" } }
+            ],
+            "apply": [ { "into": "header", "name": "X", "value": "${t}" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        let c = p.credential().await.unwrap();
+        assert!(matches!(&c, Credential::Header { value, .. } if value == "T"));
     }
 
     #[tokio::test]

--- a/crates/auth/src/flow.rs
+++ b/crates/auth/src/flow.rs
@@ -1,0 +1,824 @@
+//! Composable multi-step auth **flow** provider (#511).
+//!
+//! Turns `AuthProvider` from a single-step credential source into a small
+//! declarative program: an optional login / pre-flight request chain whose
+//! responses are captured by JSONPath, arbitrary credential *placement*
+//! (header / query / cookie / body), a pluggable HMAC request *signer*, and a
+//! dynamic per-session base-URL — on top of the existing single-flight
+//! machinery.
+//!
+//! ```yaml
+//! auth:
+//!   bullhorn:
+//!     type: flow
+//!     config:
+//!       steps:
+//!         - request: { method: POST, url: "https://auth/oauth/token",
+//!                      form: { grant_type: refresh_token, refresh_token: "..." } }
+//!           capture: { access_token: "$.access_token" }
+//!         - request: { method: GET, url: "https://login/rest/login",
+//!                      query: { access_token: "${access_token}" } }
+//!           capture: { bh_rest_token: "$.BhRestToken", base_url: "$.restUrl" }
+//!       apply:
+//!         - { into: query, name: BhRestToken, value: "${bh_rest_token}" }
+//!       base_url_from: "${base_url}"
+//!       ttl_secs: 86400
+//!       reauth_on: [401]
+//! ```
+
+use crate::auth_http_client;
+use async_trait::async_trait;
+use base64::Engine;
+use faucet_core::{AuthProvider, Credential, CredentialPlacement, FaucetError, RequestAuth};
+use hmac::{Hmac, Mac};
+use jsonpath_rust::JsonPath;
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::Sha256;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant};
+
+type HmacSha256 = Hmac<Sha256>;
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+/// One HTTP request in the login / pre-flight chain.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FlowRequest {
+    #[serde(default = "default_method")]
+    method: String,
+    url: String,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    query: HashMap<String, String>,
+    /// `application/x-www-form-urlencoded` body.
+    #[serde(default)]
+    form: Option<HashMap<String, String>>,
+    /// JSON body (mutually exclusive with `form`).
+    #[serde(default)]
+    json: Option<Value>,
+}
+
+fn default_method() -> String {
+    "GET".to_owned()
+}
+
+/// A login step: a request plus the values to capture from its JSON response.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FlowStep {
+    request: FlowRequest,
+    /// Captured-name → JSONPath into the response body.
+    #[serde(default)]
+    capture: HashMap<String, String>,
+}
+
+/// Where a captured credential is placed into data requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PlaceTarget {
+    Header,
+    Query,
+    Cookie,
+    Body,
+}
+
+/// HMAC algorithm for the request signer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SignAlg {
+    HmacSha256,
+}
+
+/// Signature encoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SigEncoding {
+    #[default]
+    Hex,
+    Base64,
+}
+
+/// Where a computed signature is placed (a header, with a value template).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SignInto {
+    header: String,
+    /// Value template; `${sig}` is the computed signature. Defaults to `${sig}`.
+    #[serde(default = "default_sig_format")]
+    format: String,
+}
+
+fn default_sig_format() -> String {
+    "${sig}".to_owned()
+}
+
+/// A pluggable HMAC request signer.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SignSpec {
+    alg: SignAlg,
+    /// HMAC key (resolve via `${env:...}` / `${vault:...}` in the catalog).
+    key: String,
+    /// The signature base string; `${captured}`, `${ts}`, `${nonce}` are
+    /// substituted before signing.
+    template: String,
+    #[serde(default)]
+    encoding: SigEncoding,
+    into: SignInto,
+}
+
+/// One `apply` entry: either a static placement or a computed signature.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum ApplySpec {
+    /// `{ into, name, value }` — place a (templated) value.
+    Place {
+        into: PlaceTarget,
+        name: String,
+        /// Value template; `${captured}` substituted.
+        value: String,
+    },
+    /// `{ sign: { ... } }` — compute and place an HMAC signature.
+    Sign { sign: SignSpec },
+}
+
+/// The `type: flow` provider config.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FlowConfig {
+    /// Login / pre-flight chain, run in order; each captures values for later
+    /// steps and for `apply`.
+    #[serde(default)]
+    steps: Vec<FlowStep>,
+    /// Credential placements applied to every data request.
+    #[serde(default)]
+    apply: Vec<ApplySpec>,
+    /// Template (over captured values) yielding a per-session base-URL that
+    /// overrides the connector's configured `base_url`.
+    #[serde(default)]
+    base_url_from: Option<String>,
+    /// Re-run the login chain after this many seconds.
+    #[serde(default)]
+    ttl_secs: Option<u64>,
+    /// HTTP statuses that trigger a re-login (via `invalidate`). Advisory —
+    /// stored for connectors that wire status-based reauth.
+    #[serde(default)]
+    reauth_on: Vec<u16>,
+}
+
+impl FlowConfig {
+    fn validate(&self) -> Result<(), FaucetError> {
+        if self.steps.is_empty() && self.apply.is_empty() {
+            return Err(FaucetError::Config(
+                "flow auth: at least one of `steps` or `apply` is required".to_owned(),
+            ));
+        }
+        for (i, step) in self.steps.iter().enumerate() {
+            if step.request.url.trim().is_empty() {
+                return Err(FaucetError::Config(format!(
+                    "flow auth: step {i} has an empty `url`"
+                )));
+            }
+            if step.request.form.is_some() && step.request.json.is_some() {
+                return Err(FaucetError::Config(format!(
+                    "flow auth: step {i} sets both `form` and `json`; pick one"
+                )));
+            }
+        }
+        for (i, a) in self.apply.iter().enumerate() {
+            match a {
+                ApplySpec::Place { name, .. } if name.trim().is_empty() => {
+                    return Err(FaucetError::Config(format!(
+                        "flow auth: apply[{i}] has an empty `name`"
+                    )));
+                }
+                ApplySpec::Sign { sign } if sign.into.header.trim().is_empty() => {
+                    return Err(FaucetError::Config(format!(
+                        "flow auth: apply[{i}].sign.into.header must not be empty"
+                    )));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── Template rendering ───────────────────────────────────────────────────────
+
+/// Substitute `${key}` tokens from `ctx`. Unknown tokens are left verbatim.
+/// Single-pass — a substituted value is never re-scanned.
+fn render(template: &str, ctx: &HashMap<String, String>) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find('}') {
+            let key = &after[..end];
+            match ctx.get(key) {
+                Some(v) => out.push_str(v),
+                None => {
+                    out.push_str("${");
+                    out.push_str(key);
+                    out.push('}');
+                }
+            }
+            rest = &after[end + 1..];
+        } else {
+            out.push_str(&rest[start..]);
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// A captured JSON value rendered to its string form for templating.
+fn value_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn jsonpath_first(body: &Value, path: &str) -> Option<Value> {
+    let results = body.query(path).ok()?;
+    results.first().map(|v| (*v).clone())
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn hmac_sign(key: &str, message: &str, encoding: SigEncoding) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(key.as_bytes()).expect("HMAC accepts a key of any length");
+    mac.update(message.as_bytes());
+    let bytes = mac.finalize().into_bytes();
+    match encoding {
+        SigEncoding::Hex => to_hex(&bytes),
+        SigEncoding::Base64 => base64::engine::general_purpose::STANDARD.encode(bytes),
+    }
+}
+
+/// Build the placements + base-URL for one request from the captured context.
+/// Pure given `captured` (and the clock values injected by the caller).
+fn build_request_auth(
+    apply: &[ApplySpec],
+    base_url_from: &Option<String>,
+    ctx: &HashMap<String, String>,
+) -> RequestAuth {
+    let mut out = RequestAuth::new();
+    for a in apply {
+        match a {
+            ApplySpec::Place { into, name, value } => {
+                let value = render(value, ctx);
+                let name = name.clone();
+                let placement = match into {
+                    PlaceTarget::Header => CredentialPlacement::Header { name, value },
+                    PlaceTarget::Query => CredentialPlacement::Query { name, value },
+                    PlaceTarget::Cookie => CredentialPlacement::Cookie { name, value },
+                    PlaceTarget::Body => CredentialPlacement::BodyField { name, value },
+                };
+                out = out.with_placement(placement);
+            }
+            ApplySpec::Sign { sign } => {
+                let base = render(&sign.template, ctx);
+                let sig = match sign.alg {
+                    SignAlg::HmacSha256 => hmac_sign(&sign.key, &base, sign.encoding),
+                };
+                let mut sig_ctx = ctx.clone();
+                sig_ctx.insert("sig".to_owned(), sig);
+                let value = render(&sign.into.format, &sig_ctx);
+                out = out.with_placement(CredentialPlacement::Header {
+                    name: sign.into.header.clone(),
+                    value,
+                });
+            }
+        }
+    }
+    if let Some(tmpl) = base_url_from {
+        let rendered = render(tmpl, ctx);
+        if !rendered.is_empty() {
+            out = out.with_base_url(rendered);
+        }
+    }
+    out
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+struct Session {
+    /// Captured values (as strings, ready for templating) plus a fresh clock.
+    ctx: HashMap<String, String>,
+    expires_at: Option<Instant>,
+}
+
+impl Session {
+    fn valid(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => Instant::now() < exp,
+            None => true,
+        }
+    }
+}
+
+/// A composable multi-step auth flow provider.
+pub struct FlowProvider {
+    http: reqwest::Client,
+    config: FlowConfig,
+    state: Mutex<Option<Session>>,
+}
+
+impl std::fmt::Debug for FlowProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlowProvider")
+            .field("steps", &self.config.steps.len())
+            .field("apply", &self.config.apply.len())
+            .finish()
+    }
+}
+
+impl FlowProvider {
+    /// Build a flow provider from its `config` block.
+    pub fn from_config(config: &Value) -> Result<Self, FaucetError> {
+        let config: FlowConfig = serde_json::from_value(config.clone())
+            .map_err(|e| FaucetError::Config(format!("flow auth: invalid config: {e}")))?;
+        config.validate()?;
+        Ok(Self {
+            http: auth_http_client(),
+            config,
+            state: Mutex::new(None),
+        })
+    }
+
+    /// A fresh clock context (`ts`, `nonce`) for signing.
+    fn clock_ctx() -> HashMap<String, String> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let mut ctx = HashMap::new();
+        ctx.insert("ts".to_owned(), now.to_string());
+        ctx.insert("nonce".to_owned(), format!("{now}{nanos}"));
+        ctx
+    }
+
+    /// Run the login chain, returning the captured context.
+    async fn run_login(&self) -> Result<HashMap<String, String>, FaucetError> {
+        let mut ctx: HashMap<String, String> = HashMap::new();
+        for (i, step) in self.config.steps.iter().enumerate() {
+            let req = &step.request;
+            let method = reqwest::Method::from_bytes(req.method.to_uppercase().as_bytes())
+                .map_err(|_| {
+                    FaucetError::Config(format!(
+                        "flow auth: step {i} has an invalid HTTP method '{}'",
+                        req.method
+                    ))
+                })?;
+            let url = render(&req.url, &ctx);
+            let mut builder = self.http.request(method, &url);
+            for (k, v) in &req.headers {
+                builder = builder.header(k.as_str(), render(v, &ctx));
+            }
+            if !req.query.is_empty() {
+                let q: Vec<(String, String)> = req
+                    .query
+                    .iter()
+                    .map(|(k, v)| (k.clone(), render(v, &ctx)))
+                    .collect();
+                builder = builder.query(&q);
+            }
+            if let Some(form) = &req.form {
+                let f: Vec<(String, String)> = form
+                    .iter()
+                    .map(|(k, v)| (k.clone(), render(v, &ctx)))
+                    .collect();
+                builder = builder.form(&f);
+            } else if let Some(json) = &req.json {
+                let rendered = render(&serde_json::to_string(json).unwrap_or_default(), &ctx);
+                let body: Value = serde_json::from_str(&rendered).unwrap_or_else(|_| json.clone());
+                builder = builder.json(&body);
+            }
+            let resp = builder.send().await.map_err(|e| {
+                FaucetError::Auth(format!("flow auth: step {i} request failed: {e}"))
+            })?;
+            let status = resp.status();
+            if !status.is_success() {
+                return Err(FaucetError::Auth(format!(
+                    "flow auth: step {i} returned HTTP {}",
+                    status.as_u16()
+                )));
+            }
+            let body: Value = if step.capture.is_empty() {
+                Value::Null
+            } else {
+                resp.json().await.map_err(|e| {
+                    FaucetError::Auth(format!(
+                        "flow auth: step {i} response was not valid JSON: {e}"
+                    ))
+                })?
+            };
+            for (name, path) in &step.capture {
+                match jsonpath_first(&body, path) {
+                    Some(v) => {
+                        ctx.insert(name.clone(), value_to_string(&v));
+                    }
+                    None => {
+                        return Err(FaucetError::Auth(format!(
+                            "flow auth: step {i} capture '{name}' matched nothing at '{path}'"
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(ctx)
+    }
+
+    /// Ensure a valid session, returning its captured context (single-flight:
+    /// the lock is held across the login network calls).
+    async fn ensure_ctx(&self) -> Result<HashMap<String, String>, FaucetError> {
+        let mut guard = self.state.lock().await;
+        if let Some(s) = guard.as_ref()
+            && s.valid()
+        {
+            return Ok(s.ctx.clone());
+        }
+        let ctx = self.run_login().await?;
+        let expires_at = self
+            .config
+            .ttl_secs
+            .map(|s| Instant::now() + Duration::from_secs(s));
+        *guard = Some(Session {
+            ctx: ctx.clone(),
+            expires_at,
+        });
+        Ok(ctx)
+    }
+
+    fn request_auth_from_ctx(&self, captured: &HashMap<String, String>) -> RequestAuth {
+        let mut ctx = captured.clone();
+        ctx.extend(Self::clock_ctx());
+        build_request_auth(&self.config.apply, &self.config.base_url_from, &ctx)
+    }
+}
+
+#[async_trait]
+impl AuthProvider for FlowProvider {
+    async fn credential(&self) -> Result<Credential, FaucetError> {
+        let ctx = self.ensure_ctx().await?;
+        let auth = self.request_auth_from_ctx(&ctx);
+        // Header/bearer fallback for connectors that only consume `credential()`
+        // (xml, graphql): return the first header placement as a header
+        // credential. Query/cookie/body placements need `request_auth`.
+        for p in &auth.placements {
+            if let CredentialPlacement::Header { name, value } = p {
+                return Ok(Credential::Header {
+                    name: name.clone(),
+                    value: value.clone(),
+                });
+            }
+        }
+        Err(FaucetError::Auth(
+            "flow auth: no header credential to apply via credential(); this flow places its \
+             credential in a query/cookie/body, which requires a connector that consumes \
+             request_auth() (e.g. the REST source)"
+                .to_owned(),
+        ))
+    }
+
+    async fn invalidate(&self, _stale: &Credential) -> Result<Credential, FaucetError> {
+        // Force a re-login on the next ensure_ctx.
+        *self.state.lock().await = None;
+        self.credential().await
+    }
+
+    async fn request_auth(
+        &self,
+        _method: &str,
+        _url: &str,
+        _query: &std::collections::BTreeMap<String, String>,
+    ) -> Result<RequestAuth, FaucetError> {
+        let ctx = self.ensure_ctx().await?;
+        Ok(self.request_auth_from_ctx(&ctx))
+    }
+
+    fn reauth_statuses(&self) -> &[u16] {
+        &self.config.reauth_on
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "flow"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn render_substitutes_known_and_leaves_unknown() {
+        let c = ctx(&[("token", "abc"), ("region", "eu")]);
+        assert_eq!(render("Bearer ${token}", &c), "Bearer abc");
+        assert_eq!(render("https://${region}.api", &c), "https://eu.api");
+        assert_eq!(render("${missing}", &c), "${missing}");
+        assert_eq!(render("no tokens", &c), "no tokens");
+        assert_eq!(render("${token}${region}", &c), "abceu");
+    }
+
+    #[test]
+    fn render_handles_unterminated_and_utf8() {
+        let c = ctx(&[("x", "✓")]);
+        assert_eq!(render("prefix ${x} ünïcode", &c), "prefix ✓ ünïcode");
+        assert_eq!(render("dangling ${x", &c), "dangling ${x");
+    }
+
+    #[test]
+    fn value_to_string_covers_kinds() {
+        assert_eq!(value_to_string(&json!("s")), "s");
+        assert_eq!(value_to_string(&json!(7)), "7");
+        assert_eq!(value_to_string(&json!(true)), "true");
+        assert_eq!(value_to_string(&json!(null)), "");
+        assert_eq!(value_to_string(&json!([1, 2])), "[1,2]");
+    }
+
+    #[test]
+    fn jsonpath_first_extracts_scalar() {
+        let body = json!({"data": {"BhRestToken": "tok", "restUrl": "https://host/x"}});
+        assert_eq!(
+            jsonpath_first(&body, "$.data.BhRestToken"),
+            Some(json!("tok"))
+        );
+        assert_eq!(
+            jsonpath_first(&body, "$.data.restUrl"),
+            Some(json!("https://host/x"))
+        );
+        assert_eq!(jsonpath_first(&body, "$.data.missing"), None);
+    }
+
+    #[test]
+    fn hmac_hex_and_base64_are_deterministic() {
+        let hex = hmac_sign("key", "message", SigEncoding::Hex);
+        // Known HMAC-SHA256("key","message") hex vector.
+        assert_eq!(
+            hex,
+            "6e9ef29b75fffc5b7abae527d58fdadb2fe42e7219011976917343065f58ed4a"
+        );
+        let b64 = hmac_sign("key", "message", SigEncoding::Base64);
+        assert_eq!(b64, "bp7ym3X//Ft6uuUn1Y/a2y/kLnIZARl2kXNDBl9Y7Uo=");
+    }
+
+    #[test]
+    fn build_request_auth_places_header_query_cookie_body() {
+        let apply: Vec<ApplySpec> = serde_json::from_value(json!([
+            { "into": "header", "name": "X-Tok", "value": "${tok}" },
+            { "into": "query",  "name": "access_token", "value": "${tok}" },
+            { "into": "cookie", "name": "sid", "value": "${sid}" },
+            { "into": "body",   "name": "auth", "value": "${tok}" }
+        ]))
+        .unwrap();
+        let c = ctx(&[("tok", "T"), ("sid", "S")]);
+        let ra = build_request_auth(&apply, &None, &c);
+        assert_eq!(ra.placements.len(), 4);
+        assert!(matches!(&ra.placements[0], CredentialPlacement::Header { name, value } if name=="X-Tok" && value=="T"));
+        assert!(matches!(&ra.placements[1], CredentialPlacement::Query { name, value } if name=="access_token" && value=="T"));
+        assert!(matches!(&ra.placements[2], CredentialPlacement::Cookie { name, value } if name=="sid" && value=="S"));
+        assert!(matches!(&ra.placements[3], CredentialPlacement::BodyField { name, value } if name=="auth" && value=="T"));
+        assert!(ra.base_url.is_none());
+    }
+
+    #[test]
+    fn build_request_auth_signs_and_sets_base_url() {
+        let apply: Vec<ApplySpec> = serde_json::from_value(json!([
+            { "sign": { "alg": "hmac_sha256", "key": "secret", "template": "${client}:${ts}",
+                        "encoding": "hex", "into": { "header": "Authorization", "format": "SS ${sig}" } } }
+        ]))
+        .unwrap();
+        let mut c = ctx(&[("client", "abc"), ("ts", "100"), ("base_url", "https://eu.host")]);
+        c.insert("base_url".to_owned(), "https://eu.host".to_owned());
+        let ra = build_request_auth(&apply, &Some("${base_url}".to_owned()), &c);
+        assert_eq!(ra.placements.len(), 1);
+        let expected = format!("SS {}", hmac_sign("secret", "abc:100", SigEncoding::Hex));
+        assert!(matches!(&ra.placements[0], CredentialPlacement::Header { name, value } if name=="Authorization" && *value==expected));
+        assert_eq!(ra.base_url.as_deref(), Some("https://eu.host"));
+    }
+
+    #[test]
+    fn base_url_from_empty_render_is_ignored() {
+        let ra = build_request_auth(&[], &Some("${missing_and_stripped}".to_owned()), &ctx(&[]));
+        // The unknown token renders verbatim (non-empty), so it is set; an
+        // actually-empty render (empty template) is ignored.
+        assert!(ra.base_url.is_some());
+        let ra2 = build_request_auth(&[], &Some("${e}".to_owned()), &ctx(&[("e", "")]));
+        assert!(ra2.base_url.is_none());
+    }
+
+    #[test]
+    fn config_validate_requires_steps_or_apply() {
+        let empty: FlowConfig = serde_json::from_value(json!({})).unwrap();
+        assert!(empty.validate().is_err());
+    }
+
+    #[test]
+    fn config_rejects_form_and_json_together() {
+        let cfg: FlowConfig = serde_json::from_value(json!({
+            "steps": [ { "request": { "url": "https://x", "form": {"a":"b"}, "json": {"c":"d"} } } ]
+        }))
+        .unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn config_rejects_empty_place_name_and_sign_header() {
+        let bad_place: FlowConfig = serde_json::from_value(json!({
+            "apply": [ { "into": "query", "name": "", "value": "${x}" } ]
+        }))
+        .unwrap();
+        assert!(bad_place.validate().is_err());
+
+        let bad_sign: FlowConfig = serde_json::from_value(json!({
+            "apply": [ { "sign": { "alg": "hmac_sha256", "key": "k", "template": "${ts}",
+                                   "into": { "header": "" } } } ]
+        }))
+        .unwrap();
+        assert!(bad_sign.validate().is_err());
+    }
+
+    #[test]
+    fn from_config_rejects_unknown_field() {
+        assert!(FlowProvider::from_config(&json!({ "bogus": 1 })).is_err());
+    }
+
+    #[test]
+    fn debug_redacts_and_summarizes() {
+        let p = FlowProvider::from_config(&json!({
+            "apply": [ { "into": "header", "name": "X", "value": "${t}" } ]
+        }))
+        .unwrap();
+        let s = format!("{p:?}");
+        assert!(s.contains("FlowProvider"));
+        assert!(s.contains("apply"));
+    }
+
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
+
+    #[tokio::test]
+    async fn login_chain_captures_placements_and_base_url() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"access_token": "AT"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                json!({"BhRestToken": "BRT", "restUrl": "https://data.example"}),
+            ))
+            .mount(&server)
+            .await;
+
+        let cfg = json!({
+            "steps": [
+                { "request": { "method": "POST", "url": format!("{}/token", server.uri()),
+                               "form": {"grant_type": "refresh_token"} },
+                  "capture": { "access_token": "$.access_token" } },
+                { "request": { "method": "GET", "url": format!("{}/login", server.uri()),
+                               "query": {"access_token": "${access_token}"} },
+                  "capture": { "bh_rest_token": "$.BhRestToken", "base_url": "$.restUrl" } }
+            ],
+            "apply": [ { "into": "query", "name": "BhRestToken", "value": "${bh_rest_token}" } ],
+            "base_url_from": "${base_url}",
+            "reauth_on": [401]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        let ra = p
+            .request_auth("GET", "https://data.example/x", &BTreeMap::new())
+            .await
+            .unwrap();
+        assert_eq!(ra.base_url.as_deref(), Some("https://data.example"));
+        assert!(
+            matches!(&ra.placements[0], CredentialPlacement::Query { name, value } if name == "BhRestToken" && value == "BRT")
+        );
+        assert_eq!(p.reauth_statuses(), &[401]);
+        // A query placement has no header credential to apply via credential().
+        assert!(p.credential().await.is_err());
+    }
+
+    struct CountingLogin(Arc<AtomicUsize>);
+    impl Respond for CountingLogin {
+        fn respond(&self, _: &wiremock::Request) -> ResponseTemplate {
+            let n = self.0.fetch_add(1, Ordering::SeqCst) + 1;
+            ResponseTemplate::new(200).set_body_json(json!({ "sid": format!("S{n}") }))
+        }
+    }
+
+    #[tokio::test]
+    async fn header_credential_caches_then_reloads_on_invalidate() {
+        let server = MockServer::start().await;
+        let hits = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(CountingLogin(hits.clone()))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [ { "request": { "method": "POST", "url": format!("{}/login", server.uri()) },
+                         "capture": { "sid": "$.sid" } } ],
+            "apply": [ { "into": "header", "name": "X-Session", "value": "${sid}" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+
+        let c1 = p.credential().await.unwrap();
+        assert!(matches!(&c1, Credential::Header { name, value } if name == "X-Session" && value == "S1"));
+        // Cached: no ttl → second call does not re-login.
+        let _ = p.credential().await.unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        // invalidate forces a fresh login.
+        let c2 = p.invalidate(&c1).await.unwrap();
+        assert!(matches!(&c2, Credential::Header { value, .. } if value == "S2"));
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn login_capture_miss_is_an_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"other": 1})))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [ { "request": { "url": format!("{}/x", server.uri()) },
+                         "capture": { "tok": "$.access_token" } } ],
+            "apply": [ { "into": "header", "name": "X", "value": "${tok}" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        assert!(p.credential().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn login_non_success_is_an_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let cfg = json!({
+            "steps": [ { "request": { "url": format!("{}/x", server.uri()) } } ],
+            "apply": [ { "into": "header", "name": "X", "value": "static" } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        assert!(
+            p.request_auth("GET", "https://x", &BTreeMap::new())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn no_steps_apply_only_flow_works() {
+        // A flow with only `apply` (a static signer/placement, no login) needs
+        // no network.
+        let cfg = json!({
+            "apply": [ { "sign": { "alg": "hmac_sha256", "key": "k", "template": "msg",
+                                   "into": { "header": "Authorization", "format": "HMAC ${sig}" } } } ]
+        });
+        let p = FlowProvider::from_config(&cfg).unwrap();
+        let c = p.credential().await.unwrap();
+        let expected = format!("HMAC {}", hmac_sign("k", "msg", SigEncoding::Hex));
+        assert!(matches!(&c, Credential::Header { name, value } if name == "Authorization" && *value == expected));
+    }
+}

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -22,6 +22,7 @@
 //!
 //! [`Arc`]: std::sync::Arc
 
+mod flow;
 #[cfg(feature = "oauth1")]
 mod oauth1;
 mod oauth2;
@@ -48,6 +49,7 @@ pub(crate) fn auth_http_client() -> reqwest::Client {
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
+pub use flow::FlowProvider;
 #[cfg(feature = "oauth1")]
 pub use oauth1::OAuth1Provider;
 pub use oauth2::{OAuth2ClientCredentialsProvider, OAuth2RefreshProvider};
@@ -62,8 +64,8 @@ pub const DEFAULT_EXPIRY_RATIO: f64 = 0.9;
 /// `{ type, config }` spec — the shape used by the CLI's top-level `auth:`
 /// catalog.
 ///
-/// Supported `type` values: `static`, `oauth2` (client-credentials),
-/// `oauth2_refresh`, `token_endpoint`.
+/// Supported `type` values: `flow` (composable multi-step, #511), `static`,
+/// `oauth2` (client-credentials), `oauth2_refresh`, `token_endpoint`, `oauth1`.
 pub fn build_provider(spec: &Value) -> Result<SharedAuthProvider, FaucetError> {
     let kind = spec
         .get("type")
@@ -72,6 +74,7 @@ pub fn build_provider(spec: &Value) -> Result<SharedAuthProvider, FaucetError> {
     let config = spec.get("config").cloned().unwrap_or(Value::Null);
 
     match kind {
+        "flow" => Ok(Arc::new(FlowProvider::from_config(&config)?)),
         "static" => Ok(Arc::new(StaticProvider::from_config(&config)?)),
         "oauth2" => Ok(Arc::new(OAuth2ClientCredentialsProvider::from_config(
             &config,
@@ -93,7 +96,7 @@ pub fn build_provider(spec: &Value) -> Result<SharedAuthProvider, FaucetError> {
             }
         }
         other => Err(FaucetError::Config(format!(
-            "auth provider: unknown type `{other}` (expected one of: static, oauth2, oauth2_refresh, token_endpoint, oauth1)"
+            "auth provider: unknown type `{other}` (expected one of: flow, static, oauth2, oauth2_refresh, token_endpoint, oauth1)"
         ))),
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,7 +18,7 @@ transform-select = []
 transform-drop = []
 transform-set = []
 transform-rename-field = []
-transform-cast = ["dep:chrono"]
+transform-cast = []
 transform-redact = []
 transform-value-case = []
 transform-spell-symbols = []
@@ -139,7 +139,7 @@ metrics-exporter-opentelemetry = { workspace = true, optional = true }
 async-compression = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
-chrono = { workspace = true, optional = true }
+chrono = { workspace = true }
 jsonschema = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 # BLAKE3 + base64 back the `hash` transform (feature `transform-hash`, #403).

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -92,6 +92,124 @@ impl Credential {
     }
 }
 
+/// One placement of a captured credential into an outgoing HTTP request,
+/// produced by [`AuthProvider::request_auth`]. Unlike [`Credential`] (which is
+/// header/bearer-shaped), a placement can target a query parameter, cookie, or
+/// JSON body field — the shapes multi-step auth flows (#511) need.
+///
+/// `#[non_exhaustive]` so new placement kinds can be added as a minor change.
+#[derive(Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CredentialPlacement {
+    /// An HTTP header `name: value`.
+    Header {
+        /// Header name.
+        name: String,
+        /// Header value.
+        value: String,
+    },
+    /// A query-string parameter `?name=value`.
+    Query {
+        /// Parameter name.
+        name: String,
+        /// Parameter value.
+        value: String,
+    },
+    /// A cookie `name=value` (sent via the `Cookie` header).
+    Cookie {
+        /// Cookie name.
+        name: String,
+        /// Cookie value.
+        value: String,
+    },
+    /// A top-level field of the JSON request body.
+    BodyField {
+        /// Field name.
+        name: String,
+        /// Field value (string).
+        value: String,
+    },
+}
+
+// Hand-written `Debug` redacts the secret-bearing `value` while keeping the
+// non-secret `name` visible — same contract as `Credential`.
+impl std::fmt::Debug for CredentialPlacement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (kind, name) = match self {
+            CredentialPlacement::Header { name, .. } => ("Header", name),
+            CredentialPlacement::Query { name, .. } => ("Query", name),
+            CredentialPlacement::Cookie { name, .. } => ("Cookie", name),
+            CredentialPlacement::BodyField { name, .. } => ("BodyField", name),
+        };
+        f.debug_struct(kind)
+            .field("name", name)
+            .field("value", &"***")
+            .finish()
+    }
+}
+
+/// The per-request auth a provider contributes beyond a single [`Credential`]:
+/// zero or more [`CredentialPlacement`]s plus an optional dynamic base-URL that
+/// overrides the connector's configured one (captured from a login response —
+/// Bullhorn `restUrl`, Zoho region host, #511).
+///
+/// A connector that receives a non-[`is_empty`](RequestAuth::is_empty)
+/// `RequestAuth` uses it **instead of** the plain [`credential`](AuthProvider::credential)
+/// path for that request. `#[non_exhaustive]`: construct via [`RequestAuth::new`]
+/// and the builder methods so fields can be added as a minor change.
+#[derive(Clone, Default)]
+#[non_exhaustive]
+pub struct RequestAuth {
+    /// Credential placements to apply to the request.
+    pub placements: Vec<CredentialPlacement>,
+    /// Optional per-session base-URL override.
+    pub base_url: Option<String>,
+}
+
+impl RequestAuth {
+    /// An empty `RequestAuth` (no placements, no base-URL override).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a credential placement (builder).
+    #[must_use]
+    pub fn with_placement(mut self, placement: CredentialPlacement) -> Self {
+        self.placements.push(placement);
+        self
+    }
+
+    /// Set the dynamic base-URL override (builder).
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+
+    /// True when the provider contributed nothing (the connector then falls back
+    /// to the plain [`credential`](AuthProvider::credential) path).
+    pub fn is_empty(&self) -> bool {
+        self.placements.is_empty() && self.base_url.is_none()
+    }
+}
+
+// Redacting `Debug`: placements redact their own values; the base-URL is passed
+// through `redact_uri_credentials` so any embedded userinfo is scrubbed.
+impl std::fmt::Debug for RequestAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestAuth")
+            .field("placements", &self.placements)
+            .field(
+                "base_url",
+                &self
+                    .base_url
+                    .as_deref()
+                    .map(crate::util::redact_uri_credentials),
+            )
+            .finish()
+    }
+}
+
 /// A live, shareable source of credentials.
 ///
 /// One instance is shared (via [`Arc`]) across all connectors that reference it,
@@ -137,6 +255,40 @@ pub trait AuthProvider: Send + Sync + std::fmt::Debug {
         _query: &std::collections::BTreeMap<String, String>,
     ) -> Result<Option<Credential>, FaucetError> {
         Ok(None)
+    }
+
+    /// Richer per-request auth for multi-step flows (#511): credential
+    /// placements across header / query / cookie / body plus an optional
+    /// dynamic base-URL override.
+    ///
+    /// Most providers issue a single [`Credential`] and return an empty
+    /// [`RequestAuth`] here (the default); the connector then applies the plain
+    /// [`credential`](Self::credential) path. A provider that must place a
+    /// captured value somewhere other than a header, place several values at
+    /// once, or redirect the request to a captured base-URL overrides this. When
+    /// it returns a non-[`is_empty`](RequestAuth::is_empty) value, the connector
+    /// applies the placements **instead of** `credential()` for that request.
+    ///
+    /// `query` is the request's query parameters before the HTTP client appends
+    /// them (some flows fold them into a signature). Object-safe: no generics,
+    /// all args are borrowed primitives.
+    async fn request_auth(
+        &self,
+        _method: &str,
+        _url: &str,
+        _query: &std::collections::BTreeMap<String, String>,
+    ) -> Result<RequestAuth, FaucetError> {
+        Ok(RequestAuth::new())
+    }
+
+    /// HTTP status codes on which the connector should force a re-auth
+    /// (via [`invalidate`](Self::invalidate)) and retry the request once.
+    ///
+    /// The default is empty — connectors keep their built-in `401` handling.
+    /// A multi-step flow (#511) whose session cookie/token can expire mid-run
+    /// returns the statuses (e.g. `[401]`, `[401, 403]`) that mean "log in again".
+    fn reauth_statuses(&self) -> &[u16] {
+        &[]
     }
 
     /// Stable, non-empty name for diagnostics and metrics.

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -390,6 +390,97 @@ mod tests {
         Bearer { token: String },
     }
 
+    #[derive(Debug)]
+    struct MinimalProvider;
+
+    #[async_trait]
+    impl AuthProvider for MinimalProvider {
+        async fn credential(&self) -> Result<Credential, FaucetError> {
+            Ok(Credential::Bearer("t".into()))
+        }
+        fn provider_name(&self) -> &'static str {
+            "minimal"
+        }
+    }
+
+    #[test]
+    fn credential_placement_debug_redacts_value_keeps_name() {
+        let cases = [
+            CredentialPlacement::Header {
+                name: "X-Tok".into(),
+                value: "secret".into(),
+            },
+            CredentialPlacement::Query {
+                name: "access_token".into(),
+                value: "secret".into(),
+            },
+            CredentialPlacement::Cookie {
+                name: "sid".into(),
+                value: "secret".into(),
+            },
+            CredentialPlacement::BodyField {
+                name: "auth".into(),
+                value: "secret".into(),
+            },
+        ];
+        for p in cases {
+            let s = format!("{p:?}");
+            assert!(s.contains("***"), "value must be redacted: {s}");
+            assert!(!s.contains("secret"), "secret leaked: {s}");
+        }
+    }
+
+    #[test]
+    fn request_auth_builders_and_is_empty() {
+        let empty = RequestAuth::new();
+        assert!(empty.is_empty());
+
+        let ra = RequestAuth::new()
+            .with_placement(CredentialPlacement::Query {
+                name: "t".into(),
+                value: "v".into(),
+            })
+            .with_base_url("https://host");
+        assert!(!ra.is_empty());
+        assert_eq!(ra.placements.len(), 1);
+        assert_eq!(ra.base_url.as_deref(), Some("https://host"));
+
+        // base-URL alone (no placements) is still non-empty.
+        assert!(!RequestAuth::new().with_base_url("https://h").is_empty());
+        assert!(RequestAuth::default().is_empty());
+    }
+
+    #[test]
+    fn request_auth_debug_redacts_placements_and_base_url() {
+        let ra = RequestAuth::new()
+            .with_placement(CredentialPlacement::Header {
+                name: "Authorization".into(),
+                value: "topsecret".into(),
+            })
+            .with_base_url("https://user:pw@host/path");
+        let s = format!("{ra:?}");
+        assert!(!s.contains("topsecret"), "placement value leaked: {s}");
+        assert!(!s.contains("pw"), "base-url userinfo leaked: {s}");
+    }
+
+    #[tokio::test]
+    async fn default_request_auth_is_empty_and_reauth_is_empty() {
+        let p = MinimalProvider;
+        let ra = p
+            .request_auth("GET", "https://x", &std::collections::BTreeMap::new())
+            .await
+            .unwrap();
+        assert!(ra.is_empty());
+        assert!(p.reauth_statuses().is_empty());
+        // The default sign_request also contributes nothing.
+        assert!(
+            p.sign_request("GET", "https://x", &std::collections::BTreeMap::new())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
     #[test]
     fn credential_authorization_value() {
         assert_eq!(

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -466,6 +466,11 @@ mod tests {
     #[tokio::test]
     async fn default_request_auth_is_empty_and_reauth_is_empty() {
         let p = MinimalProvider;
+        assert!(matches!(
+            p.credential().await.unwrap(),
+            Credential::Bearer(_)
+        ));
+        assert_eq!(p.provider_name(), "minimal");
         let ra = p
             .request_auth("GET", "https://x", &std::collections::BTreeMap::new())
             .await

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,10 @@ pub mod compression;
 pub use adaptive::{
     AdaptiveBatchConfig, AdjustDirection, AdjustReason, Adjustment, AimdController, Observation,
 };
-pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
+pub use auth::{
+    AuthProvider, AuthReference, AuthSpec, Credential, CredentialPlacement, RequestAuth,
+    SharedAuthProvider,
+};
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use cleanup::{CleanupMode, CleanupPolicy, DEFAULT_MAX_KEYS, SeenKeys};
 #[cfg(feature = "arrow")]
@@ -104,7 +107,9 @@ pub use pipeline::{
     DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE, Pipeline, PipelineResult, StreamPage, run_stream,
     validate_batch_size,
 };
-pub use replication::{ReplicationMethod, json_gt};
+pub use replication::{
+    BindFormat, BindTarget, ReplicationBind, ReplicationMethod, format_bookmark, json_gt,
+};
 pub use resilience::{
     BackoffKind, CircuitBreaker, CircuitBreakerConfig, PoisonAction, PoisonPolicy,
     ResiliencePolicy, RetryClass, RetryClassSet, RetryMetrics, RetryPolicy, classify,

--- a/crates/core/src/replication.rs
+++ b/crates/core/src/replication.rs
@@ -1,5 +1,7 @@
 //! Incremental replication support.
 
+use crate::error::FaucetError;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -141,6 +143,166 @@ pub fn json_gt(a: &Value, b: &Value) -> bool {
     json_compare(a, b) == Ordering::Greater
 }
 
+// ── Server-side incremental push-down (#513) ─────────────────────────────────
+
+/// The placeholder replaced by the formatted bookmark inside a
+/// [`ReplicationBind::template`].
+pub const BIND_PLACEHOLDER: &str = "${bookmark}";
+
+fn default_bind_template() -> String {
+    BIND_PLACEHOLDER.to_owned()
+}
+
+/// Where a rendered bookmark is injected into the outgoing request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BindTarget {
+    /// A query-string parameter (default) — e.g. `?updated_after=…`.
+    #[default]
+    Query,
+    /// A request header — e.g. `If-Modified-Since: …`.
+    Header,
+    /// A top-level field of the JSON request body (POST-search APIs).
+    Body,
+    /// A `{name}` placeholder in the request path.
+    Path,
+}
+
+/// How the bookmark value is formatted before it is substituted into the
+/// [`ReplicationBind::template`].
+///
+/// For every non-[`Raw`](BindFormat::Raw) format the bookmark is first parsed
+/// into an instant: a string is read as RFC 3339, a bare `YYYY-MM-DD` date
+/// (midnight UTC), or a naive `YYYY-MM-DDTHH:MM:SS` (assumed UTC); a JSON
+/// number is read as **epoch seconds**. It is then re-emitted in the target
+/// representation, so `epoch_ms` ← ISO string and `iso8601` ← epoch number both
+/// work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BindFormat {
+    /// Emit the scalar verbatim (string as-is, number as its decimal form).
+    /// The default; no timestamp parsing.
+    #[default]
+    Raw,
+    /// RFC 3339 / ISO-8601 UTC timestamp, e.g. `2024-06-01T00:00:00Z`.
+    Iso8601,
+    /// Unix epoch **seconds** (integer).
+    EpochS,
+    /// Unix epoch **milliseconds** (integer).
+    EpochMs,
+    /// Calendar date `YYYY-MM-DD` (UTC).
+    Date,
+}
+
+/// Declarative binding of the stored bookmark into the **outgoing request** —
+/// "server-side incremental push-down" (#513).
+///
+/// Today faucet tracks bookmarks and filters incrementally *client-side* (after
+/// download). A bind lets a source instead push the bookmark into the request
+/// (query param / header / body field / path) so the server returns only the
+/// new rows. The existing client-side [`filter_incremental`] stays active as a
+/// safety net for servers that don't honour the filter exactly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReplicationBind {
+    /// Where to place the rendered value.
+    #[serde(default)]
+    pub into: BindTarget,
+    /// The parameter / header / body-field / path-placeholder name.
+    pub name: String,
+    /// Template rendered with [`BIND_PLACEHOLDER`] (`${bookmark}`) replaced by
+    /// the formatted bookmark. Defaults to the bare `${bookmark}`; set e.g.
+    /// `"gte|${bookmark}"` (Greenhouse) or `"[${bookmark} TO *]"` (Lucene).
+    #[serde(default = "default_bind_template")]
+    pub template: String,
+    /// How to format the bookmark before substitution.
+    #[serde(default)]
+    pub format: BindFormat,
+    /// Optional JSONPath into the response body to advance the bookmark from,
+    /// instead of `max(record[replication_key])`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub advance_from: Option<String>,
+}
+
+impl ReplicationBind {
+    /// Validate the binding at config-load time.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.name.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "replication bind: `name` must not be empty".to_owned(),
+            ));
+        }
+        if !self.template.contains(BIND_PLACEHOLDER) {
+            return Err(FaucetError::Config(format!(
+                "replication bind: `template` must contain the `{BIND_PLACEHOLDER}` placeholder"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Render the binding for a concrete bookmark: format the value, then
+    /// substitute it into the template.
+    pub fn render(&self, bookmark: &Value) -> Result<String, FaucetError> {
+        let formatted = format_bookmark(bookmark, self.format)?;
+        Ok(self.template.replace(BIND_PLACEHOLDER, &formatted))
+    }
+}
+
+/// Parse a bookmark value into a UTC instant (see [`BindFormat`] for the rules).
+fn bookmark_instant(value: &Value) -> Result<DateTime<Utc>, FaucetError> {
+    match value {
+        Value::String(s) => {
+            let s = s.trim();
+            if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+                return Ok(dt.with_timezone(&Utc));
+            }
+            if let Ok(d) = NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                && let Some(ndt) = d.and_hms_opt(0, 0, 0)
+            {
+                return Ok(DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+            }
+            if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+                return Ok(DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+            }
+            Err(FaucetError::Config(format!(
+                "replication bind: cannot parse bookmark '{s}' as a timestamp \
+                 (expected RFC 3339, YYYY-MM-DD, or YYYY-MM-DDTHH:MM:SS)"
+            )))
+        }
+        Value::Number(n) => {
+            let secs = n.as_i64().or_else(|| n.as_f64().map(|f| f as i64));
+            secs.and_then(|s| DateTime::<Utc>::from_timestamp(s, 0))
+                .ok_or_else(|| {
+                    FaucetError::Config(format!(
+                        "replication bind: numeric bookmark {n} is out of range for epoch seconds"
+                    ))
+                })
+        }
+        other => Err(FaucetError::Config(format!(
+            "replication bind: bookmark must be a string or number, got {other}"
+        ))),
+    }
+}
+
+/// Format a bookmark value per [`BindFormat`].
+pub fn format_bookmark(value: &Value, format: BindFormat) -> Result<String, FaucetError> {
+    match format {
+        BindFormat::Raw => match value {
+            Value::String(s) => Ok(s.clone()),
+            Value::Number(n) => Ok(n.to_string()),
+            Value::Bool(b) => Ok(b.to_string()),
+            other => Err(FaucetError::Config(format!(
+                "replication bind: cannot render {other} as a raw scalar"
+            ))),
+        },
+        BindFormat::Iso8601 => Ok(bookmark_instant(value)?
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        BindFormat::Date => Ok(bookmark_instant(value)?.format("%Y-%m-%d").to_string()),
+        BindFormat::EpochS => Ok(bookmark_instant(value)?.timestamp().to_string()),
+        BindFormat::EpochMs => Ok(bookmark_instant(value)?.timestamp_millis().to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,5 +438,121 @@ mod tests {
         let start = json!("2024-06-01"); // string bookmark vs numeric key
         let filtered = filter_incremental(records, "seq", &start);
         assert_eq!(filtered.len(), 1, "type mismatch must not silently drop");
+    }
+
+    // ── ReplicationBind (#513) ──────────────────────────────────────────────
+
+    fn bind(into: BindTarget, template: &str, format: BindFormat) -> ReplicationBind {
+        ReplicationBind {
+            into,
+            name: "updated_after".to_owned(),
+            template: template.to_owned(),
+            format,
+            advance_from: None,
+        }
+    }
+
+    #[test]
+    fn bind_defaults_template_to_bare_placeholder() {
+        let b: ReplicationBind =
+            serde_json::from_value(json!({ "name": "since" })).expect("deserializes");
+        assert_eq!(b.into, BindTarget::Query);
+        assert_eq!(b.template, "${bookmark}");
+        assert_eq!(b.format, BindFormat::Raw);
+        assert!(b.advance_from.is_none());
+    }
+
+    #[test]
+    fn bind_render_raw_string_and_number() {
+        let b = bind(BindTarget::Query, "${bookmark}", BindFormat::Raw);
+        assert_eq!(b.render(&json!("2024-06-01")).unwrap(), "2024-06-01");
+        assert_eq!(b.render(&json!(150)).unwrap(), "150");
+    }
+
+    #[test]
+    fn bind_render_applies_operator_template() {
+        let b = bind(BindTarget::Query, "gte|${bookmark}", BindFormat::Raw);
+        assert_eq!(
+            b.render(&json!("2024-06-01T00:00:00Z")).unwrap(),
+            "gte|2024-06-01T00:00:00Z"
+        );
+        // Lucene range form (Bullhorn).
+        let l = bind(BindTarget::Query, "[${bookmark} TO *]", BindFormat::Raw);
+        assert_eq!(l.render(&json!("20240601")).unwrap(), "[20240601 TO *]");
+    }
+
+    #[test]
+    fn bind_format_iso8601_from_date_and_epoch() {
+        let b = bind(BindTarget::Header, "${bookmark}", BindFormat::Iso8601);
+        assert_eq!(b.render(&json!("2024-06-01")).unwrap(), "2024-06-01T00:00:00Z");
+        // Epoch seconds → ISO.
+        assert_eq!(
+            b.render(&json!(1_717_200_000)).unwrap(),
+            "2024-06-01T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn bind_format_epoch_s_and_ms_from_iso() {
+        let s = bind(BindTarget::Query, "${bookmark}", BindFormat::EpochS);
+        assert_eq!(
+            s.render(&json!("2024-06-01T00:00:00Z")).unwrap(),
+            "1717200000"
+        );
+        let ms = bind(BindTarget::Query, "${bookmark}", BindFormat::EpochMs);
+        assert_eq!(
+            ms.render(&json!("2024-06-01T00:00:00Z")).unwrap(),
+            "1717200000000"
+        );
+    }
+
+    #[test]
+    fn bind_format_date_truncates_datetime() {
+        let b = bind(BindTarget::Query, "${bookmark}", BindFormat::Date);
+        assert_eq!(
+            b.render(&json!("2024-06-01T12:34:56Z")).unwrap(),
+            "2024-06-01"
+        );
+    }
+
+    #[test]
+    fn bind_format_naive_datetime_assumed_utc() {
+        let b = bind(BindTarget::Query, "${bookmark}", BindFormat::Iso8601);
+        assert_eq!(
+            b.render(&json!("2024-06-01T08:00:00")).unwrap(),
+            "2024-06-01T08:00:00Z"
+        );
+    }
+
+    #[test]
+    fn bind_format_unparseable_string_errors() {
+        let b = bind(BindTarget::Query, "${bookmark}", BindFormat::Iso8601);
+        assert!(b.render(&json!("not-a-date")).is_err());
+    }
+
+    #[test]
+    fn bind_format_raw_rejects_composite() {
+        let b = bind(BindTarget::Query, "${bookmark}", BindFormat::Raw);
+        assert!(b.render(&json!({"a": 1})).is_err());
+        assert!(b.render(&json!(null)).is_err());
+    }
+
+    #[test]
+    fn bind_validate_rejects_empty_name_and_missing_placeholder() {
+        let mut b = bind(BindTarget::Query, "${bookmark}", BindFormat::Raw);
+        b.name = "  ".to_owned();
+        assert!(b.validate().is_err());
+
+        let mut b2 = bind(BindTarget::Query, "no placeholder here", BindFormat::Raw);
+        b2.name = "since".to_owned();
+        assert!(b2.validate().is_err());
+
+        let ok = bind(BindTarget::Query, "gte|${bookmark}", BindFormat::Raw);
+        assert!(ok.validate().is_ok());
+    }
+
+    #[test]
+    fn bind_format_bookmark_bool_raw() {
+        assert_eq!(format_bookmark(&json!(true), BindFormat::Raw).unwrap(), "true");
     }
 }

--- a/crates/core/src/replication.rs
+++ b/crates/core/src/replication.rs
@@ -295,8 +295,9 @@ pub fn format_bookmark(value: &Value, format: BindFormat) -> Result<String, Fauc
                 "replication bind: cannot render {other} as a raw scalar"
             ))),
         },
-        BindFormat::Iso8601 => Ok(bookmark_instant(value)?
-            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        BindFormat::Iso8601 => {
+            Ok(bookmark_instant(value)?.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        }
         BindFormat::Date => Ok(bookmark_instant(value)?.format("%Y-%m-%d").to_string()),
         BindFormat::EpochS => Ok(bookmark_instant(value)?.timestamp().to_string()),
         BindFormat::EpochMs => Ok(bookmark_instant(value)?.timestamp_millis().to_string()),
@@ -484,7 +485,10 @@ mod tests {
     #[test]
     fn bind_format_iso8601_from_date_and_epoch() {
         let b = bind(BindTarget::Header, "${bookmark}", BindFormat::Iso8601);
-        assert_eq!(b.render(&json!("2024-06-01")).unwrap(), "2024-06-01T00:00:00Z");
+        assert_eq!(
+            b.render(&json!("2024-06-01")).unwrap(),
+            "2024-06-01T00:00:00Z"
+        );
         // Epoch seconds → ISO.
         assert_eq!(
             b.render(&json!(1_717_200_000)).unwrap(),
@@ -553,6 +557,9 @@ mod tests {
 
     #[test]
     fn bind_format_bookmark_bool_raw() {
-        assert_eq!(format_bookmark(&json!(true), BindFormat::Raw).unwrap(), "true");
+        assert_eq!(
+            format_bookmark(&json!(true), BindFormat::Raw).unwrap(),
+            "true"
+        );
     }
 }

--- a/crates/core/src/replication.rs
+++ b/crates/core/src/replication.rs
@@ -562,4 +562,17 @@ mod tests {
             "true"
         );
     }
+
+    #[test]
+    fn bind_format_non_scalar_bookmark_errors() {
+        // A composite / null bookmark cannot be parsed into an instant.
+        assert!(format_bookmark(&json!({"a": 1}), BindFormat::Iso8601).is_err());
+        assert!(format_bookmark(&json!(null), BindFormat::EpochS).is_err());
+    }
+
+    #[test]
+    fn bind_format_out_of_range_epoch_errors() {
+        // i64::MAX seconds is far outside chrono's representable range.
+        assert!(format_bookmark(&json!(i64::MAX), BindFormat::Iso8601).is_err());
+    }
 }

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -47,6 +47,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 jsonpath-rust = "1"
+quick-xml = { workspace = true }  # OData $metadata (EDMX/CSDL) parsing (#512)
 csv-async = { workspace = true }
 calamine = { workspace = true, optional = true }
 tokio = { version = "1", features = ["time"] }

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -146,6 +146,58 @@ Because the REST source keeps its own `429`/`Retry-After`-aware retry runner, it
 | `start_replication_value` | JSON / null | `null` | Bookmark value; records where `record[replication_key] <= start_replication_value` are filtered out in `Incremental` mode. |
 | `state_key` | string / null | `null` | Stable key used by `Pipeline::with_state_store` to persist this stream's bookmark across runs. See [Resume & state](#resume--state). |
 
+#### Server-side incremental push-down (`replication_bind`)
+
+By default `Incremental` mode filters **client-side** (after download). A
+`replication_bind` block instead pushes the stored bookmark **into the request**
+so the server returns only new rows (the client-side filter stays on as a safety
+net). Requires `replication_method: incremental` + `replication_key`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `into` | `query \| header \| body \| path` | `query` | Where to place the rendered bookmark. |
+| `name` | string | — | Query param / header / body-field / path-placeholder name. |
+| `template` | string | `${bookmark}` | Rendered with `${bookmark}` → the formatted value, e.g. `"gte\|${bookmark}"`, `"[${bookmark} TO *]"`. |
+| `format` | `raw \| iso8601 \| epoch_s \| epoch_ms \| date` | `raw` | Value formatting (string↔epoch conversion via a parsed instant). |
+| `advance_from` | string / null | `null` | JSONPath into the **response** to advance the bookmark from, instead of `max(record[replication_key])`. |
+
+```yaml
+replication_method: { type: incremental }
+replication_key: updated_at
+start_replication_value: "2024-01-01T00:00:00Z"
+replication_bind:
+  into: query
+  name: updated_after
+  template: "gte|${bookmark}"
+  format: iso8601
+```
+
+### OData (`odata`)
+
+Speak the OData protocol natively — a single block derives `@odata.nextLink`
+paging, the `$.value` envelope, the `$select`/`$filter`/`$expand`/`$orderby`
+query options, and the `Prefer: odata.maxpagesize` header. It stays a `rest`
+source (no new crate). `faucet discover` reads the service's `$metadata` (EDMX)
+and emits one dataset per entity set, with a typed schema.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `version` | `v2 \| v4` | `v4` | Selects the next-link key (`odata.nextLink` vs `@odata.nextLink`). |
+| `entity` | string / null | `null` | Entity set → the request path (when `path` is empty). |
+| `select` | array<string> | `[]` | `$select` columns. |
+| `expand` | array<string> | `[]` | `$expand` related entities (one level). |
+| `filter` | string / null | `null` | `$filter` expression (verbatim). |
+| `orderby` | string / null | `null` | `$orderby` (verbatim). |
+| `page_size` | int / null | `null` | `Prefer: odata.maxpagesize=<n>`. |
+
+```yaml
+source:
+  type: rest
+  config:
+    base_url: "https://host/odata/v4"
+    odata: { version: v4, entity: Orders, select: [DocEntry, DocDate], page_size: 500 }
+```
+
 ### Singer / Meltano metadata
 
 | Field | Type | Default | Description |

--- a/crates/source/rest/src/config.rs
+++ b/crates/source/rest/src/config.rs
@@ -3,7 +3,7 @@
 use crate::auth::Auth;
 use crate::pagination::PaginationStyle;
 use faucet_core::AuthSpec;
-use faucet_core::ReplicationMethod;
+use faucet_core::{ReplicationBind, ReplicationMethod};
 use reqwest::{
     Method,
     header::{HeaderMap, HeaderName, HeaderValue},
@@ -159,6 +159,79 @@ pub struct RestStreamConfig {
     /// skipped; the header row supplies field names. `response_format: excel` only.
     #[serde(default)]
     pub excel_header_row: usize,
+
+    // ── Server-side incremental push-down (#513) ────────────────────────────────
+    /// Bind the stored bookmark into the outgoing request (query param / header /
+    /// body field / path) so the server returns only new rows. Composes with the
+    /// existing `replication_key` client-side filter, which stays active as a
+    /// safety net. Requires `replication_method: incremental` + `replication_key`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replication_bind: Option<ReplicationBind>,
+
+    // ── OData (#512) ────────────────────────────────────────────────────────────
+    /// Speak the OData protocol: `@odata.nextLink` paging, the `$.value`
+    /// envelope, `$select`/`$filter`/`$expand`/`$orderby` sugar, and
+    /// `$metadata` (EDMX) → schema discovery. When set, it derives the
+    /// pagination, `records_path`, query params, and `Prefer` header at load
+    /// time (explicit values still win). See [`ODataConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub odata: Option<ODataConfig>,
+}
+
+/// OData protocol version, which selects the paging-link key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ODataVersion {
+    /// OData v2 — JSON-light next link `odata.nextLink`.
+    V2,
+    /// OData v4 (default) — next link `@odata.nextLink`.
+    #[default]
+    V4,
+}
+
+impl ODataVersion {
+    /// JSONPath to the next-page link for this version.
+    pub fn next_link_path(self) -> &'static str {
+        match self {
+            // Bracketed single-quoted keys — `@`/`.` aren't bare-identifier
+            // chars, and jsonpath-rust wants `$['key']`, not `$."key"`.
+            ODataVersion::V2 => "$['odata.nextLink']",
+            ODataVersion::V4 => "$['@odata.nextLink']",
+        }
+    }
+}
+
+/// OData protocol options for the REST source (#512).
+///
+/// A minimal block — `{ entity: Orders }` — is enough; it derives paging,
+/// the `$.value` envelope, and (for `faucet discover`) `$metadata` parsing.
+/// The query-option fields render into the standard `$select`/`$filter`/
+/// `$expand`/`$orderby` params.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ODataConfig {
+    /// Protocol version (default `v4`).
+    #[serde(default)]
+    pub version: ODataVersion,
+    /// Entity set to read (appended to `base_url` as the path, e.g. `Orders`).
+    /// Optional when the path already names the entity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity: Option<String>,
+    /// `$select` — columns to return.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub select: Vec<String>,
+    /// `$expand` — related entities to inline (one level).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expand: Vec<String>,
+    /// `$filter` — server-side filter expression (verbatim).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    /// `$orderby` — server-side ordering (verbatim).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orderby: Option<String>,
+    /// Server page size, sent as `Prefer: odata.maxpagesize=<n>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<usize>,
 }
 
 pub use faucet_core::TlsClientConfig;
@@ -197,6 +270,8 @@ impl Default for RestStreamConfig {
             csv_has_headers: true,
             excel_sheet: None,
             excel_header_row: 0,
+            replication_bind: None,
+            odata: None,
         }
     }
 }
@@ -224,7 +299,76 @@ impl RestStreamConfig {
                 ));
             }
         }
+        if let Some(bind) = &self.replication_bind {
+            bind.validate()?;
+            if !matches!(self.replication_method, ReplicationMethod::Incremental) {
+                return Err(faucet_core::FaucetError::Config(
+                    "rest: `replication_bind` requires `replication_method: incremental`".into(),
+                ));
+            }
+            if self.replication_key.is_none() {
+                return Err(faucet_core::FaucetError::Config(
+                    "rest: `replication_bind` requires `replication_key` (the field whose \
+                     bookmark is pushed down)"
+                        .into(),
+                ));
+            }
+        }
+        if self.odata.is_some() && !matches!(self.response_format, ResponseFormat::Json) {
+            return Err(faucet_core::FaucetError::Config(
+                "rest: `odata` speaks JSON — remove `response_format: csv|excel`".into(),
+            ));
+        }
         Ok(())
+    }
+
+    /// Derive request defaults from the `odata:` block (paging, `$.value`
+    /// envelope, `$select`/`$filter`/`$expand`/`$orderby` params, and the
+    /// `Prefer` page-size header). Explicit config always wins — a field the
+    /// user already set is never overwritten. Idempotent.
+    pub fn apply_odata_defaults(&mut self) {
+        let Some(odata) = self.odata.clone() else {
+            return;
+        };
+        // Entity → path when the path doesn't already name one.
+        if self.path.trim_matches('/').is_empty()
+            && let Some(entity) = &odata.entity
+        {
+            self.path = entity.clone();
+        }
+        // OData records live under `$.value`.
+        if self.records_path.is_none() {
+            self.records_path = Some("$.value[*]".to_owned());
+        }
+        // Follow `@odata.nextLink` (v4) / `odata.nextLink` (v2).
+        if matches!(self.pagination, PaginationStyle::None) {
+            self.pagination = PaginationStyle::NextLinkInBody {
+                next_link_path: odata.version.next_link_path().to_owned(),
+            };
+        }
+        // Query-option sugar → standard params (don't clobber explicit ones).
+        let mut set_param = |k: &str, v: String| {
+            self.query_params.entry(k.to_owned()).or_insert(v);
+        };
+        if !odata.select.is_empty() {
+            set_param("$select", odata.select.join(","));
+        }
+        if !odata.expand.is_empty() {
+            set_param("$expand", odata.expand.join(","));
+        }
+        if let Some(filter) = &odata.filter {
+            set_param("$filter", filter.clone());
+        }
+        if let Some(orderby) = &odata.orderby {
+            set_param("$orderby", orderby.clone());
+        }
+        // Server page size via the `Prefer` header.
+        if let Some(n) = odata.page_size
+            && !self.headers.contains_key("prefer")
+            && let Ok(val) = HeaderValue::from_str(&format!("odata.maxpagesize={n}"))
+        {
+            self.headers.insert(HeaderName::from_static("prefer"), val);
+        }
     }
 
     pub fn new(base_url: &str, path: &str) -> Self {
@@ -343,6 +487,19 @@ impl RestStreamConfig {
     /// applied to the stream before fetching.
     pub fn state_key(mut self, key: &str) -> Self {
         self.state_key = Some(key.into());
+        self
+    }
+
+    /// Bind the stored bookmark into the outgoing request (#513).
+    pub fn replication_bind(mut self, bind: ReplicationBind) -> Self {
+        self.replication_bind = Some(bind);
+        self
+    }
+
+    /// Speak OData: derive paging, the `$.value` envelope, the query-option
+    /// sugar, and `$metadata` discovery from the block (#512).
+    pub fn odata(mut self, odata: ODataConfig) -> Self {
+        self.odata = Some(odata);
         self
     }
 

--- a/crates/source/rest/src/config.rs
+++ b/crates/source/rest/src/config.rs
@@ -545,3 +545,92 @@ impl RestStreamConfig {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::{BindFormat, BindTarget, ReplicationBind};
+
+    fn bind() -> ReplicationBind {
+        ReplicationBind {
+            into: BindTarget::Query,
+            name: "since".to_owned(),
+            template: "${bookmark}".to_owned(),
+            format: BindFormat::Raw,
+            advance_from: None,
+        }
+    }
+
+    #[test]
+    fn replication_bind_requires_incremental_and_key() {
+        // Bind without incremental method → error.
+        let mut c = RestStreamConfig::new("https://x", "/y");
+        c.replication_bind = Some(bind());
+        assert!(c.validate().is_err());
+
+        // Incremental but no replication_key → error.
+        c.replication_method = ReplicationMethod::Incremental;
+        assert!(c.validate().is_err());
+
+        // Incremental + key → ok.
+        c.replication_key = Some("updated_at".to_owned());
+        assert!(c.validate().is_ok());
+
+        // An invalid bind (empty name) is rejected too.
+        let mut bad = c.clone();
+        bad.replication_bind = Some(ReplicationBind {
+            name: String::new(),
+            ..bind()
+        });
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn odata_rejects_non_json_response_format() {
+        let mut c = RestStreamConfig::new("https://x", "");
+        c.odata = Some(ODataConfig {
+            entity: Some("Orders".to_owned()),
+            ..Default::default()
+        });
+        c.response_format = ResponseFormat::Csv;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn apply_odata_defaults_renders_all_options_and_v2_link() {
+        let mut c = RestStreamConfig::new("https://host/odata", "");
+        c.odata = Some(ODataConfig {
+            version: ODataVersion::V2,
+            entity: Some("Orders".to_owned()),
+            select: vec!["A".to_owned(), "B".to_owned()],
+            expand: vec!["Lines".to_owned()],
+            filter: Some("A gt 1".to_owned()),
+            orderby: Some("A desc".to_owned()),
+            page_size: Some(250),
+        });
+        c.apply_odata_defaults();
+
+        assert_eq!(c.path, "Orders");
+        assert_eq!(c.records_path.as_deref(), Some("$.value[*]"));
+        assert_eq!(c.query_params.get("$select").unwrap(), "A,B");
+        assert_eq!(c.query_params.get("$expand").unwrap(), "Lines");
+        assert_eq!(c.query_params.get("$filter").unwrap(), "A gt 1");
+        assert_eq!(c.query_params.get("$orderby").unwrap(), "A desc");
+        assert_eq!(c.headers.get("prefer").unwrap(), "odata.maxpagesize=250");
+        // v2 uses the un-prefixed next-link key.
+        assert!(matches!(
+            c.pagination,
+            crate::pagination::PaginationStyle::NextLinkInBody { ref next_link_path }
+                if next_link_path == "$['odata.nextLink']"
+        ));
+        // Idempotent: a second application doesn't clobber explicit values.
+        c.apply_odata_defaults();
+        assert_eq!(c.query_params.get("$select").unwrap(), "A,B");
+    }
+
+    #[test]
+    fn odata_version_next_link_paths() {
+        assert_eq!(ODataVersion::V4.next_link_path(), "$['@odata.nextLink']");
+        assert_eq!(ODataVersion::V2.next_link_path(), "$['odata.nextLink']");
+    }
+}

--- a/crates/source/rest/src/lib.rs
+++ b/crates/source/rest/src/lib.rs
@@ -9,6 +9,7 @@ pub mod auth;
 pub mod config;
 pub mod extract;
 pub mod format;
+pub mod odata;
 pub mod pagination;
 pub mod retry;
 pub mod serde_helpers;
@@ -22,6 +23,6 @@ pub use faucet_core::{
 pub use auth::oauth2::DEFAULT_EXPIRY_RATIO;
 pub use auth::token_endpoint::DEFAULT_TOKEN_ENDPOINT_EXPIRY_RATIO;
 pub use auth::{Auth, ResponseValidator, fetch_oauth2_token, fetch_token_from_endpoint};
-pub use config::{ResponseFormat, RestStreamConfig, TlsClientConfig};
+pub use config::{ODataConfig, ODataVersion, ResponseFormat, RestStreamConfig, TlsClientConfig};
 pub use pagination::PaginationStyle;
 pub use stream::RestStream;

--- a/crates/source/rest/src/odata.rs
+++ b/crates/source/rest/src/odata.rs
@@ -274,4 +274,20 @@ mod tests {
     fn invalid_xml_errors() {
         assert!(parse_edmx("<Schema><EntityType Name=").is_err());
     }
+
+    #[test]
+    fn property_without_name_is_skipped() {
+        // A `<Property>` with no `Name` is skipped (not added as an empty-named
+        // column); an explicit `Nullable="true"` is honoured.
+        let xml = r#"<Schema>
+          <EntityType Name="T">
+            <Property Type="Edm.String"/>
+            <Property Name="ok" Type="Edm.String" Nullable="true"/>
+          </EntityType>
+        </Schema>"#;
+        let (types, _sets) = parse_edmx(xml).unwrap();
+        assert_eq!(types[0].properties.len(), 1);
+        assert_eq!(types[0].properties[0].name, "ok");
+        assert!(types[0].properties[0].nullable);
+    }
 }

--- a/crates/source/rest/src/odata.rs
+++ b/crates/source/rest/src/odata.rs
@@ -1,0 +1,272 @@
+//! OData `$metadata` (EDMX / CSDL) parsing → dataset discovery (#512).
+//!
+//! Pure, network-free: [`parse_edmx`] turns a `$metadata` XML document into the
+//! entity types + sets it declares, and [`descriptors_from_edmx`] maps those
+//! onto [`DatasetDescriptor`]s (one per entity set, each with a typed schema and
+//! a `config_patch` that selects the entity).
+
+use faucet_core::FaucetError;
+use faucet_core::discover::{DatasetDescriptor, columns_to_schema, nullable_type};
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+/// One EDM property (column) of an entity type.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EdmProperty {
+    /// Property name.
+    pub name: String,
+    /// EDM type (e.g. `Edm.String`, `Edm.Int32`).
+    pub edm_type: String,
+    /// Whether the property may be null (EDM default is `true`).
+    pub nullable: bool,
+}
+
+/// An EDM entity type: its key columns + properties.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct EdmEntityType {
+    /// Type name (local, namespace-stripped).
+    pub name: String,
+    /// Key property names.
+    pub keys: Vec<String>,
+    /// Properties in declaration order.
+    pub properties: Vec<EdmProperty>,
+}
+
+/// An EDM entity set: the queryable collection name + the type it holds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EdmEntitySet {
+    /// Entity-set name (the path segment you query).
+    pub name: String,
+    /// Local name of the entity type backing this set.
+    pub type_name: String,
+}
+
+/// Map an EDM primitive type to a JSON-Schema type fragment.
+pub fn edm_type_to_json(edm_type: &str) -> Value {
+    let t = edm_type.strip_prefix("Edm.").unwrap_or(edm_type);
+    let ty = match t {
+        "Boolean" => "boolean",
+        "Byte" | "SByte" | "Int16" | "Int32" | "Int64" => "integer",
+        "Decimal" | "Double" | "Single" => "number",
+        // String, Guid, DateTimeOffset, Date, TimeOfDay, Duration, Binary,
+        // Stream, Geography*, … all serialize as JSON strings.
+        _ => "string",
+    };
+    json!({ "type": ty })
+}
+
+/// Namespace-strip a possibly-prefixed XML name (`edm:Property` → `Property`).
+fn local_name(qname: &[u8]) -> String {
+    let s = String::from_utf8_lossy(qname);
+    s.rsplit(':').next().unwrap_or(&s).to_string()
+}
+
+/// Read one attribute of an element by (namespace-stripped) name.
+fn attr(e: &BytesStart, key: &str) -> Option<String> {
+    e.attributes()
+        .flatten()
+        .find(|a| local_name(a.key.as_ref()) == key)
+        .and_then(|a| a.unescape_value().ok().map(|v| v.to_string()))
+}
+
+/// Parse an EDMX / CSDL `$metadata` document into its entity types + sets.
+pub fn parse_edmx(xml: &str) -> Result<(Vec<EdmEntityType>, Vec<EdmEntitySet>), FaucetError> {
+    let mut reader = Reader::from_str(xml);
+    let mut types: Vec<EdmEntityType> = Vec::new();
+    let mut sets: Vec<EdmEntitySet> = Vec::new();
+    let mut current: Option<EdmEntityType> = None;
+    let mut in_key = false;
+
+    // Handle a start/empty element's attributes; `is_empty` self-closing tags
+    // (`<Property .../>`, `<EntitySet .../>`) never get a matching `End`.
+    let open = |e: &BytesStart,
+                is_empty: bool,
+                    current: &mut Option<EdmEntityType>,
+                    in_key: &mut bool,
+                    types: &mut Vec<EdmEntityType>,
+                    sets: &mut Vec<EdmEntitySet>| {
+        match local_name(e.name().as_ref()).as_str() {
+            "EntityType" => {
+                let t = EdmEntityType {
+                    name: attr(e, "Name").unwrap_or_default(),
+                    ..Default::default()
+                };
+                if is_empty {
+                    types.push(t);
+                } else {
+                    *current = Some(t);
+                }
+            }
+            "Key" => {
+                if !is_empty {
+                    *in_key = true;
+                }
+            }
+            "PropertyRef" => {
+                if *in_key
+                    && let (Some(cur), Some(n)) = (current.as_mut(), attr(e, "Name"))
+                {
+                    cur.keys.push(n);
+                }
+            }
+            "Property" => {
+                if let Some(cur) = current.as_mut() {
+                    let name = attr(e, "Name").unwrap_or_default();
+                    if !name.is_empty() {
+                        cur.properties.push(EdmProperty {
+                            name,
+                            edm_type: attr(e, "Type").unwrap_or_else(|| "Edm.String".to_owned()),
+                            // EDM `Nullable` defaults to true when absent.
+                            nullable: attr(e, "Nullable").map(|v| v != "false").unwrap_or(true),
+                        });
+                    }
+                }
+            }
+            "EntitySet" => {
+                if let (Some(name), Some(ty)) = (attr(e, "Name"), attr(e, "EntityType")) {
+                    let type_name = ty.rsplit('.').next().unwrap_or(&ty).to_owned();
+                    sets.push(EdmEntitySet { name, type_name });
+                }
+            }
+            _ => {}
+        }
+    };
+
+    loop {
+        match reader
+            .read_event()
+            .map_err(|e| FaucetError::Source(format!("odata: invalid $metadata XML: {e}")))?
+        {
+            Event::Eof => break,
+            Event::Start(e) => open(&e, false, &mut current, &mut in_key, &mut types, &mut sets),
+            Event::Empty(e) => open(&e, true, &mut current, &mut in_key, &mut types, &mut sets),
+            Event::End(e) => match local_name(e.name().as_ref()).as_str() {
+                "EntityType" => {
+                    if let Some(t) = current.take() {
+                        types.push(t);
+                    }
+                }
+                "Key" => in_key = false,
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    Ok((types, sets))
+}
+
+/// Parse `$metadata` and produce one [`DatasetDescriptor`] per entity set,
+/// each carrying a typed schema and a `config_patch` selecting the entity.
+pub fn descriptors_from_edmx(xml: &str) -> Result<Vec<DatasetDescriptor>, FaucetError> {
+    let (types, sets) = parse_edmx(xml)?;
+    let by_name: HashMap<&str, &EdmEntityType> =
+        types.iter().map(|t| (t.name.as_str(), t)).collect();
+    let mut out = Vec::with_capacity(sets.len());
+    for set in &sets {
+        let schema = by_name.get(set.type_name.as_str()).map(|t| {
+            let cols = t.properties.iter().map(|p| {
+                let frag = edm_type_to_json(&p.edm_type);
+                let frag = if p.nullable { nullable_type(frag) } else { frag };
+                (p.name.clone(), frag)
+            });
+            columns_to_schema(cols)
+        });
+        let mut d = DatasetDescriptor::new(
+            set.name.clone(),
+            "entity",
+            json!({ "odata": { "entity": set.name.clone() } }),
+        );
+        if let Some(s) = schema {
+            d = d.with_schema(s);
+        }
+        out.push(d);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Sales" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Order">
+        <Key><PropertyRef Name="DocEntry"/></Key>
+        <Property Name="DocEntry" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="DocDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="Total" Type="Edm.Decimal" Nullable="false"/>
+        <Property Name="Posted" Type="Edm.Boolean"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Orders" EntityType="Sales.Order"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"#;
+
+    #[test]
+    fn edm_types_map_to_json_types() {
+        assert_eq!(edm_type_to_json("Edm.Boolean"), json!({"type": "boolean"}));
+        assert_eq!(edm_type_to_json("Edm.Int64"), json!({"type": "integer"}));
+        assert_eq!(edm_type_to_json("Edm.Decimal"), json!({"type": "number"}));
+        assert_eq!(edm_type_to_json("Edm.String"), json!({"type": "string"}));
+        assert_eq!(
+            edm_type_to_json("Edm.DateTimeOffset"),
+            json!({"type": "string"})
+        );
+        assert_eq!(edm_type_to_json("Something.Custom"), json!({"type": "string"}));
+    }
+
+    #[test]
+    fn parse_edmx_extracts_types_and_sets() {
+        let (types, sets) = parse_edmx(SAMPLE).unwrap();
+        assert_eq!(types.len(), 1);
+        assert_eq!(types[0].name, "Order");
+        assert_eq!(types[0].keys, vec!["DocEntry".to_string()]);
+        assert_eq!(types[0].properties.len(), 4);
+        assert_eq!(types[0].properties[0].name, "DocEntry");
+        assert!(!types[0].properties[0].nullable);
+        assert!(types[0].properties[1].nullable); // DocDate has no Nullable attr
+        assert_eq!(sets.len(), 1);
+        assert_eq!(sets[0].name, "Orders");
+        assert_eq!(sets[0].type_name, "Order");
+    }
+
+    #[test]
+    fn descriptors_carry_schema_and_config_patch() {
+        let ds = descriptors_from_edmx(SAMPLE).unwrap();
+        assert_eq!(ds.len(), 1);
+        let d = &ds[0];
+        assert_eq!(d.name, "Orders");
+        assert_eq!(d.kind, "entity");
+        assert_eq!(d.config_patch, json!({ "odata": { "entity": "Orders" } }));
+        let schema = d.schema.as_ref().unwrap();
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["properties"]["DocEntry"]["type"], "integer");
+        assert_eq!(schema["properties"]["Total"]["type"], "number");
+        assert_eq!(schema["properties"]["Posted"]["type"][0], "boolean");
+        assert_eq!(schema["properties"]["Posted"]["type"][1], "null");
+    }
+
+    #[test]
+    fn empty_entity_type_and_missing_type_are_tolerated() {
+        let xml = r#"<Schema>
+            <EntityType Name="Empty"/>
+            <EntitySet Name="Ghosts" EntityType="ns.NotDeclared"/>
+        </Schema>"#;
+        let ds = descriptors_from_edmx(xml).unwrap();
+        assert_eq!(ds.len(), 1);
+        // No matching type → no schema, but the set is still discoverable.
+        assert!(ds[0].schema.is_none());
+        assert_eq!(ds[0].name, "Ghosts");
+    }
+
+    #[test]
+    fn invalid_xml_errors() {
+        assert!(parse_edmx("<Schema><EntityType Name=").is_err());
+    }
+}

--- a/crates/source/rest/src/odata.rs
+++ b/crates/source/rest/src/odata.rs
@@ -83,10 +83,10 @@ pub fn parse_edmx(xml: &str) -> Result<(Vec<EdmEntityType>, Vec<EdmEntitySet>), 
     // (`<Property .../>`, `<EntitySet .../>`) never get a matching `End`.
     let open = |e: &BytesStart,
                 is_empty: bool,
-                    current: &mut Option<EdmEntityType>,
-                    in_key: &mut bool,
-                    types: &mut Vec<EdmEntityType>,
-                    sets: &mut Vec<EdmEntitySet>| {
+                current: &mut Option<EdmEntityType>,
+                in_key: &mut bool,
+                types: &mut Vec<EdmEntityType>,
+                sets: &mut Vec<EdmEntitySet>| {
         match local_name(e.name().as_ref()).as_str() {
             "EntityType" => {
                 let t = EdmEntityType {
@@ -105,9 +105,7 @@ pub fn parse_edmx(xml: &str) -> Result<(Vec<EdmEntityType>, Vec<EdmEntitySet>), 
                 }
             }
             "PropertyRef" => {
-                if *in_key
-                    && let (Some(cur), Some(n)) = (current.as_mut(), attr(e, "Name"))
-                {
+                if *in_key && let (Some(cur), Some(n)) = (current.as_mut(), attr(e, "Name")) {
                     cur.keys.push(n);
                 }
             }
@@ -168,7 +166,11 @@ pub fn descriptors_from_edmx(xml: &str) -> Result<Vec<DatasetDescriptor>, Faucet
         let schema = by_name.get(set.type_name.as_str()).map(|t| {
             let cols = t.properties.iter().map(|p| {
                 let frag = edm_type_to_json(&p.edm_type);
-                let frag = if p.nullable { nullable_type(frag) } else { frag };
+                let frag = if p.nullable {
+                    nullable_type(frag)
+                } else {
+                    frag
+                };
                 (p.name.clone(), frag)
             });
             columns_to_schema(cols)
@@ -218,7 +220,10 @@ mod tests {
             edm_type_to_json("Edm.DateTimeOffset"),
             json!({"type": "string"})
         );
-        assert_eq!(edm_type_to_json("Something.Custom"), json!({"type": "string"}));
+        assert_eq!(
+            edm_type_to_json("Something.Custom"),
+            json!({"type": "string"})
+        );
     }
 
     #[test]

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -141,8 +141,9 @@ fn credential_to_auth(cred: Credential) -> Auth {
 fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) -> Result<(), FaucetError> {
     let hn = HeaderName::from_bytes(name.as_bytes())
         .map_err(|e| FaucetError::Config(format!("rest: invalid header name '{name}': {e}")))?;
-    let hv = HeaderValue::from_str(value)
-        .map_err(|e| FaucetError::Config(format!("rest: invalid value for header '{name}': {e}")))?;
+    let hv = HeaderValue::from_str(value).map_err(|e| {
+        FaucetError::Config(format!("rest: invalid value for header '{name}': {e}"))
+    })?;
     headers.insert(hn, hv);
     Ok(())
 }
@@ -1336,7 +1337,8 @@ impl faucet_core::Source for RestStream {
     async fn discover(&self) -> Result<Vec<faucet_core::DatasetDescriptor>, FaucetError> {
         if self.config.odata.is_none() {
             return Err(FaucetError::Source(
-                "rest: discovery is only supported for OData sources — set an `odata:` block".into(),
+                "rest: discovery is only supported for OData sources — set an `odata:` block"
+                    .into(),
             ));
         }
         let url = format!("{}/$metadata", self.config.base_url.trim_end_matches('/'));
@@ -1347,7 +1349,9 @@ impl faucet_core::Source for RestStream {
             .headers(headers)
             .send()
             .await
-            .map_err(|e| FaucetError::Source(format!("rest: OData $metadata request failed: {e}")))?;
+            .map_err(|e| {
+                FaucetError::Source(format!("rest: OData $metadata request failed: {e}"))
+            })?;
         let status = resp.status();
         if !status.is_success() {
             return Err(FaucetError::Source(format!(
@@ -1355,10 +1359,9 @@ impl faucet_core::Source for RestStream {
                 status.as_u16()
             )));
         }
-        let xml = resp
-            .text()
-            .await
-            .map_err(|e| FaucetError::Source(format!("rest: reading OData $metadata failed: {e}")))?;
+        let xml = resp.text().await.map_err(|e| {
+            FaucetError::Source(format!("rest: reading OData $metadata failed: {e}"))
+        })?;
         crate::odata::descriptors_from_edmx(&xml)
     }
 }

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -9,13 +9,13 @@ use crate::pagination::{PaginationState, PaginationStyle};
 use crate::retry;
 use async_trait::async_trait;
 use faucet_core::replication::{
-    ReplicationMethod, filter_incremental, max_replication_value, max_value,
+    BindTarget, ReplicationMethod, filter_incremental, max_replication_value, max_value,
 };
 use faucet_core::schema;
-use faucet_core::{AuthSpec, Credential, FaucetError, SharedAuthProvider};
+use faucet_core::{AuthSpec, Credential, CredentialPlacement, FaucetError, SharedAuthProvider};
 use futures_core::Stream;
 use reqwest::Client;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -136,9 +136,23 @@ fn credential_to_auth(cred: Credential) -> Auth {
     }
 }
 
+/// Insert a header from string parts, mapping invalid names/values to a typed
+/// config error rather than panicking.
+fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) -> Result<(), FaucetError> {
+    let hn = HeaderName::from_bytes(name.as_bytes())
+        .map_err(|e| FaucetError::Config(format!("rest: invalid header name '{name}': {e}")))?;
+    let hv = HeaderValue::from_str(value)
+        .map_err(|e| FaucetError::Config(format!("rest: invalid value for header '{name}': {e}")))?;
+    headers.insert(hn, hv);
+    Ok(())
+}
+
 impl RestStream {
     /// Create a new stream from the given configuration.
-    pub fn new(config: RestStreamConfig) -> Result<Self, FaucetError> {
+    pub fn new(mut config: RestStreamConfig) -> Result<Self, FaucetError> {
+        // Derive OData request defaults (paging, `$.value`, query sugar, Prefer)
+        // before validation so the checks see the effective request shape.
+        config.apply_odata_defaults();
         // Cross-field config invariants (e.g. file response formats can't paginate).
         config.validate()?;
         // Validate expiry_ratio at construction time.
@@ -481,16 +495,33 @@ impl RestStream {
                     };
 
                 // Track the running max replication value across pages so the
-                // final page can carry the consolidated bookmark.
-                if self.config.replication_method == ReplicationMethod::Incremental
-                    && let Some(key) = self.config.replication_key.as_deref()
-                        && let Some(page_max) = max_replication_value(&records, key) {
-                            let page_max = page_max.clone();
-                            running_max = Some(match running_max.take() {
-                                Some(prev) => max_value(prev, page_max),
-                                None => page_max,
-                            });
-                        }
+                // final page can carry the consolidated bookmark. When the
+                // replication bind declares `advance_from`, the next bookmark is
+                // read from that JSONPath in the **response body** (#513);
+                // otherwise it is `max(record[replication_key])`.
+                if self.config.replication_method == ReplicationMethod::Incremental {
+                    let page_max: Option<Value> = match self
+                        .config
+                        .replication_bind
+                        .as_ref()
+                        .and_then(|b| b.advance_from.as_deref())
+                    {
+                        Some(path) => faucet_core::util::extract_records(&body, Some(path))
+                            .ok()
+                            .and_then(|vs| vs.into_iter().next()),
+                        None => self
+                            .config
+                            .replication_key
+                            .as_deref()
+                            .and_then(|key| max_replication_value(&records, key).cloned()),
+                    };
+                    if let Some(page_max) = page_max {
+                        running_max = Some(match running_max.take() {
+                            Some(prev) => max_value(prev, page_max),
+                            None => page_max,
+                        });
+                    }
+                }
 
                 // Advance pagination state to learn whether there is a next
                 // page BEFORE yielding the current one. This way the bookmark
@@ -637,8 +668,36 @@ impl RestStream {
                 )
                 .await
             }
+            // #511: a shared provider (e.g. a multi-step flow) whose session
+            // expired mid-run — re-auth on a status it declared in `reauth_on`
+            // and retry once.
+            Err(FaucetError::HttpStatus { status, .. }) if self.provider_wants_reauth(status) => {
+                if let Some(provider) = &self.auth_provider {
+                    tracing::warn!(
+                        status,
+                        "shared auth provider requested re-auth on this status; \
+                         re-authenticating and retrying once"
+                    );
+                    let _ = provider.invalidate(&Credential::Token(String::new())).await;
+                }
+                self.execute_request_once(
+                    params,
+                    url_override,
+                    path_context,
+                    is_first_page,
+                    body_cursor,
+                )
+                .await
+            }
             other => other,
         }
+    }
+
+    /// `true` when a shared provider declared `status` in its `reauth_statuses`.
+    fn provider_wants_reauth(&self, status: u16) -> bool {
+        self.auth_provider
+            .as_ref()
+            .is_some_and(|p| p.reauth_statuses().contains(&status))
     }
 
     /// `true` when this source resolves its bearer token from one of the inline
@@ -665,49 +724,48 @@ impl RestStream {
         }
     }
 
-    /// Execute a single HTTP request and return the response body and headers.
-    ///
-    /// - When `url_override` is `Some`, that full URL is used and query params
-    ///   are **not** appended (Link header pagination encodes them in the URL).
-    /// - When `path_context` is `Some`, `{key}` placeholders in `config.path`
-    ///   are substituted with values from the context map (partition support).
-    async fn execute_request_once(
-        &self,
-        params: &HashMap<String, String>,
-        url_override: Option<&str>,
-        path_context: Option<&HashMap<String, Value>>,
-        is_first_page: bool,
-        body_cursor: Option<(&str, &str)>,
-    ) -> Result<(Value, HeaderMap), FaucetError> {
-        let use_override = url_override.is_some();
-        let url = match url_override {
-            Some(u) => u.to_string(),
-            None => {
-                let path = match path_context {
-                    Some(ctx) => faucet_core::util::substitute_context(&self.config.path, ctx),
-                    None => self.config.path.clone(),
-                };
-                format!("{}/{}", self.config.base_url, path.trim_start_matches('/'))
-            }
+    /// Resolve the server-side push-down binding for this run:
+    /// `(target, name, rendered-value)`. Returns `None` when no `replication_bind`
+    /// is configured or there is no bookmark yet (first run — a full pull).
+    async fn resolved_bind(&self) -> Result<Option<(BindTarget, String, String)>, FaucetError> {
+        let Some(bind) = &self.config.replication_bind else {
+            return Ok(None);
         };
+        let bookmark = {
+            let guard = self.runtime_start.lock().await;
+            guard.clone()
+        }
+        .or_else(|| self.config.start_replication_value.clone());
+        match bookmark {
+            Some(bm) => Ok(Some((bind.into, bind.name.clone(), bind.render(&bm)?))),
+            None => Ok(None),
+        }
+    }
 
-        // Resolve credentials to concrete auth headers. A shared auth provider
-        // (from `auth: { ref }` or injected by a library caller) takes
-        // precedence; otherwise inline OAuth2 / TokenEndpoint are resolved to a
-        // Bearer token via the per-source cache (cached until expiry, avoiding a
-        // token fetch on every request).
-        let resolved_auth = if let Some(provider) = &self.auth_provider {
-            // A per-request signer (OAuth1, #496) signs this exact method + URL +
-            // query; every other provider returns `None` here and we apply its
-            // reusable credential.
-            let query: std::collections::BTreeMap<String, String> =
-                params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-            match provider
-                .sign_request(self.config.method.as_str(), &url, &query)
-                .await?
-            {
-                Some(cred) => credential_to_auth(cred),
-                None => credential_to_auth(provider.credential().await?),
+    /// Resolve auth headers for a non-paginated preflight request (OData
+    /// `$metadata`). Applies a flow provider's header/cookie placements or its
+    /// credential; else the inline auth (bearer via cache for OAuth2/token
+    /// endpoint). Query/body placements and `ApiKeyQuery` are not applied here.
+    async fn metadata_headers(&self, url: &str) -> Result<HeaderMap, FaucetError> {
+        let mut headers = HeaderMap::new();
+        if let Some(provider) = &self.auth_provider {
+            let ra = provider
+                .request_auth("GET", url, &std::collections::BTreeMap::new())
+                .await?;
+            if ra.is_empty() {
+                credential_to_auth(provider.credential().await?).apply(&mut headers)?;
+            } else {
+                for p in ra.placements {
+                    match p {
+                        CredentialPlacement::Header { name, value } => {
+                            insert_header(&mut headers, &name, &value)?
+                        }
+                        CredentialPlacement::Cookie { name, value } => {
+                            insert_header(&mut headers, "Cookie", &format!("{name}={value}"))?
+                        }
+                        _ => {}
+                    }
+                }
             }
         } else {
             match &self.config.auth {
@@ -729,7 +787,7 @@ impl RestStream {
                             *expiry_ratio,
                         )
                         .await?;
-                    Auth::Bearer { token }
+                    Auth::Bearer { token }.apply(&mut headers)?;
                 }
                 AuthSpec::Inline(Auth::TokenEndpoint {
                     url: token_url,
@@ -755,9 +813,158 @@ impl RestStream {
                             response_validator.as_ref(),
                         )
                         .await?;
-                    Auth::Bearer { token }
+                    Auth::Bearer { token }.apply(&mut headers)?;
                 }
-                AuthSpec::Inline(other) => other.clone(),
+                AuthSpec::Inline(other) => other.apply(&mut headers)?,
+                AuthSpec::Reference(_) => {}
+            }
+        }
+        Ok(headers)
+    }
+
+    /// Execute a single HTTP request and return the response body and headers.
+    ///
+    /// - When `url_override` is `Some`, that full URL is used and query params
+    ///   are **not** appended (Link header pagination encodes them in the URL).
+    /// - When `path_context` is `Some`, `{key}` placeholders in `config.path`
+    ///   are substituted with values from the context map (partition support).
+    async fn execute_request_once(
+        &self,
+        params: &HashMap<String, String>,
+        url_override: Option<&str>,
+        path_context: Option<&HashMap<String, Value>>,
+        is_first_page: bool,
+        body_cursor: Option<(&str, &str)>,
+    ) -> Result<(Value, HeaderMap), FaucetError> {
+        let use_override = url_override.is_some();
+
+        // #513 server-side push-down: resolve the bookmark binding for this run
+        // (`None` on the first run, before any bookmark exists).
+        let bind = self.resolved_bind().await?;
+
+        let query_btree: std::collections::BTreeMap<String, String> =
+            params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+        // #511 rich per-request auth: a flow provider may place credentials
+        // across header/query/cookie/body and override the base-URL for this
+        // session. When it contributes anything, it supersedes the plain
+        // credential()/sign_request() path below.
+        let mut base_url = self.config.base_url.clone();
+        let mut ra_headers: Vec<(String, String)> = Vec::new();
+        let mut ra_query: Vec<(String, String)> = Vec::new();
+        let mut ra_cookies: Vec<(String, String)> = Vec::new();
+        let mut ra_body: Vec<(String, String)> = Vec::new();
+        let mut used_request_auth = false;
+        if let Some(provider) = &self.auth_provider {
+            let ra = provider
+                .request_auth(self.config.method.as_str(), &base_url, &query_btree)
+                .await?;
+            if !ra.is_empty() {
+                used_request_auth = true;
+                if let Some(b) = ra.base_url {
+                    base_url = b;
+                }
+                for p in ra.placements {
+                    match p {
+                        CredentialPlacement::Header { name, value } => {
+                            ra_headers.push((name, value))
+                        }
+                        CredentialPlacement::Query { name, value } => ra_query.push((name, value)),
+                        CredentialPlacement::Cookie { name, value } => {
+                            ra_cookies.push((name, value))
+                        }
+                        CredentialPlacement::BodyField { name, value } => {
+                            ra_body.push((name, value))
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // Build the URL (honouring any dynamic base-URL) and apply a `path`-target
+        // push-down binding.
+        let mut url = match url_override {
+            Some(u) => u.to_string(),
+            None => {
+                let path = match path_context {
+                    Some(ctx) => faucet_core::util::substitute_context(&self.config.path, ctx),
+                    None => self.config.path.clone(),
+                };
+                format!("{}/{}", base_url, path.trim_start_matches('/'))
+            }
+        };
+        if let Some((BindTarget::Path, name, rendered)) = &bind {
+            url = url.replace(&format!("{{{name}}}"), rendered);
+        }
+
+        // Resolve inline / signed credentials — unless a flow provider already
+        // supplied the request auth. A shared provider (from `auth: { ref }` or
+        // a library caller) takes precedence over inline; inline OAuth2 /
+        // TokenEndpoint resolve to a Bearer token via the per-source cache.
+        let resolved_auth: Option<Auth> = if used_request_auth {
+            None
+        } else if let Some(provider) = &self.auth_provider {
+            // A per-request signer (OAuth1, #496) signs this exact method + URL +
+            // query; every other provider returns `None` here and we apply its
+            // reusable credential.
+            let cred = match provider
+                .sign_request(self.config.method.as_str(), &url, &query_btree)
+                .await?
+            {
+                Some(cred) => cred,
+                None => provider.credential().await?,
+            };
+            Some(credential_to_auth(cred))
+        } else {
+            match &self.config.auth {
+                AuthSpec::Inline(Auth::OAuth2 {
+                    token_url,
+                    client_id,
+                    client_secret,
+                    scopes,
+                    expiry_ratio,
+                }) => {
+                    let token = self
+                        .token_cache
+                        .get_or_refresh(
+                            &self.client,
+                            token_url,
+                            client_id,
+                            client_secret,
+                            scopes,
+                            *expiry_ratio,
+                        )
+                        .await?;
+                    Some(Auth::Bearer { token })
+                }
+                AuthSpec::Inline(Auth::TokenEndpoint {
+                    url: token_url,
+                    method: token_method,
+                    headers: token_headers,
+                    body: token_body,
+                    token_path,
+                    expiry_path,
+                    expiry_ratio,
+                    response_validator,
+                }) => {
+                    let token = self
+                        .token_endpoint_cache
+                        .get_or_refresh(
+                            &self.client,
+                            token_url,
+                            token_method,
+                            token_headers,
+                            token_body.as_ref(),
+                            token_path,
+                            expiry_path.as_deref(),
+                            *expiry_ratio,
+                            response_validator.as_ref(),
+                        )
+                        .await?;
+                    Some(Auth::Bearer { token })
+                }
+                AuthSpec::Inline(other) => Some(other.clone()),
                 AuthSpec::Reference(r) => {
                     return Err(FaucetError::Auth(format!(
                         "auth references provider '{}' but no provider was supplied; \
@@ -769,7 +976,25 @@ impl RestStream {
         };
 
         let mut headers = self.config.headers.clone();
-        resolved_auth.apply(&mut headers)?;
+        if let Some(auth) = &resolved_auth {
+            auth.apply(&mut headers)?;
+        }
+        // #511 header + cookie placements from the flow provider.
+        for (name, value) in &ra_headers {
+            insert_header(&mut headers, name, value)?;
+        }
+        if !ra_cookies.is_empty() {
+            let cookie = ra_cookies
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            insert_header(&mut headers, "Cookie", &cookie)?;
+        }
+        // #513 header-target binding.
+        if let Some((BindTarget::Header, name, rendered)) = &bind {
+            insert_header(&mut headers, name, rendered)?;
+        }
 
         let mut req = self
             .client
@@ -788,6 +1013,18 @@ impl RestStream {
             } else {
                 req = req.query(params);
             }
+        }
+        // #511 query placements from the flow provider.
+        if !ra_query.is_empty() {
+            let pairs: Vec<(&str, &str)> = ra_query
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            req = req.query(&pairs);
+        }
+        // #513 query-target binding.
+        if let Some((BindTarget::Query, name, rendered)) = &bind {
+            req = req.query(&[(name.as_str(), rendered.as_str())]);
         }
 
         // ApiKeyQuery: inject the API key as a query parameter.
@@ -834,6 +1071,28 @@ impl RestStream {
                     return Err(FaucetError::Source(
                         "REST source: pagination `CursorInBody` requires a JSON object request \
                          body to inject the cursor into"
+                            .into(),
+                    ));
+                }
+            }
+        }
+        // #511 body-field placements + #513 body-target binding.
+        let body_bind = matches!(&bind, Some((BindTarget::Body, _, _)));
+        if !ra_body.is_empty() || body_bind {
+            let obj = body_value.get_or_insert_with(|| Value::Object(serde_json::Map::new()));
+            match obj.as_object_mut() {
+                Some(map) => {
+                    for (name, value) in &ra_body {
+                        map.insert(name.clone(), Value::String(value.clone()));
+                    }
+                    if let Some((BindTarget::Body, name, rendered)) = &bind {
+                        map.insert(name.clone(), Value::String(rendered.clone()));
+                    }
+                }
+                None => {
+                    return Err(FaucetError::Source(
+                        "REST source: a body-target auth/replication binding requires a JSON \
+                         object request body"
                             .into(),
                     ));
                 }
@@ -1066,6 +1325,41 @@ impl faucet_core::Source for RestStream {
     async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
         *self.runtime_start.lock().await = Some(bookmark);
         Ok(())
+    }
+
+    fn supports_discover(&self) -> bool {
+        // OData exposes a machine-readable `$metadata` catalog; a plain REST API
+        // has none, so discovery is OData-only.
+        self.config.odata.is_some()
+    }
+
+    async fn discover(&self) -> Result<Vec<faucet_core::DatasetDescriptor>, FaucetError> {
+        if self.config.odata.is_none() {
+            return Err(FaucetError::Source(
+                "rest: discovery is only supported for OData sources — set an `odata:` block".into(),
+            ));
+        }
+        let url = format!("{}/$metadata", self.config.base_url.trim_end_matches('/'));
+        let headers = self.metadata_headers(&url).await?;
+        let resp = self
+            .client
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|e| FaucetError::Source(format!("rest: OData $metadata request failed: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(FaucetError::Source(format!(
+                "rest: OData $metadata returned HTTP {}",
+                status.as_u16()
+            )));
+        }
+        let xml = resp
+            .text()
+            .await
+            .map_err(|e| FaucetError::Source(format!("rest: reading OData $metadata failed: {e}")))?;
+        crate::odata::descriptors_from_edmx(&xml)
     }
 }
 

--- a/crates/source/rest/tests/source_side_unlocks.rs
+++ b/crates/source/rest/tests/source_side_unlocks.rs
@@ -76,19 +76,20 @@ async fn odata_discover_parses_metadata() {
         .mount(&server)
         .await;
 
-    let stream = RestStream::new(
-        RestStreamConfig::new(&server.uri(), "").odata(ODataConfig {
-            entity: Some("Orders".to_owned()),
-            ..Default::default()
-        }),
-    )
+    let stream = RestStream::new(RestStreamConfig::new(&server.uri(), "").odata(ODataConfig {
+        entity: Some("Orders".to_owned()),
+        ..Default::default()
+    }))
     .unwrap();
 
     assert!(stream.supports_discover());
     let datasets = stream.discover().await.unwrap();
     assert_eq!(datasets.len(), 1);
     assert_eq!(datasets[0].name, "Orders");
-    assert_eq!(datasets[0].config_patch, json!({"odata": {"entity": "Orders"}}));
+    assert_eq!(
+        datasets[0].config_patch,
+        json!({"odata": {"entity": "Orders"}})
+    );
     assert_eq!(
         datasets[0].schema.as_ref().unwrap()["properties"]["DocEntry"]["type"],
         "integer"

--- a/crates/source/rest/tests/source_side_unlocks.rs
+++ b/crates/source/rest/tests/source_side_unlocks.rs
@@ -1,0 +1,201 @@
+//! Integration tests for the source-side unlocks: OData mode (#512),
+//! server-side incremental push-down (#513), and flow-provider request-auth
+//! placement / dynamic base-URL (#511).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use faucet_core::{
+    AuthProvider, Credential, CredentialPlacement, FaucetError, ReplicationBind, ReplicationMethod,
+    RequestAuth, SharedAuthProvider, Source,
+};
+use faucet_source_rest::{ODataConfig, ODataVersion, RestStream, RestStreamConfig};
+use serde_json::json;
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── #512 OData ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn odata_follows_nextlink_and_unwraps_value_envelope() {
+    let server = MockServer::start().await;
+    let page2 = format!("{}/Orders?page=2", server.uri());
+    // Page 1: `$.value` records + a `@odata.nextLink` to page 2, and the derived
+    // `$select` + `Prefer` should be present.
+    Mock::given(method("GET"))
+        .and(path("/Orders"))
+        .and(query_param("$select", "DocEntry,DocDate"))
+        .and(header("prefer", "odata.maxpagesize=2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "value": [ {"DocEntry": 1}, {"DocEntry": 2} ],
+            "@odata.nextLink": page2,
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/Orders"))
+        .and(query_param("page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "value": [ {"DocEntry": 3} ],
+        })))
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(RestStreamConfig::new(&server.uri(), "").odata(ODataConfig {
+        version: ODataVersion::V4,
+        entity: Some("Orders".to_owned()),
+        select: vec!["DocEntry".to_owned(), "DocDate".to_owned()],
+        page_size: Some(2),
+        ..Default::default()
+    }))
+    .unwrap();
+
+    let records = stream.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[2]["DocEntry"], 3);
+}
+
+#[tokio::test]
+async fn odata_discover_parses_metadata() {
+    let server = MockServer::start().await;
+    let edmx = r#"<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+      <Schema Namespace="S">
+        <EntityType Name="Order">
+          <Key><PropertyRef Name="DocEntry"/></Key>
+          <Property Name="DocEntry" Type="Edm.Int32" Nullable="false"/>
+          <Property Name="DocDate" Type="Edm.DateTimeOffset"/>
+        </EntityType>
+        <EntityContainer Name="C">
+          <EntitySet Name="Orders" EntityType="S.Order"/>
+        </EntityContainer>
+      </Schema>
+    </edmx:Edmx>"#;
+    Mock::given(method("GET"))
+        .and(path("/$metadata"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(edmx))
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "").odata(ODataConfig {
+            entity: Some("Orders".to_owned()),
+            ..Default::default()
+        }),
+    )
+    .unwrap();
+
+    assert!(stream.supports_discover());
+    let datasets = stream.discover().await.unwrap();
+    assert_eq!(datasets.len(), 1);
+    assert_eq!(datasets[0].name, "Orders");
+    assert_eq!(datasets[0].config_patch, json!({"odata": {"entity": "Orders"}}));
+    assert_eq!(
+        datasets[0].schema.as_ref().unwrap()["properties"]["DocEntry"]["type"],
+        "integer"
+    );
+}
+
+// ── #513 server-side incremental push-down ─────────────────────────────────────
+
+#[tokio::test]
+async fn bind_pushes_bookmark_into_query_and_advances() {
+    let server = MockServer::start().await;
+    // The mock only matches when the rendered bookmark is pushed down as
+    // `?updated_after=gte|2024-06-01T00:00:00Z`.
+    Mock::given(method("GET"))
+        .and(path("/events"))
+        .and(query_param("updated_after", "gte|2024-06-01T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [ {"id": 1, "updated_at": "2024-07-01T00:00:00Z"} ],
+            "max_updated": "2024-07-15T00:00:00Z",
+        })))
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/events")
+            .records_path("$.data[*]")
+            .replication_method(ReplicationMethod::Incremental)
+            .replication_key("updated_at")
+            .start_replication_value(json!("2024-06-01"))
+            .replication_bind(ReplicationBind {
+                into: faucet_core::BindTarget::Query,
+                name: "updated_after".to_owned(),
+                template: "gte|${bookmark}".to_owned(),
+                format: faucet_core::BindFormat::Iso8601,
+                advance_from: Some("$.max_updated".to_owned()),
+            }),
+    )
+    .unwrap();
+
+    let ctx = std::collections::HashMap::new();
+    let mut pages = Vec::new();
+    {
+        use futures::StreamExt;
+        let mut s = Source::stream_pages(&stream, &ctx, 0);
+        while let Some(p) = s.next().await {
+            pages.push(p.unwrap());
+        }
+    }
+    let records: Vec<_> = pages.iter().flat_map(|p| p.records.clone()).collect();
+    assert_eq!(records.len(), 1);
+    // advance_from pulled the next bookmark from `$.max_updated`, not max(record).
+    let bookmark = pages.iter().rev().find_map(|p| p.bookmark.clone()).unwrap();
+    assert_eq!(bookmark, json!("2024-07-15T00:00:00Z"));
+}
+
+// ── #511 flow-provider request-auth placement + dynamic base-URL ────────────────
+
+#[derive(Debug)]
+struct MockFlow {
+    base_url: String,
+}
+
+#[async_trait::async_trait]
+impl AuthProvider for MockFlow {
+    async fn credential(&self) -> Result<Credential, FaucetError> {
+        Err(FaucetError::Auth("query-placed; use request_auth".into()))
+    }
+    async fn request_auth(
+        &self,
+        _method: &str,
+        _url: &str,
+        _query: &BTreeMap<String, String>,
+    ) -> Result<RequestAuth, FaucetError> {
+        Ok(RequestAuth::new()
+            .with_placement(CredentialPlacement::Query {
+                name: "BhRestToken".to_owned(),
+                value: "SESSION".to_owned(),
+            })
+            .with_base_url(self.base_url.clone()))
+    }
+    fn provider_name(&self) -> &'static str {
+        "mock-flow"
+    }
+}
+
+#[tokio::test]
+async fn flow_provider_places_query_token_and_overrides_base_url() {
+    // The data server is the base-URL the provider captures; the config points at
+    // a decoy base-URL to prove the dynamic override wins.
+    let data = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/orders"))
+        .and(query_param("BhRestToken", "SESSION"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"value": [{"id": 7}]})))
+        .mount(&data)
+        .await;
+
+    let provider: SharedAuthProvider = Arc::new(MockFlow {
+        base_url: data.uri(),
+    });
+    let stream = RestStream::new(
+        RestStreamConfig::new("https://decoy.invalid", "/orders").records_path("$.value[*]"),
+    )
+    .unwrap()
+    .with_auth_provider(provider);
+
+    let records = stream.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["id"], 7);
+}

--- a/crates/source/rest/tests/source_side_unlocks.rs
+++ b/crates/source/rest/tests/source_side_unlocks.rs
@@ -200,3 +200,82 @@ async fn flow_provider_places_query_token_and_overrides_base_url() {
     assert_eq!(records.len(), 1);
     assert_eq!(records[0]["id"], 7);
 }
+
+#[derive(Debug)]
+struct MockFlowHeaderCookie;
+
+#[async_trait::async_trait]
+impl AuthProvider for MockFlowHeaderCookie {
+    async fn credential(&self) -> Result<Credential, FaucetError> {
+        Err(FaucetError::Auth("use request_auth".into()))
+    }
+    async fn request_auth(
+        &self,
+        _method: &str,
+        _url: &str,
+        _query: &BTreeMap<String, String>,
+    ) -> Result<RequestAuth, FaucetError> {
+        Ok(RequestAuth::new()
+            .with_placement(CredentialPlacement::Header {
+                name: "X-Session".to_owned(),
+                value: "SID".to_owned(),
+            })
+            .with_placement(CredentialPlacement::Cookie {
+                name: "sid".to_owned(),
+                value: "abc".to_owned(),
+            }))
+    }
+    fn provider_name(&self) -> &'static str {
+        "mock-flow-hc"
+    }
+}
+
+#[tokio::test]
+async fn flow_provider_places_header_and_cookie() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .and(header("X-Session", "SID"))
+        .and(header("Cookie", "sid=abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"value": [{"id": 1}]})))
+        .mount(&server)
+        .await;
+    let provider: SharedAuthProvider = Arc::new(MockFlowHeaderCookie);
+    let stream =
+        RestStream::new(RestStreamConfig::new(&server.uri(), "/data").records_path("$.value[*]"))
+            .unwrap()
+            .with_auth_provider(provider);
+    let records = stream.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+}
+
+#[tokio::test]
+async fn replication_bind_pushes_bookmark_into_a_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/events"))
+        .and(header("If-Modified-Since", "2024-06-01T00:00:00Z"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"data": [{"id": 1, "updated_at": "2024-07-01T00:00:00Z"}]})),
+        )
+        .mount(&server)
+        .await;
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/events")
+            .records_path("$.data[*]")
+            .replication_method(ReplicationMethod::Incremental)
+            .replication_key("updated_at")
+            .start_replication_value(json!("2024-06-01"))
+            .replication_bind(ReplicationBind {
+                into: faucet_core::BindTarget::Header,
+                name: "If-Modified-Since".to_owned(),
+                template: "${bookmark}".to_owned(),
+                format: faucet_core::BindFormat::Iso8601,
+                advance_from: None,
+            }),
+    )
+    .unwrap();
+    let records = stream.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+}

--- a/docs/book/src/cookbook/auth.md
+++ b/docs/book/src/cookbook/auth.md
@@ -166,6 +166,48 @@ pipeline:
       auth: { ref: netsuite }
 ```
 
+## Composable multi-step flows (`type: flow`)
+
+Some APIs make auth a small *program*: log in, capture a session token from the
+response, place it in a query param (not a header), and follow a base-URL the
+server hands back. The `flow` provider (a catalog provider, always available)
+runs a login/pre-flight chain, captures values by JSONPath, applies credential
+*placements* (header / query / cookie / body), can HMAC-sign each request, and
+overrides the base-URL per session:
+
+```yaml
+auth:
+  bullhorn:
+    type: flow
+    config:
+      steps:
+        - request: { method: POST, url: https://auth.example.com/oauth/token,
+                     form: { grant_type: refresh_token, refresh_token: ${secret:BH_RT} } }
+          capture: { access_token: "$.access_token" }
+        - request: { method: GET, url: https://login.example.com/rest-services/login,
+                     query: { access_token: "${access_token}" } }
+          capture: { bh_rest_token: "$.BhRestToken", base_url: "$.restUrl" }
+      apply:
+        - { into: query, name: BhRestToken, value: "${bh_rest_token}" }
+      base_url_from: "${base_url}"   # follow the server-supplied REST host
+      reauth_on: [401]               # re-login + retry once when the session expires
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://placeholder.example.com   # overridden by base_url_from
+      path: /entity/Candidate
+      auth: { ref: bullhorn }
+      records_path: "$.data[*]"
+```
+
+`${captured}` values from earlier steps are substituted into later steps and into
+`apply`; a signer entry is `{ sign: { alg: hmac_sha256, key, template, encoding:
+hex|base64, into: { header, format: "${sig}" } } }` (with `${ts}` / `${nonce}`
+available in the template). Header placements also work on the `xml`/`graphql`
+sources; query / cookie / body placement and dynamic base-URL are honored by
+`rest`. See the [`rest_flow_auth.yaml`](https://github.com/faucet-hq/faucet-stream/blob/main/cli/examples/rest_flow_auth.yaml) example.
+
 ## Shared auth providers (`auth: { ref }`)
 
 When several connectors authenticate against the **same** system — e.g. four

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -23,7 +23,7 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 
 | Connector | Tier¹¹ | Feature | Streams¹ | Resumable² | Effectively-once³ | Compression | Discover¹⁰ | Underlying primitive |
 |-----------|:---:|---------|:---:|:---:|:---:|:---:|:---:|----------------------|
-| REST | T1 ✅ᵐ | `source-rest` | ✓ | ✓ | ✗ | ✗ | ✗ | HTTP + 6 pagination styles, JSONPath extraction; `response_format: csv\|excel` parses an authed file body (Graph/OneDrive/signed URL), Excel via `source-rest-excel` |
+| REST | T1 ✅ᵐ | `source-rest` | ✓ | ✓ | ✗ | ✗ | ✓ᵒ | HTTP + 6 pagination styles, JSONPath extraction; `response_format: csv\|excel` parses an authed file body (Graph/OneDrive/signed URL), Excel via `source-rest-excel`; `odata:` block adds OData paging/query + `$metadata` discovery; `replication_bind` pushes the bookmark server-side |
 | GraphQL | T1 ✅ᵐ | `source-graphql` | ✓ | ✗ | ✗ | ✗ | ✗ | cursor pagination, variable injection |
 | XML / SOAP | T1 ✅ᵐ | `source-xml` | ✓ | ✗ | ✗ | ✗ | ✗ | streaming XML→JSON, dot-path extraction, first-class `soap:` block (envelope + headers + fault handling) |
 | gRPC | T1 ✅ | `source-grpc` | ✓⁴ | ✗ | ✗ | ✗ | ✗ | dynamic protobuf; unary + server-streaming |
@@ -64,6 +64,8 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 ¹⁰ **Discover** = enumerates the datasets behind the connection for
 [`faucet discover`](../cookbook/discover.md) (tables / collections / indices /
 prefixes with schemas + row estimates where the catalog provides them).
+ᵒ REST supports discovery **only** with an `odata:` block, via the OData
+`$metadata` (EDMX) catalog — one dataset per entity set, with typed schemas.
 ¹ **Streams** = yields records in bounded-memory batches rather than buffering the
 whole result. ² **Resumable** = persists a bookmark to a [state store](../cookbook/state.md)
 so re-runs continue where they left off (incremental replication / CDC / Kafka

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -10361,6 +10361,28 @@
                         ]
                       },
                       "type": "array"
+                    },
+                    "odata": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/source_rest__ODataConfig"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Speak the OData protocol: `@odata.nextLink` paging, the `$.value`\nenvelope, `$select`/`$filter`/`$expand`/`$orderby` sugar, and\n`$metadata` (EDMX) → schema discovery. When set, it derives the\npagination, `records_path`, query params, and `Prefer` header at load\ntime (explicit values still win). See [`ODataConfig`]."
+                    },
+                    "replication_bind": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/source_rest__ReplicationBind"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Bind the stored bookmark into the outgoing request (query param / header /\nbody field / path) so the server returns only new rows. Composes with the\nexisting `replication_key` client-side filter, which stays active as a\nsafety net. Requires `replication_method: incremental` + `replication_key`."
                     }
                   },
                   "title": "RestStreamConfig",
@@ -17350,6 +17372,166 @@
         "select",
         "as"
       ],
+      "type": "object"
+    },
+    "source_rest__BindFormat": {
+      "description": "How the bookmark value is formatted before it is substituted into the\n[`ReplicationBind::template`].\n\nFor every non-[`Raw`](BindFormat::Raw) format the bookmark is first parsed\ninto an instant: a string is read as RFC 3339, a bare `YYYY-MM-DD` date\n(midnight UTC), or a naive `YYYY-MM-DDTHH:MM:SS` (assumed UTC); a JSON\nnumber is read as **epoch seconds**. It is then re-emitted in the target\nrepresentation, so `epoch_ms` ← ISO string and `iso8601` ← epoch number both\nwork.",
+      "oneOf": [
+        {
+          "const": "raw",
+          "description": "Emit the scalar verbatim (string as-is, number as its decimal form).\nThe default; no timestamp parsing.",
+          "type": "string"
+        },
+        {
+          "const": "iso8601",
+          "description": "RFC 3339 / ISO-8601 UTC timestamp, e.g. `2024-06-01T00:00:00Z`.",
+          "type": "string"
+        },
+        {
+          "const": "epoch_s",
+          "description": "Unix epoch **seconds** (integer).",
+          "type": "string"
+        },
+        {
+          "const": "epoch_ms",
+          "description": "Unix epoch **milliseconds** (integer).",
+          "type": "string"
+        },
+        {
+          "const": "date",
+          "description": "Calendar date `YYYY-MM-DD` (UTC).",
+          "type": "string"
+        }
+      ]
+    },
+    "source_rest__BindTarget": {
+      "description": "Where a rendered bookmark is injected into the outgoing request.",
+      "oneOf": [
+        {
+          "const": "query",
+          "description": "A query-string parameter (default) — e.g. `?updated_after=…`.",
+          "type": "string"
+        },
+        {
+          "const": "header",
+          "description": "A request header — e.g. `If-Modified-Since: …`.",
+          "type": "string"
+        },
+        {
+          "const": "body",
+          "description": "A top-level field of the JSON request body (POST-search APIs).",
+          "type": "string"
+        },
+        {
+          "const": "path",
+          "description": "A `{name}` placeholder in the request path.",
+          "type": "string"
+        }
+      ]
+    },
+    "source_rest__ODataConfig": {
+      "additionalProperties": true,
+      "description": "OData protocol options for the REST source (#512).\n\nA minimal block — `{ entity: Orders }` — is enough; it derives paging,\nthe `$.value` envelope, and (for `faucet discover`) `$metadata` parsing.\nThe query-option fields render into the standard `$select`/`$filter`/\n`$expand`/`$orderby` params.",
+      "properties": {
+        "entity": {
+          "description": "Entity set to read (appended to `base_url` as the path, e.g. `Orders`).\nOptional when the path already names the entity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expand": {
+          "description": "`$expand` — related entities to inline (one level).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "filter": {
+          "description": "`$filter` — server-side filter expression (verbatim).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orderby": {
+          "description": "`$orderby` — server-side ordering (verbatim).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "page_size": {
+          "description": "Server page size, sent as `Prefer: odata.maxpagesize=<n>`.",
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null",
+            "string"
+          ]
+        },
+        "select": {
+          "description": "`$select` — columns to return.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "version": {
+          "$ref": "#/$defs/source_rest__ODataVersion",
+          "default": "v4",
+          "description": "Protocol version (default `v4`)."
+        }
+      },
+      "type": "object"
+    },
+    "source_rest__ODataVersion": {
+      "description": "OData protocol version, which selects the paging-link key.",
+      "oneOf": [
+        {
+          "const": "v2",
+          "description": "OData v2 — JSON-light next link `odata.nextLink`.",
+          "type": "string"
+        },
+        {
+          "const": "v4",
+          "description": "OData v4 (default) — next link `@odata.nextLink`.",
+          "type": "string"
+        }
+      ]
+    },
+    "source_rest__ReplicationBind": {
+      "additionalProperties": true,
+      "description": "Declarative binding of the stored bookmark into the **outgoing request** —\n\"server-side incremental push-down\" (#513).\n\nToday faucet tracks bookmarks and filters incrementally *client-side* (after\ndownload). A bind lets a source instead push the bookmark into the request\n(query param / header / body field / path) so the server returns only the\nnew rows. The existing client-side [`filter_incremental`] stays active as a\nsafety net for servers that don't honour the filter exactly.",
+      "properties": {
+        "advance_from": {
+          "description": "Optional JSONPath into the response body to advance the bookmark from,\ninstead of `max(record[replication_key])`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/source_rest__BindFormat",
+          "default": "raw",
+          "description": "How to format the bookmark before substitution."
+        },
+        "into": {
+          "$ref": "#/$defs/source_rest__BindTarget",
+          "default": "query",
+          "description": "Where to place the rendered value."
+        },
+        "name": {
+          "description": "The parameter / header / body-field / path-placeholder name.",
+          "type": "string"
+        },
+        "template": {
+          "default": "${bookmark}",
+          "description": "Template rendered with [`BIND_PLACEHOLDER`] (`${bookmark}`) replaced by\nthe formatted bookmark. Defaults to the bare `${bookmark}`; set e.g.\n`\"gte|${bookmark}\"` (Greenhouse) or `\"[${bookmark} TO *]\"` (Lucene).",
+          "type": "string"
+        }
+      },
       "type": "object"
     }
   }


### PR DESCRIPTION
The three source-side unlocks from the Meltano→faucet parity analysis, in one PR. They compose: an OData ERP uses a `flow` provider (#511) for its session cookie, the `odata:` block (#512) for paging/query/discovery, and `replication_bind` (#513) for `$filter ge <bookmark>` push-down.

Closes #511
Closes #512
Closes #513

## #511 — composable multi-step auth flows
A new `type: flow` catalog provider (`crates/auth/src/flow.rs`): a login/pre-flight request chain with JSONPath capture, credential **placement** across header/query/cookie/body, a pluggable HMAC **signer**, dynamic per-session **base-URL**, TTL + `reauth_on` re-login — on the existing single-flight machinery.

Core additions (all additive; the frozen `Credential` enum is untouched): `#[non_exhaustive]` `CredentialPlacement` + `RequestAuth`, and defaulted object-safe `AuthProvider::request_auth()` / `reauth_statuses()`. The REST source consumes `request_auth` (placements + base-URL override, superseding the plain credential path) and honors `reauth_on`; header placements also reach xml/graphql via `credential()`.

## #512 — OData as a REST `odata:` block (no new crate)
Per the design decision, OData folds into the existing REST source. The `odata:` block derives `@odata.nextLink` paging (v2/v4), the `$.value` envelope, `$select`/`$filter`/`$expand`/`$orderby` params, and `Prefer: odata.maxpagesize`. `faucet discover` parses the service's `$metadata` (EDMX, via `quick-xml`) into one typed dataset per entity set.

## #513 — server-side incremental push-down
A shared `ReplicationBind` (`crates/core/src/replication.rs`): render the stored bookmark into the request (`into: query|header|body|path`, operator `template`, `format: raw|iso8601|epoch_s|epoch_ms|date`, optional `advance_from` JSONPath). Wired into the REST request build; the client-side filter stays on as a safety net. `chrono` is now an unconditional core dep (epoch↔ISO). `${bookmark}` is a reserved CLI interpolation id.

## Tests & gates (all verified locally)
- New unit + wiremock integration tests across all three crates; **patch coverage clean** on every changed file (core/auth/rest measured vs `origin/main`).
- `clippy --all-features` clean; `cargo doc -D warnings` clean.
- **cargo-semver-checks on `faucet-core` vs the pristine baseline: 222 pass, no breaking change** (all additions land on non_exhaustive surfaces / defaulted trait methods).
- Two runnable examples validate offline: `cli/examples/odata_to_jsonl.yaml`, `cli/examples/rest_flow_auth.yaml`.
- Docs: REST + faucet-auth READMEs, connector capability matrix (+Discover), auth cookbook, `faucet discover` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)