### PR TITLE
feat: response-decode + async-job (rest), scoped overwrite, run/lineage metadata columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "csv-async",
  "faucet-conformance",
  "faucet-core",
+ "flate2",
  "futures",
  "futures-core",
  "httpdate",
@@ -5799,6 +5800,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wiremock",
+ "zip 2.4.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,7 @@ deltalake = { version = "0.32.4", default-features = false, features = ["rustls"
 async-compression = { version = "0.4", features = ["tokio", "gzip", "zstd"] }
 flate2 = "1"
 zstd = "0.13"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 glob = "0.3"
 duckdb = "1.10503"
 # WebAssembly runtime for the `wasm` transform (issue #124). Lean embedding:

--- a/cli/examples/data/metadata_demo.csv
+++ b/cli/examples/data/metadata_demo.csv
@@ -1,0 +1,3 @@
+id,name
+1,alice
+2,bob

--- a/cli/examples/metadata_columns.yaml
+++ b/cli/examples/metadata_columns.yaml
@@ -1,0 +1,20 @@
+# Opt-in `_faucet_*` run/lineage metadata columns (#510) — stamped onto every
+# row by a connector-agnostic sink decorator (works for any sink).
+#
+#   faucet run cli/examples/metadata_columns.yaml
+version: 1
+name: metadata_demo
+
+metadata_columns:
+  prefix: "_faucet"
+  columns: [extracted_at, loaded_at, run_id, source]
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/metadata_demo.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./out/metadata_demo.jsonl

--- a/cli/examples/rest_async_job.yaml
+++ b/cli/examples/rest_async_job.yaml
@@ -1,0 +1,25 @@
+# Async-job source (#514): submit an export job, poll until complete, download
+# the (CSV) result. The shape of Salesforce Bulk / Stripe Reporting exports.
+#
+#   faucet validate cli/examples/rest_async_job.yaml
+#   faucet run      cli/examples/rest_async_job.yaml
+version: 1
+name: async_export
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: "https://api.example.com"
+      auth: { type: bearer, config: { token: "${env:AUTH_TOKEN}" } }
+      pagination: { type: none }
+      async_job:
+        submit: { method: POST, url: /jobs, json: { query: "SELECT id, name FROM contacts" } }
+        job_id: "$.id"
+        poll:   { url: "/jobs/${job_id}", interval_secs: 5, timeout_secs: 1800 }
+        status: { path: "$.state", success: [JobComplete], failure: [Failed, Aborted] }
+        fetch:  { method: GET, url: "/jobs/${job_id}/result" }
+      decode:
+        - parse: { format: csv }
+  sink:
+    type: jsonl
+    config: { path: ./out/contacts.jsonl }

--- a/cli/examples/rest_decode_report.yaml
+++ b/cli/examples/rest_decode_report.yaml
@@ -1,0 +1,23 @@
+# Response-decode pipeline (#515): the payload is a base64-encoded, gzipped CSV
+# inside a JSON envelope (the shape of many "report bytes" export APIs).
+#
+#   faucet validate cli/examples/rest_decode_report.yaml
+#   faucet run      cli/examples/rest_decode_report.yaml
+version: 1
+name: decode_report
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: "https://api.example.com"
+      path: /reports/latest
+      auth: { type: bearer, config: { token: "${env:AUTH_TOKEN}" } }
+      pagination: { type: none }
+      decode:
+        - extract: "$.d.reportBytes"   # pull the encoded blob out of the envelope
+        - base64
+        - gunzip
+        - parse: { format: csv }
+  sink:
+    type: jsonl
+    config: { path: ./out/report.jsonl }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -176,6 +176,12 @@ pub struct PipelineConfig {
     #[cfg(feature = "notify")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub notifications: Vec<crate::notify::NotificationSpec>,
+
+    /// Optional `_faucet_*` run/lineage metadata columns (#510) stamped onto
+    /// every row by a connector-agnostic sink decorator (works for any sink).
+    /// Off unless present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_columns: Option<faucet_core::MetadataColumnsSpec>,
 }
 
 /// The base pipeline definition. Each matrix row is resolved against the

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -350,6 +350,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         shard: None,
         replication: None,
         backfill: None,
+        metadata_columns: None,
         partition: None,
         #[cfg(feature = "schedule")]
         schedule: None,

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1395,6 +1395,26 @@ async fn run_one_invocation(
         source
     };
 
+    // #510: stamp `_faucet_*` run/lineage metadata columns closest to the real
+    // sink (so `loaded_at` ≈ the actual write), and inside the lineage sampler
+    // below so samples reflect the source records, not the added columns.
+    let sink: Box<dyn Sink> = match &node.metadata_columns {
+        Some(spec) => match faucet_core::CompiledMetadata::compile(spec)
+            .map_err(|e| CliError::Config(format!("metadata_columns: {e}")))?
+        {
+            Some(meta) => Box::new(faucet_core::MetadataSink::new(
+                sink,
+                meta,
+                faucet_core::MetadataContext {
+                    run_id: run_id.clone(),
+                    source: node.source.kind.clone(),
+                },
+            )),
+            None => sink,
+        },
+        None => sink,
+    };
+
     // Wrap the sink so it samples written records — outermost, immediately
     // before the pipeline is constructed (after capture/limit wrappers).
     #[cfg(feature = "lineage")]
@@ -2246,6 +2266,7 @@ mod tests {
             },
             matrix: Vec::new(),
             execution: None,
+            metadata_columns: None,
             selection: None,
             observability: None,
             delivery: faucet_core::DeliveryMode::default(),
@@ -2308,6 +2329,32 @@ mod tests {
         assert!(!summary.had_failures());
         let body = std::fs::read_to_string(&output).unwrap();
         assert_eq!(body.lines().count(), 2);
+    }
+
+    #[tokio::test]
+    async fn metadata_columns_are_stamped_onto_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\n").unwrap();
+        let mut cfg = cfg_csv_to_jsonl(&input, &output);
+        cfg.metadata_columns = Some(faucet_core::MetadataColumnsSpec {
+            enabled: true,
+            prefix: "_faucet".into(),
+            columns: vec![
+                faucet_core::MetadataColumn::RunId,
+                faucet_core::MetadataColumn::Source,
+                faucet_core::MetadataColumn::LoadedAt,
+            ],
+        });
+        let nodes = expand(&cfg).unwrap();
+        run_expanded(nodes, opts("t")).await.unwrap();
+        let body = std::fs::read_to_string(&output).unwrap();
+        let row: serde_json::Value = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        assert_eq!(row["name"], "alice");
+        assert_eq!(row["_faucet_source"], "csv");
+        assert!(row["_faucet_run_id"].is_string());
+        assert!(row["_faucet_loaded_at"].is_string());
     }
 
     /// Minimal options with a catalog handle attached.
@@ -3285,6 +3332,7 @@ matrix:
                 status: crate::config::SourceStatus::Active,
                 tags: Vec::new(),
                 cleanup_scope: None,
+                metadata_columns: None,
                 deferred_refs: refs
                     .iter()
                     .map(|(rid, p)| DeferredRef {
@@ -3365,6 +3413,7 @@ matrix:
             status: crate::config::SourceStatus::Active,
             tags: Vec::new(),
             cleanup_scope: None,
+            metadata_columns: None,
             deferred_refs: vec![DeferredRef {
                 referenced_id: "p".into(),
                 dotted_path: "".into(),
@@ -3687,6 +3736,7 @@ matrix:
             status: crate::config::SourceStatus::Active,
             tags: Vec::new(),
             cleanup_scope: None,
+            metadata_columns: None,
             deferred_refs: Vec::new(),
             source_override: None,
         }
@@ -3910,6 +3960,7 @@ matrix:
             status: crate::config::SourceStatus::Active,
             tags: Vec::new(),
             cleanup_scope: None,
+            metadata_columns: None,
             deferred_refs: Vec::new(),
             source_override: None,
         };

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -2357,6 +2357,25 @@ mod tests {
         assert!(row["_faucet_loaded_at"].is_string());
     }
 
+    #[tokio::test]
+    async fn metadata_columns_disabled_stamps_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\n").unwrap();
+        let mut cfg = cfg_csv_to_jsonl(&input, &output);
+        cfg.metadata_columns = Some(faucet_core::MetadataColumnsSpec {
+            enabled: false,
+            ..Default::default()
+        });
+        let nodes = expand(&cfg).unwrap();
+        run_expanded(nodes, opts("t")).await.unwrap();
+        let body = std::fs::read_to_string(&output).unwrap();
+        let row: serde_json::Value = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        assert_eq!(row["name"], "alice");
+        assert!(row.get("_faucet_run_id").is_none());
+    }
+
     /// Minimal options with a catalog handle attached.
     #[cfg(feature = "catalog")]
     fn opts_with_catalog(name: &str, handle: crate::catalog::CatalogHandle) -> ExecuteOptions {

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -867,6 +867,33 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // ── Scoped/windowed overwrite gate (#518) ───────────────────────────
+        // A `scope:` block replaces only the rows matching it (a date window)
+        // instead of truncating. Valid only with `write_mode: overwrite` on a
+        // sink that implements the scoped begin/delete/insert swap.
+        if let Some(scope_val) = merged_sink.config.get("scope") {
+            if !matches!(mode, faucet_core::WriteMode::Overwrite) {
+                return Err(CliError::Config(format!(
+                    "row '{}': `scope` is only valid with `write_mode: overwrite`",
+                    ids[i]
+                )));
+            }
+            if !crate::registry::sink_supports_scoped_overwrite(&merged_sink.kind) {
+                return Err(CliError::Config(format!(
+                    "row '{}': scoped overwrite (`scope`) is not supported by sink '{}' \
+                     (scoped-overwrite sinks: {})",
+                    ids[i],
+                    merged_sink.kind,
+                    crate::registry::SCOPED_OVERWRITE_SINK_KINDS.join(", ")
+                )));
+            }
+            let scope: faucet_core::OverwriteScope = serde_json::from_value(scope_val.clone())
+                .map_err(|e| CliError::Config(format!("row '{}': invalid `scope`: {e}", ids[i])))?;
+            scope
+                .validate()
+                .map_err(|e| CliError::Config(format!("row '{}': {e}", ids[i])))?;
+        }
+
         // Derived end-to-end delivery guarantee (issue #292): computed for
         // *every* row — regardless of the requested `delivery:` mode — so
         // `faucet validate` / `doctor` report the truth (a keyed-upsert row is
@@ -3069,6 +3096,70 @@ pipeline:
         assert!(
             expand(&c).is_ok(),
             "overwrite needs no key and postgres supports it"
+        );
+    }
+
+    #[test]
+    fn scoped_overwrite_passes_on_postgres() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:
+    type: postgres
+    config:
+      connection_url: "postgres://x"
+      table_name: t
+      column_mapping: auto_map
+      write_mode: overwrite
+      scope: { window: { column: posting_date, from: "2024-06-01", to: "2024-07-01" } }
+"#);
+        assert!(expand(&c).is_ok(), "postgres supports scoped overwrite");
+    }
+
+    #[test]
+    fn rejects_scope_on_non_scoped_sink() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:
+    type: sqlite
+    config:
+      connection_url: "sqlite://x"
+      table_name: t
+      column_mapping: auto_map
+      write_mode: overwrite
+      scope: { window: { column: d, from: 1, to: 2 } }
+"#);
+        let msg = format!("{}", expand(&c).unwrap_err());
+        assert!(
+            msg.contains("scoped overwrite") && msg.contains("not supported"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_scope_without_overwrite_mode() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:
+    type: postgres
+    config:
+      connection_url: "postgres://x"
+      table_name: t
+      column_mapping: auto_map
+      scope: { window: { column: d, from: 1, to: 2 } }
+"#);
+        let msg = format!("{}", expand(&c).unwrap_err());
+        assert!(
+            msg.contains("only valid with `write_mode: overwrite`"),
+            "{msg}"
         );
     }
 

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -35,6 +35,7 @@ pub const RESERVED_IDS: &[&str] = &[
     "param",
     "partition",
     "bookmark",
+    "job_id",
 ];
 
 /// One fully-merged matrix row, ready for the executor.
@@ -1348,6 +1349,7 @@ fn check_refs(value: &Value, id_set: &HashSet<&str>, owner: &str) -> CliResult<(
                 && id != "backfill"
                 && id != "partition"
                 && id != "bookmark"
+                && id != "job_id"
                 && !id_set.contains(id)
             {
                 return Err(CliError::UnknownInterpolationId {
@@ -1440,7 +1442,12 @@ fn collect_deferred(value: &Value, out: &mut Vec<DeferredRef>) {
                 // parent-record refs. `bookmark` is consumed *inside* a source's
                 // `replication_bind.template` (#513) — the connector renders it,
                 // so the CLI must pass it through untouched.
-                if id == "now" || id == "backfill" || id == "partition" || id == "bookmark" {
+                if id == "now"
+                    || id == "backfill"
+                    || id == "partition"
+                    || id == "bookmark"
+                    || id == "job_id"
+                {
                     continue;
                 }
                 out.push(DeferredRef {
@@ -1639,6 +1646,24 @@ pipeline:
     config:
       base_url: https://x
       replication_bind: { into: query, name: since, template: "gt ${bookmark}" }
+  sink: { type: jsonl, config: { path: ./o } }
+"#);
+        let nodes = expand(&c).unwrap();
+        assert_eq!(nodes.len(), 1);
+    }
+
+    #[test]
+    fn job_id_token_is_reserved_and_passes_through() {
+        // `${job_id}` is consumed inside a source's `async_job` block (#514);
+        // expand must treat it as a reserved deferred id.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://x
+      async_job: { submit: { url: /jobs }, job_id: "$.id", poll: { url: "/jobs/${job_id}" }, status: { path: "$.s", success: [Done] }, fetch: { url: "/jobs/${job_id}/r" } }
   sink: { type: jsonl, config: { path: ./o } }
 "#);
         let nodes = expand(&c).unwrap();

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -112,6 +112,9 @@ pub struct ExpandedNode {
     /// destination sink also opted in with `cleanup: delete_missing`, so this
     /// being present already means a cleanup is intended.
     pub cleanup_scope: Option<std::collections::BTreeMap<String, serde_json::Value>>,
+    /// Pipeline-level `_faucet_*` metadata columns (#510), shared by every node;
+    /// the executor wraps the sink in a `MetadataSink` decorator when present.
+    pub metadata_columns: Option<faucet_core::MetadataColumnsSpec>,
 }
 
 #[derive(Debug, Clone)]
@@ -578,6 +581,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
                 deferred_refs: Vec::new(),
                 source_override: None,
                 cleanup_scope: None,
+                metadata_columns: None,
             });
             continue;
         }
@@ -1215,6 +1219,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             deferred_refs: deferred,
             source_override: None,
             cleanup_scope,
+            metadata_columns: cfg.metadata_columns.clone(),
         };
 
         if chunks.is_empty() {

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -892,6 +892,18 @@ pub fn sink_supports_overwrite(kind: &str) -> bool {
     OVERWRITE_SINK_KINDS.contains(&kind)
 }
 
+/// Sinks that support a **scoped/windowed** overwrite (#518) — replacing only
+/// the rows matching a `scope` (a date window) instead of the whole table. A
+/// subset of [`OVERWRITE_SINK_KINDS`]; the others still support full overwrite.
+/// (v1: the atomic scoped delete + staged insert; the wider SQL family and
+/// key-scope are follow-ups.)
+pub const SCOPED_OVERWRITE_SINK_KINDS: &[&str] = &["postgres", "bigquery"];
+
+/// Whether a sink kind supports a scoped overwrite `scope`.
+pub fn sink_supports_scoped_overwrite(kind: &str) -> bool {
+    SCOPED_OVERWRITE_SINK_KINDS.contains(&kind)
+}
+
 /// Source kinds that implement live dataset discovery (`Source::discover`,
 /// issue #211) — mirrors the discoverable-source list in the connector docs.
 /// Single source of truth for the conformance scorecard (#330).

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod idempotency;
 pub mod join;
 #[cfg(feature = "masking")]
 pub mod masking;
+pub mod metadata;
 pub mod observability;
 pub mod pipeline;
 #[cfg(feature = "quality")]
@@ -89,6 +90,9 @@ pub use idempotency::{
 };
 pub use join::{
     HashJoin, JoinConfig, JoinMode, JoinStats, KeyNormalize, OnCollision, OnDuplicate, Projection,
+};
+pub use metadata::{
+    CompiledMetadata, MetadataColumn, MetadataColumnsSpec, MetadataContext, MetadataSink,
 };
 #[cfg(feature = "contract")]
 pub use observability::instrumented_apply_contract;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -150,8 +150,8 @@ pub use transforming_source::TransformingSource;
 pub use util::redact_uri_credentials;
 pub use verify::{IntegrityCheck, LengthCheck, VerifyingReader};
 pub use write_mode::{
-    DeleteMarker, KeyTuple, WriteMode, WritePlan, WriteSpec, key_to_doc_id, key_to_filter,
-    plan_writes,
+    DeleteMarker, KeyTuple, OverwriteScope, WriteMode, WritePlan, WriteSpec, key_to_doc_id,
+    key_to_filter, plan_writes,
 };
 
 // Re-export dependencies that connector authors need, so they only depend on

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -1,0 +1,404 @@
+//! Optional `_faucet_*` run/lineage metadata columns (#510).
+//!
+//! An opt-in, connector-agnostic **sink decorator** that stamps a small set of
+//! metadata columns onto every row — the faucet-native analogue of Singer's
+//! `_sdc_*` columns, for freshness/lineage and debugging. Because it's a
+//! decorator (like [`CleanupTracker`](crate::cleanup::CleanupTracker)) it works
+//! for every sink without per-connector code.
+//!
+//! ```yaml
+//! metadata_columns:
+//!   prefix: "_faucet"                       # column-name prefix (default)
+//!   columns: [extracted_at, loaded_at, run_id, source]
+//! ```
+
+use crate::error::FaucetError;
+use crate::traits::{RowOutcome, Sink};
+use chrono::Utc;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A metadata column to stamp onto every row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataColumn {
+    /// When the record entered the pipeline (ingest time). In the sink-decorator
+    /// model this is captured just before the write, so it's ≈ `loaded_at`.
+    ExtractedAt,
+    /// Sink write time.
+    LoadedAt,
+    /// The pipeline run id.
+    RunId,
+    /// The source connector kind / stream id.
+    Source,
+    /// A monotonic per-run row ordinal.
+    Sequence,
+}
+
+impl MetadataColumn {
+    /// The column-name suffix (appended to the prefix as `{prefix}_{suffix}`).
+    pub fn suffix(self) -> &'static str {
+        match self {
+            MetadataColumn::ExtractedAt => "extracted_at",
+            MetadataColumn::LoadedAt => "loaded_at",
+            MetadataColumn::RunId => "run_id",
+            MetadataColumn::Source => "source",
+            MetadataColumn::Sequence => "sequence",
+        }
+    }
+}
+
+fn default_prefix() -> String {
+    "_faucet".to_owned()
+}
+fn default_true() -> bool {
+    true
+}
+
+/// The `metadata_columns:` config block.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MetadataColumnsSpec {
+    /// Master switch (default `true` when the block is present).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Column-name prefix (default `_faucet`).
+    #[serde(default = "default_prefix")]
+    pub prefix: String,
+    /// Columns to stamp. Empty = the default set
+    /// (`extracted_at`, `loaded_at`, `run_id`, `source`).
+    #[serde(default)]
+    pub columns: Vec<MetadataColumn>,
+}
+
+impl Default for MetadataColumnsSpec {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            prefix: default_prefix(),
+            columns: Vec::new(),
+        }
+    }
+}
+
+const DEFAULT_COLUMNS: &[MetadataColumn] = &[
+    MetadataColumn::ExtractedAt,
+    MetadataColumn::LoadedAt,
+    MetadataColumn::RunId,
+    MetadataColumn::Source,
+];
+
+/// A validated metadata-columns policy.
+#[derive(Debug, Clone)]
+pub struct CompiledMetadata {
+    prefix: String,
+    columns: Vec<MetadataColumn>,
+}
+
+impl CompiledMetadata {
+    /// Compile a spec: resolve the default column set and validate the prefix.
+    /// Returns `Ok(None)` when disabled (so the caller skips the decorator).
+    pub fn compile(spec: &MetadataColumnsSpec) -> Result<Option<Self>, FaucetError> {
+        if !spec.enabled {
+            return Ok(None);
+        }
+        if spec.prefix.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "metadata_columns: `prefix` must not be empty".into(),
+            ));
+        }
+        let columns = if spec.columns.is_empty() {
+            DEFAULT_COLUMNS.to_vec()
+        } else {
+            spec.columns.clone()
+        };
+        Ok(Some(Self {
+            prefix: spec.prefix.clone(),
+            columns,
+        }))
+    }
+
+    fn column_name(&self, col: MetadataColumn) -> String {
+        format!("{}_{}", self.prefix, col.suffix())
+    }
+}
+
+/// Per-run values the decorator stamps.
+#[derive(Debug, Clone)]
+pub struct MetadataContext {
+    /// The pipeline run id.
+    pub run_id: String,
+    /// The source connector kind / stream id.
+    pub source: String,
+}
+
+/// A [`Sink`] decorator that stamps `_faucet_*` metadata columns onto every row
+/// before delegating the write.
+pub struct MetadataSink {
+    inner: Box<dyn Sink>,
+    meta: CompiledMetadata,
+    ctx: MetadataContext,
+    seq: AtomicU64,
+}
+
+impl std::fmt::Debug for MetadataSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetadataSink")
+            .field("prefix", &self.meta.prefix)
+            .field("columns", &self.meta.columns)
+            .finish()
+    }
+}
+
+impl MetadataSink {
+    /// Wrap a sink so every written row carries the configured metadata columns.
+    pub fn new(inner: Box<dyn Sink>, meta: CompiledMetadata, ctx: MetadataContext) -> Self {
+        Self {
+            inner,
+            meta,
+            ctx,
+            seq: AtomicU64::new(0),
+        }
+    }
+
+    /// Return a copy of `records` with the metadata columns injected. Non-object
+    /// records pass through unchanged (nowhere to stamp).
+    fn stamp(&self, records: &[Value]) -> Vec<Value> {
+        let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        records
+            .iter()
+            .map(|rec| match rec {
+                Value::Object(map) => {
+                    let mut map = map.clone();
+                    self.inject(&mut map, &now);
+                    Value::Object(map)
+                }
+                other => other.clone(),
+            })
+            .collect()
+    }
+
+    fn inject(&self, map: &mut Map<String, Value>, now: &str) {
+        for &col in &self.meta.columns {
+            let name = self.meta.column_name(col);
+            let value = match col {
+                MetadataColumn::ExtractedAt | MetadataColumn::LoadedAt => {
+                    Value::String(now.to_owned())
+                }
+                MetadataColumn::RunId => Value::String(self.ctx.run_id.clone()),
+                MetadataColumn::Source => Value::String(self.ctx.source.clone()),
+                MetadataColumn::Sequence => Value::from(self.seq.fetch_add(1, Ordering::Relaxed)),
+            };
+            map.insert(name, value);
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Sink for MetadataSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        self.inner.write_batch(&self.stamp(records)).await
+    }
+
+    async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<RowOutcome>, FaucetError> {
+        self.inner.write_batch_partial(&self.stamp(records)).await
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.inner
+            .write_batch_idempotent(&self.stamp(records), scope, token)
+            .await
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        self.inner.flush().await
+    }
+
+    // ── Pure forwarding ──────────────────────────────────────────────────────
+    async fn check(
+        &self,
+        ctx: &crate::check::CheckContext,
+    ) -> Result<crate::check::CheckReport, FaucetError> {
+        self.inner.check(ctx).await
+    }
+    fn supports_cleanup(&self) -> bool {
+        self.inner.supports_cleanup()
+    }
+    async fn cleanup_scope(
+        &self,
+        scope: &BTreeMap<String, Value>,
+        seen: &crate::cleanup::SeenKeys,
+    ) -> Result<u64, FaucetError> {
+        self.inner.cleanup_scope(scope, seen).await
+    }
+    fn supports_idempotent_writes(&self) -> bool {
+        self.inner.supports_idempotent_writes()
+    }
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        self.inner.last_committed_token(scope).await
+    }
+    fn supported_write_modes(&self) -> &'static [crate::write_mode::WriteMode] {
+        self.inner.supported_write_modes()
+    }
+    fn dedups_by_key(&self) -> bool {
+        self.inner.dedups_by_key()
+    }
+    fn sink_guarantee(&self) -> crate::idempotency::SinkGuarantee {
+        self.inner.sink_guarantee()
+    }
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        self.inner.current_schema().await
+    }
+    fn supports_schema_evolution(&self) -> bool {
+        self.inner.supports_schema_evolution()
+    }
+    async fn evolve_schema(
+        &self,
+        evolution: &crate::drift::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        self.inner.evolve_schema(evolution).await
+    }
+    fn config_schema(&self) -> Value {
+        self.inner.config_schema()
+    }
+    fn connector_name(&self) -> &'static str {
+        self.inner.connector_name()
+    }
+    fn dataset_uri(&self) -> String {
+        self.inner.dataset_uri()
+    }
+    fn is_overwrite(&self) -> bool {
+        self.inner.is_overwrite()
+    }
+    async fn begin_overwrite(&self) -> Result<(), FaucetError> {
+        self.inner.begin_overwrite().await
+    }
+    async fn commit_overwrite(&self) -> Result<(), FaucetError> {
+        self.inner.commit_overwrite().await
+    }
+    async fn abort_overwrite(&self) -> Result<(), FaucetError> {
+        self.inner.abort_overwrite().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    struct CapturingSink {
+        rows: Mutex<Vec<Value>>,
+    }
+    #[async_trait::async_trait]
+    impl Sink for CapturingSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            self.rows.lock().unwrap().extend_from_slice(records);
+            Ok(records.len())
+        }
+        fn config_schema(&self) -> Value {
+            json!({})
+        }
+    }
+
+    fn spec(cols: &[MetadataColumn]) -> MetadataColumnsSpec {
+        MetadataColumnsSpec {
+            enabled: true,
+            prefix: "_faucet".into(),
+            columns: cols.to_vec(),
+        }
+    }
+
+    fn ctx() -> MetadataContext {
+        MetadataContext {
+            run_id: "run-42".into(),
+            source: "rest".into(),
+        }
+    }
+
+    #[test]
+    fn compile_resolves_defaults_and_respects_disable() {
+        let c = CompiledMetadata::compile(&spec(&[])).unwrap().unwrap();
+        assert_eq!(c.columns, DEFAULT_COLUMNS.to_vec());
+        // disabled → None
+        let disabled = MetadataColumnsSpec {
+            enabled: false,
+            ..Default::default()
+        };
+        assert!(CompiledMetadata::compile(&disabled).unwrap().is_none());
+        // empty prefix → error
+        let bad = MetadataColumnsSpec {
+            prefix: " ".into(),
+            ..Default::default()
+        };
+        assert!(CompiledMetadata::compile(&bad).is_err());
+    }
+
+    #[tokio::test]
+    async fn stamps_all_column_kinds_with_prefix() {
+        let meta = CompiledMetadata::compile(&spec(&[
+            MetadataColumn::ExtractedAt,
+            MetadataColumn::LoadedAt,
+            MetadataColumn::RunId,
+            MetadataColumn::Source,
+            MetadataColumn::Sequence,
+        ]))
+        .unwrap()
+        .unwrap();
+        let inner = Box::new(CapturingSink::default());
+        let sink = MetadataSink::new(inner, meta, ctx());
+        let n = sink
+            .write_batch(&[json!({"id": 1}), json!({"id": 2})])
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+        // Re-wrap to read the captured rows would need the inner; instead assert
+        // via a fresh capturing sink shared by Arc — simpler: re-stamp directly.
+        let stamped = sink.stamp(&[json!({"id": 1}), json!({"id": 2})]);
+        let r0 = &stamped[0];
+        assert_eq!(r0["id"], 1);
+        assert_eq!(r0["_faucet_run_id"], "run-42");
+        assert_eq!(r0["_faucet_source"], "rest");
+        assert!(r0["_faucet_extracted_at"].is_string());
+        assert!(r0["_faucet_loaded_at"].is_string());
+        // Sequence is monotonic across records.
+        assert_eq!(
+            stamped[0]["_faucet_sequence"].as_u64().unwrap() + 1,
+            stamped[1]["_faucet_sequence"].as_u64().unwrap()
+        );
+    }
+
+    #[test]
+    fn non_object_records_pass_through() {
+        let meta = CompiledMetadata::compile(&spec(&[MetadataColumn::RunId]))
+            .unwrap()
+            .unwrap();
+        let sink = MetadataSink::new(Box::new(CapturingSink::default()), meta, ctx());
+        let out = sink.stamp(&[json!("scalar"), json!(42)]);
+        assert_eq!(out, vec![json!("scalar"), json!(42)]);
+    }
+
+    #[test]
+    fn custom_prefix_and_subset() {
+        let meta = CompiledMetadata::compile(&MetadataColumnsSpec {
+            enabled: true,
+            prefix: "_dt".into(),
+            columns: vec![MetadataColumn::RunId],
+        })
+        .unwrap()
+        .unwrap();
+        let sink = MetadataSink::new(Box::new(CapturingSink::default()), meta, ctx());
+        let out = sink.stamp(&[json!({"a": 1})]);
+        assert_eq!(out[0]["_dt_run_id"], "run-42");
+        assert!(out[0].get("_dt_loaded_at").is_none());
+    }
+}

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -387,6 +387,54 @@ mod tests {
         assert_eq!(out, vec![json!("scalar"), json!(42)]);
     }
 
+    #[tokio::test]
+    async fn delegates_every_sink_method_to_inner() {
+        let meta = CompiledMetadata::compile(&spec(&[MetadataColumn::RunId]))
+            .unwrap()
+            .unwrap();
+        let sink = MetadataSink::new(Box::new(CapturingSink::default()), meta, ctx());
+
+        // Write paths stamp + forward.
+        assert_eq!(sink.write_batch(&[json!({"a": 1})]).await.unwrap(), 1);
+        assert_eq!(
+            sink.write_batch_partial(&[json!({"a": 1})])
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        let _ = sink
+            .write_batch_idempotent(&[json!({"a": 1})], "scope", "tok")
+            .await;
+        sink.flush().await.unwrap();
+
+        // Pure forwards (inner uses trait defaults).
+        let _ = sink.check(&crate::check::CheckContext::default()).await;
+        assert!(!sink.supports_cleanup());
+        let _ = sink
+            .cleanup_scope(&BTreeMap::new(), &crate::cleanup::SeenKeys::new())
+            .await;
+        assert!(!sink.supports_idempotent_writes());
+        assert!(sink.last_committed_token("s").await.unwrap().is_none());
+        let _ = sink.supported_write_modes();
+        let _ = sink.dedups_by_key();
+        let _ = sink.sink_guarantee();
+        let _ = sink.current_schema().await.unwrap();
+        let _ = sink.supports_schema_evolution();
+        let _ = sink
+            .evolve_schema(&crate::drift::SchemaEvolution::default())
+            .await;
+        let _ = sink.config_schema();
+        let _ = sink.connector_name();
+        let _ = sink.dataset_uri();
+        assert!(!sink.is_overwrite());
+        let _ = sink.begin_overwrite().await;
+        let _ = sink.commit_overwrite().await;
+        sink.abort_overwrite().await.unwrap();
+
+        assert!(format!("{sink:?}").contains("MetadataSink"));
+    }
+
     #[test]
     fn custom_prefix_and_subset() {
         let meta = CompiledMetadata::compile(&MetadataColumnsSpec {

--- a/crates/core/src/write_mode.rs
+++ b/crates/core/src/write_mode.rs
@@ -53,6 +53,82 @@ pub struct DeleteMarker {
     pub values: Vec<String>,
 }
 
+/// Scope for a **scoped/windowed overwrite** (#518): with `write_mode:
+/// overwrite`, replace only the destination rows matching this scope instead of
+/// truncating the whole table. The sink-side sibling of scoped cleanup (#478).
+///
+/// v1 supports a half-open date/number **window** on a single column.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OverwriteScope {
+    /// Replace rows where `column` is in the half-open range `[from, to)`.
+    Window {
+        /// The destination column to window on.
+        column: String,
+        /// Inclusive lower bound.
+        from: Value,
+        /// Exclusive upper bound.
+        to: Value,
+    },
+}
+
+impl OverwriteScope {
+    /// The scoped column name.
+    pub fn column(&self) -> &str {
+        match self {
+            OverwriteScope::Window { column, .. } => column,
+        }
+    }
+
+    /// Validate the scope at config-load time.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        match self {
+            OverwriteScope::Window { column, from, to } => {
+                if column.trim().is_empty() {
+                    return Err(FaucetError::Config(
+                        "overwrite scope: window `column` must not be empty".into(),
+                    ));
+                }
+                if from.is_null() || to.is_null() {
+                    return Err(FaucetError::Config(
+                        "overwrite scope: window `from`/`to` must not be null".into(),
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Render a SQL `WHERE` predicate over the (already-quoted) column using
+    /// escaped SQL **literals** for the bounds. Literals (not bind params) are
+    /// used so the engine coerces a string bound to the column's real type
+    /// (`date >= '2024-06-01'` works; a text-typed bind param would not). String
+    /// literals have their single quotes doubled, so a crafted bound cannot
+    /// break out of the quotes.
+    pub fn render_where_literal(&self, quoted_col: &str) -> String {
+        match self {
+            OverwriteScope::Window { from, to, .. } => format!(
+                "{quoted_col} >= {} AND {quoted_col} < {}",
+                sql_literal(from),
+                sql_literal(to)
+            ),
+        }
+    }
+}
+
+/// Render a JSON scalar as a SQL literal (strings single-quoted + escaped).
+fn sql_literal(v: &Value) -> String {
+    match v {
+        Value::String(s) => format!("'{}'", s.replace('\'', "''")),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        // Validated non-null upstream; any residual maps to NULL (never matches
+        // a range comparison, so the delete is a safe no-op rather than wrong).
+        _ => "NULL".to_owned(),
+    }
+}
+
 /// Shared write-mode config, embedded in each upsert-capable sink config via
 /// `#[serde(flatten)]` so `write_mode` / `key` / `delete_marker` appear at the
 /// sink-config top level.
@@ -448,8 +524,7 @@ mod tests {
     fn overwrite_mode_flags_and_needs_no_key() {
         let spec = WriteSpec {
             write_mode: WriteMode::Overwrite,
-            key: vec![],
-            delete_marker: None,
+            ..Default::default()
         };
         assert!(spec.is_overwrite());
         assert!(!spec.dedups_by_key());
@@ -459,6 +534,68 @@ mod tests {
         // Non-overwrite specs report false.
         assert!(!WriteSpec::default().is_overwrite());
         assert!(!upsert_spec(&["id"]).is_overwrite());
+    }
+
+    #[test]
+    fn overwrite_scope_window_validates_and_renders() {
+        let scope = OverwriteScope::Window {
+            column: "posting_date".into(),
+            from: json!("2024-06-01"),
+            to: json!("2024-07-01"),
+        };
+        assert_eq!(scope.column(), "posting_date");
+        assert!(scope.validate().is_ok());
+        let whr = scope.render_where_literal("\"posting_date\"");
+        assert_eq!(
+            whr,
+            "\"posting_date\" >= '2024-06-01' AND \"posting_date\" < '2024-07-01'"
+        );
+
+        // Empty column / null bounds are rejected.
+        assert!(
+            OverwriteScope::Window {
+                column: " ".into(),
+                from: json!(1),
+                to: json!(2)
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            OverwriteScope::Window {
+                column: "c".into(),
+                from: json!(null),
+                to: json!(2)
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn scope_window_number_bounds() {
+        let scope = OverwriteScope::Window {
+            column: "seq".into(),
+            from: json!(100),
+            to: json!(200),
+        };
+        assert!(scope.validate().is_ok());
+        assert_eq!(
+            scope.render_where_literal("`seq`"),
+            "`seq` >= 100 AND `seq` < 200"
+        );
+    }
+
+    #[test]
+    fn scope_literal_escapes_quotes() {
+        // A crafted bound cannot break out of the string literal.
+        let scope = OverwriteScope::Window {
+            column: "c".into(),
+            from: json!("x' OR '1'='1"),
+            to: json!("z"),
+        };
+        let whr = scope.render_where_literal("\"c\"");
+        assert!(whr.contains("'x'' OR ''1''=''1'"), "{whr}");
     }
 
     #[test]

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -448,3 +448,8 @@ query API (not streaming `insertAll`), then swapped with a
 target's partitioning and clustering — only after the run succeeds, so a mid-run
 failure leaves the previous rows intact. No `key` is needed; the target table
 must already exist.
+
+**Scoped / windowed overwrite (#518):** add a `scope: { window: { column, from, to } }`
+to replace only the rows in a half-open `[from, to)` window — the swap becomes
+`BEGIN TRANSACTION; DELETE FROM target WHERE <window>; INSERT … SELECT; COMMIT`,
+leaving out-of-window rows intact (ideal for rolling-window / period-report loads).

--- a/crates/sink/bigquery/src/config.rs
+++ b/crates/sink/bigquery/src/config.rs
@@ -53,6 +53,11 @@ pub struct BigQuerySinkConfig {
     /// column(s) of the target table.
     #[serde(flatten)]
     pub write: faucet_core::WriteSpec,
+    /// Scoped/windowed overwrite (#518): with `write_mode: overwrite`, replace
+    /// only the rows matching this scope (e.g. a partition/date window) instead
+    /// of the whole table — the out-of-scope rows are preserved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<faucet_core::OverwriteScope>,
     /// Arrow columnar **load-job** mode (#380): buffer Arrow `RecordBatch`es to
     /// Parquet, stage them on a GCS bucket, then run a BigQuery `PARQUET` load
     /// job (`jobs.insert`) instead of the per-row `insertAll` path. Only
@@ -121,6 +126,7 @@ impl BigQuerySinkConfig {
             batch_size: DEFAULT_BATCH_SIZE,
             insert_id_field: None,
             write: faucet_core::WriteSpec::default(),
+            scope: None,
             #[cfg(feature = "arrow")]
             bulk_load: None,
         }

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -275,6 +275,22 @@ pub fn build_overwrite_commit_sql(target_ref: &str, temp_ref: &str) -> String {
     )
 }
 
+/// Scoped/windowed overwrite commit (#518): delete only the rows matching
+/// `where_clause`, then insert the staged rows, in one transaction. Preserves
+/// out-of-scope rows and the target's partitioning/clustering.
+pub fn build_scoped_overwrite_commit_sql(
+    target_ref: &str,
+    temp_ref: &str,
+    where_clause: &str,
+) -> String {
+    format!(
+        "BEGIN TRANSACTION;\n\
+         DELETE FROM {target_ref} WHERE {where_clause};\n\
+         INSERT INTO {target_ref} SELECT * FROM {temp_ref};\n\
+         COMMIT TRANSACTION;"
+    )
+}
+
 /// The typed `INSERT … SELECT FROM UNNEST(JSON_QUERY_ARRAY(@payload))` statement.
 pub(crate) fn build_insert_select(
     columns: &[FieldSpec],
@@ -612,6 +628,24 @@ mod tests {
         assert!(sql.starts_with("BEGIN TRANSACTION;"));
         assert!(sql.contains("TRUNCATE TABLE `p.d.t`;"));
         assert!(sql.contains("INSERT INTO `p.d.t` SELECT * FROM `p.d.t__faucet_ovw`;"));
+        assert!(sql.trim_end().ends_with("COMMIT TRANSACTION;"));
+    }
+
+    #[test]
+    fn scoped_overwrite_commit_sql_deletes_in_scope_then_inserts() {
+        let target = table_ref("p", "d", "t");
+        let temp = table_ref("p", "d", "t__faucet_ovw");
+        let sql = build_scoped_overwrite_commit_sql(
+            &target,
+            &temp,
+            "`posting_date` >= '2024-06-01' AND `posting_date` < '2024-07-01'",
+        );
+        assert!(sql.starts_with("BEGIN TRANSACTION;"));
+        assert!(sql.contains(
+            "DELETE FROM `p.d.t` WHERE `posting_date` >= '2024-06-01' AND `posting_date` < '2024-07-01';"
+        ));
+        assert!(sql.contains("INSERT INTO `p.d.t` SELECT * FROM `p.d.t__faucet_ovw`;"));
+        assert!(!sql.contains("TRUNCATE"));
         assert!(sql.trim_end().ends_with("COMMIT TRANSACTION;"));
     }
 

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -917,11 +917,19 @@ impl faucet_core::Sink for BigQuerySink {
     /// path, so there is no streaming buffer to miss.
     async fn commit_overwrite(&self) -> Result<(), FaucetError> {
         let temp = self.overwrite_temp_ref();
-        self.run_ddl(idempotent::build_overwrite_commit_sql(
-            &self.table_ref(),
-            &temp,
-        ))
-        .await?;
+        let sql = match &self.config.scope {
+            Some(scope) => {
+                // Backtick-quote the scoped column (strip any backticks).
+                let col = format!("`{}`", scope.column().replace('`', ""));
+                idempotent::build_scoped_overwrite_commit_sql(
+                    &self.table_ref(),
+                    &temp,
+                    &scope.render_where_literal(&col),
+                )
+            }
+            None => idempotent::build_overwrite_commit_sql(&self.table_ref(), &temp),
+        };
+        self.run_ddl(sql).await?;
         self.run_ddl(format!("DROP TABLE IF EXISTS {temp}")).await
     }
 

--- a/crates/sink/bigquery/tests/overwrite.rs
+++ b/crates/sink/bigquery/tests/overwrite.rs
@@ -3,7 +3,7 @@
 //! swap. Driven against a wiremock BigQuery so the DDL/query bodies can be
 //! asserted without a real project.
 
-use faucet_core::{Sink, WriteMode};
+use faucet_core::{OverwriteScope, Sink, WriteMode};
 use faucet_sink_bigquery::{BigQueryCredentials, BigQuerySink, BigQuerySinkConfig};
 use gcp_bigquery_client::client_builder::ClientBuilder;
 use serde::Serialize;
@@ -195,6 +195,40 @@ async fn overwrite_lifecycle_posts_bucket_free_swap() {
         qs.iter()
             .any(|q| q.contains("DROP TABLE IF EXISTS `p.d.t__faucet_ovw`")),
         "drop temp missing: {qs:?}"
+    );
+}
+
+#[tokio::test]
+async fn scoped_overwrite_commit_deletes_in_window_not_truncate() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_and_job(&server, "job-s").await;
+
+    let mut config = config_overwrite();
+    config.scope = Some(OverwriteScope::Window {
+        column: "posting_date".into(),
+        from: json!("2024-06-01"),
+        to: json!("2024-07-01"),
+    });
+    let (sink, _sa) = build_sink(&server, config).await;
+
+    sink.begin_overwrite().await.expect("begin");
+    sink.write_batch(&[json!({"id": 1, "name": "a"})])
+        .await
+        .expect("write");
+    sink.commit_overwrite().await.expect("commit");
+
+    let qs = queries(&server).await;
+    assert!(
+        qs.iter().any(|q| q.contains("BEGIN TRANSACTION")
+            && q.contains("DELETE FROM `p.d.t` WHERE `posting_date` >= '2024-06-01' AND `posting_date` < '2024-07-01'")
+            && q.contains("INSERT INTO `p.d.t` SELECT * FROM `p.d.t__faucet_ovw`")),
+        "scoped commit swap missing: {qs:?}"
+    );
+    assert!(
+        !qs.iter().any(|q| q.contains("TRUNCATE TABLE `p.d.t`")),
+        "scoped overwrite must not truncate: {qs:?}"
     );
 }
 

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -443,3 +443,8 @@ transaction (`TRUNCATE` + `INSERT … SELECT` + `DROP`) only after the run
 succeeds, so a mid-run failure leaves the previous rows intact. No `key` is
 needed; the target table must already exist. See the
 [Overwrite cookbook](../../../docs/book/src/cookbook/upsert.md).
+
+**Scoped / windowed overwrite (#518):** add a `scope: { window: { column, from, to } }`
+to replace only the rows in a half-open `[from, to)` window — the swap becomes
+`DELETE FROM target WHERE <window>; INSERT … SELECT` in one transaction, leaving
+out-of-window rows intact.

--- a/crates/sink/postgres/src/config.rs
+++ b/crates/sink/postgres/src/config.rs
@@ -109,6 +109,11 @@ pub struct PostgresSinkConfig {
     /// on `insert` so data + watermark commit in one transaction.
     #[serde(default)]
     pub write_method: PostgresWriteMethod,
+    /// Scoped/windowed overwrite (#518): with `write_mode: overwrite`, replace
+    /// only the rows matching this scope (e.g. a date window) instead of
+    /// truncating the whole table. The prior out-of-scope rows are preserved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<faucet_core::OverwriteScope>,
 }
 
 fn default_batch_size() -> usize {
@@ -145,6 +150,7 @@ impl PostgresSinkConfig {
             max_connections: 5,
             write: faucet_core::WriteSpec::default(),
             write_method: PostgresWriteMethod::default(),
+            scope: None,
         }
     }
 

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -838,21 +838,34 @@ impl faucet_core::Sink for PostgresSink {
         Ok(())
     }
 
-    /// Atomically replace the destination in one transaction: `TRUNCATE target;
-    /// INSERT INTO target SELECT * FROM staging; DROP TABLE staging`. Postgres
-    /// runs TRUNCATE and DDL transactionally, so a failure rolls the whole swap
-    /// back and the prior rows survive.
+    /// Atomically replace the destination in one transaction. Full overwrite:
+    /// `TRUNCATE target; INSERT INTO target SELECT * FROM staging; DROP staging`.
+    /// Scoped/windowed overwrite (#518): `DELETE FROM target WHERE <scope>;
+    /// INSERT …; DROP staging` — only the in-scope rows are replaced, the rest
+    /// preserved. Postgres runs TRUNCATE and DDL transactionally, so a failure
+    /// rolls the whole swap back and the prior rows survive.
     async fn commit_overwrite(&self) -> Result<(), FaucetError> {
         let staging =
             qualified_table_ref(self.config.schema.as_deref(), &self.staging_table_name());
         let target = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
+        // Full replace truncates; a scope replaces only the matching rows.
+        let clear = match &self.config.scope {
+            Some(scope) => {
+                let col = quote_ident(scope.column());
+                format!(
+                    "DELETE FROM {target} WHERE {}",
+                    scope.render_where_literal(&col)
+                )
+            }
+            None => format!("TRUNCATE TABLE {target}"),
+        };
         let mut tx = self
             .pool
             .begin()
             .await
             .map_err(|e| FaucetError::Sink(format!("postgres overwrite: begin swap: {e}")))?;
         for stmt in [
-            format!("TRUNCATE TABLE {target}"),
+            clear,
             format!("INSERT INTO {target} SELECT * FROM {staging}"),
             format!("DROP TABLE {staging}"),
         ] {

--- a/crates/sink/postgres/tests/overwrite.rs
+++ b/crates/sink/postgres/tests/overwrite.rs
@@ -8,7 +8,7 @@
 //! run land in a staging table, so the destination keeps its old rows until the
 //! atomic swap — and an aborted run leaves the previous rows fully intact.
 
-use faucet_core::{Sink, WriteMode, WriteSpec};
+use faucet_core::{OverwriteScope, Sink, WriteMode, WriteSpec};
 use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
 use serde_json::json;
 use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
@@ -105,6 +105,43 @@ async fn overwrite_replaces_all_rows_on_commit() {
         !staging_exists(&url).await,
         "staging table must be dropped after commit"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scoped_overwrite_replaces_only_in_window_rows() {
+    let (_container, url) = start_postgres().await;
+    create_kv_table(&url).await;
+    // id 1 is out of the [10, 20) window (kept); id 15 is in-window (replaced).
+    seed(
+        &url,
+        "INSERT INTO kv (id, name) VALUES (1, 'keep'), (15, 'old_in')",
+    )
+    .await;
+
+    let mut config = overwrite_config(&url);
+    config.scope = Some(OverwriteScope::Window {
+        column: "id".into(),
+        from: json!(10),
+        to: json!(20),
+    });
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    sink.begin_overwrite().await.expect("begin");
+    sink.write_batch(&[
+        json!({"id": 15, "name": "new_in"}),
+        json!({"id": 16, "name": "new_in2"}),
+    ])
+    .await
+    .expect("write");
+
+    // Before commit the destination still holds the OLD rows.
+    assert_eq!(names_ordered(&url).await, vec!["keep", "old_in"]);
+
+    sink.commit_overwrite().await.expect("commit");
+
+    // Out-of-window id 1 preserved; in-window id 15 replaced; id 16 added.
+    assert_eq!(names_ordered(&url).await, vec!["keep", "new_in", "new_in2"]);
+    assert!(!staging_exists(&url).await, "staging dropped after commit");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -47,7 +47,9 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 jsonpath-rust = "1"
-quick-xml = { workspace = true }  # OData $metadata (EDMX/CSDL) parsing (#512)
+quick-xml = { workspace = true }  # OData $metadata (EDMX/CSDL) parsing (#512); XML decode (#515)
+flate2 = { workspace = true }  # gunzip decode step (#515)
+zip = { workspace = true }  # unzip decode step (#515)
 csv-async = { workspace = true }
 calamine = { workspace = true, optional = true }
 tokio = { version = "1", features = ["time"] }

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -198,6 +198,52 @@ source:
     odata: { version: v4, entity: Orders, select: [DocEntry, DocDate], page_size: 500 }
 ```
 
+### Response-decode pipeline (`decode`)
+
+Consume payloads that aren't plain JSON — including files embedded in a JSON/SOAP
+envelope. A `decode:` chain runs over the raw response **body** before record
+extraction (replaces `response_format` parsing; requires `pagination: none`):
+
+| Step | Form | Effect |
+|------|------|--------|
+| `extract` | `{ extract: "$.d.reportBytes" }` | Pull a string field out of a JSON envelope. |
+| `base64` | `base64` | Base64-decode the buffer. |
+| `gunzip` | `gunzip` | Gzip-decompress. |
+| `unzip` | `{ unzip: { member: "*.csv" } }` | Extract a zip member (glob; first file if omitted). |
+| `parse` | `{ parse: { format: json\|csv\|xlsx\|xml, … } }` | Terminal: parse bytes → records. |
+
+```yaml
+decode:
+  - extract: "$.d.reportBytes"   # base64 XLSX inside a SOAP/JSON envelope
+  - base64
+  - parse: { format: xlsx, sheet: "Sheet1", header_row: 4 }
+```
+
+### Async-job pattern (`async_job`)
+
+For bulk/export/report-run APIs (Salesforce Bulk, Stripe Reporting, …): submit a
+job → poll a status endpoint until terminal → fetch the result → hand it to the
+`decode:` pipeline. Requires `pagination: none`.
+
+| Field | Description |
+|-------|-------------|
+| `submit` | `{ method, url, headers, query, json }` — job-creation request. |
+| `job_id` | JSONPath to the job id in the submit response. |
+| `poll` | `{ url, method, interval_secs (5), timeout_secs (1800) }` — `${job_id}` substituted. |
+| `status` | `{ path, success: [...], failure: [...] }` — classify the poll response. |
+| `fetch` | `{ method, url }` — result download; body flows through `decode:`. |
+
+```yaml
+async_job:
+  submit: { method: POST, url: /jobs, json: { query: "SELECT ..." } }
+  job_id: "$.id"
+  poll:   { url: "/jobs/${job_id}", interval_secs: 5, timeout_secs: 1800 }
+  status: { path: "$.state", success: [JobComplete], failure: [Failed, Aborted] }
+  fetch:  { url: "/jobs/${job_id}/result" }
+decode:
+  - parse: { format: csv }
+```
+
 ### Singer / Meltano metadata
 
 | Field | Type | Default | Description |

--- a/crates/source/rest/src/async_job.rs
+++ b/crates/source/rest/src/async_job.rs
@@ -1,0 +1,242 @@
+//! Async-job source pattern (#514): submit → poll → fetch result.
+//!
+//! Covers the "big-data export / bulk / report-run" class of APIs that a
+//! paginated GET can't express (Salesforce Bulk, Stripe Reporting, warehouse
+//! UNLOAD, …). Configured as an `async_job:` block on the REST source; the
+//! fetched result is handed to the `decode:` pipeline (#515) or the normal
+//! body parsing.
+//!
+//! ```yaml
+//! async_job:
+//!   submit: { method: POST, url: "/jobs", json: { query: "SELECT ..." } }
+//!   job_id: "$.id"
+//!   poll:   { url: "/jobs/${job_id}", interval_secs: 5, timeout_secs: 1800 }
+//!   status: { path: "$.state", success: [JobComplete], failure: [Failed, Aborted] }
+//!   fetch:  { url: "/jobs/${job_id}/result" }
+//! decode:
+//!   - parse: { format: csv }
+//! ```
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+fn default_get() -> String {
+    "GET".to_owned()
+}
+fn default_interval() -> u64 {
+    5
+}
+fn default_timeout() -> u64 {
+    1800
+}
+
+/// One HTTP request in a job lifecycle (submit / fetch).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct JobRequest {
+    /// HTTP method (default `GET`; set `POST` for `submit`).
+    #[serde(default = "default_get")]
+    pub method: String,
+    /// URL — absolute, or a `base_url`-relative path. `${job_id}` is substituted.
+    pub url: String,
+    /// Extra headers.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
+    /// Extra query params.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub query: HashMap<String, String>,
+    /// JSON request body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub json: Option<Value>,
+}
+
+/// The poll request + cadence.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PollSpec {
+    /// HTTP method (default `GET`).
+    #[serde(default = "default_get")]
+    pub method: String,
+    /// Status URL — absolute or `base_url`-relative; `${job_id}` substituted.
+    pub url: String,
+    /// Extra headers.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
+    /// Extra query params.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub query: HashMap<String, String>,
+    /// Seconds between polls (default `5`).
+    #[serde(default = "default_interval")]
+    pub interval_secs: u64,
+    /// Give up after this many seconds (default `1800`).
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+}
+
+/// How to read the job's terminal state from a poll response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct JobStatus {
+    /// JSONPath to the status value in the poll response.
+    pub path: String,
+    /// Status values meaning "done — go fetch".
+    pub success: Vec<String>,
+    /// Status values meaning "failed — abort".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failure: Vec<String>,
+}
+
+/// Terminal classification of a poll status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobOutcome {
+    /// Ready to fetch.
+    Success,
+    /// Failed / aborted.
+    Failure,
+    /// Not terminal yet — keep polling.
+    Pending,
+}
+
+impl JobStatus {
+    /// Classify a poll's status value.
+    pub fn classify(&self, status: &str) -> JobOutcome {
+        if self.success.iter().any(|s| s == status) {
+            JobOutcome::Success
+        } else if self.failure.iter().any(|s| s == status) {
+            JobOutcome::Failure
+        } else {
+            JobOutcome::Pending
+        }
+    }
+}
+
+/// The `async_job:` config block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AsyncJobConfig {
+    /// Job-creation request.
+    pub submit: JobRequest,
+    /// JSONPath to the job id in the submit response.
+    pub job_id: String,
+    /// Status polling.
+    pub poll: PollSpec,
+    /// Terminal-state classification.
+    pub status: JobStatus,
+    /// Result-download request.
+    pub fetch: JobRequest,
+}
+
+impl AsyncJobConfig {
+    /// Validate the block at config-load time.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        if self.submit.url.trim().is_empty() || self.fetch.url.trim().is_empty() {
+            return Err(faucet_core::FaucetError::Config(
+                "async_job: `submit.url` and `fetch.url` must not be empty".into(),
+            ));
+        }
+        if self.job_id.trim().is_empty() {
+            return Err(faucet_core::FaucetError::Config(
+                "async_job: `job_id` (JSONPath) must not be empty".into(),
+            ));
+        }
+        if self.status.success.is_empty() {
+            return Err(faucet_core::FaucetError::Config(
+                "async_job: `status.success` must list at least one terminal value".into(),
+            ));
+        }
+        if self.poll.interval_secs == 0 && self.poll.timeout_secs == 0 {
+            return Err(faucet_core::FaucetError::Config(
+                "async_job: `poll.timeout_secs` must be > 0".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Substitute `${job_id}` in a URL/template.
+pub fn substitute_job_id(template: &str, job_id: &str) -> String {
+    template.replace("${job_id}", job_id)
+}
+
+/// Resolve a possibly-relative URL against `base_url`.
+pub fn resolve_url(base_url: &str, url: &str) -> String {
+    if url.starts_with("http://") || url.starts_with("https://") {
+        url.to_string()
+    } else {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            url.trim_start_matches('/')
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn classify_maps_status_to_outcome() {
+        let s = JobStatus {
+            path: "$.state".into(),
+            success: vec!["JobComplete".into()],
+            failure: vec!["Failed".into(), "Aborted".into()],
+        };
+        assert_eq!(s.classify("JobComplete"), JobOutcome::Success);
+        assert_eq!(s.classify("Failed"), JobOutcome::Failure);
+        assert_eq!(s.classify("Aborted"), JobOutcome::Failure);
+        assert_eq!(s.classify("InProgress"), JobOutcome::Pending);
+    }
+
+    #[test]
+    fn substitute_and_resolve_urls() {
+        assert_eq!(substitute_job_id("/jobs/${job_id}/x", "42"), "/jobs/42/x");
+        assert_eq!(resolve_url("https://h", "/jobs"), "https://h/jobs");
+        assert_eq!(resolve_url("https://h/", "jobs"), "https://h/jobs");
+        assert_eq!(
+            resolve_url("https://h", "https://other/x"),
+            "https://other/x"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_and_no_success() {
+        let base: AsyncJobConfig = serde_json::from_value(json!({
+            "submit": { "url": "/jobs" },
+            "job_id": "$.id",
+            "poll": { "url": "/jobs/${job_id}" },
+            "status": { "path": "$.state", "success": ["Done"] },
+            "fetch": { "url": "/jobs/${job_id}/result", "method": "GET" }
+        }))
+        .unwrap();
+        assert!(base.validate().is_ok());
+
+        let mut no_success = base.clone();
+        no_success.status.success.clear();
+        assert!(no_success.validate().is_err());
+
+        let mut empty_id = base.clone();
+        empty_id.job_id = " ".into();
+        assert!(empty_id.validate().is_err());
+    }
+
+    #[test]
+    fn poll_defaults_apply() {
+        let cfg: AsyncJobConfig = serde_json::from_value(json!({
+            "submit": { "url": "/jobs" },
+            "job_id": "$.id",
+            "poll": { "url": "/jobs/${job_id}" },
+            "status": { "path": "$.state", "success": ["Done"] },
+            "fetch": { "url": "/r" }
+        }))
+        .unwrap();
+        assert_eq!(cfg.poll.interval_secs, 5);
+        assert_eq!(cfg.poll.timeout_secs, 1800);
+        assert_eq!(cfg.poll.method, "GET");
+        assert_eq!(cfg.submit.method, "GET"); // default; examples set POST explicitly
+        assert_eq!(cfg.fetch.method, "GET");
+    }
+}

--- a/crates/source/rest/src/config.rs
+++ b/crates/source/rest/src/config.rs
@@ -186,6 +186,14 @@ pub struct RestStreamConfig {
     /// must be `none`. See [`DecodeStep`](crate::decode::DecodeStep).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub decode: Vec<crate::decode::DecodeStep>,
+
+    // ── Async-job pattern (#514) ────────────────────────────────────────────────
+    /// Run a submit→poll→fetch job lifecycle instead of a single GET, for
+    /// bulk/export/report-run APIs (Salesforce Bulk, Stripe Reporting, …). The
+    /// fetched result flows through `decode:` / `response_format`. When set,
+    /// pagination must be `none`. See [`AsyncJobConfig`](crate::async_job::AsyncJobConfig).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub async_job: Option<crate::async_job::AsyncJobConfig>,
 }
 
 /// OData protocol version, which selects the paging-link key.
@@ -283,6 +291,7 @@ impl Default for RestStreamConfig {
             replication_bind: None,
             odata: None,
             decode: Vec::new(),
+            async_job: None,
         }
     }
 }
@@ -342,6 +351,16 @@ impl RestStreamConfig {
                 return Err(faucet_core::FaucetError::Config(
                     "rest: `decode:` replaces `response_format` body parsing — remove \
                      `response_format: csv|excel`"
+                        .into(),
+                ));
+            }
+        }
+        if let Some(job) = &self.async_job {
+            job.validate()?;
+            if !matches!(self.pagination, PaginationStyle::None) {
+                return Err(faucet_core::FaucetError::Config(
+                    "rest: an `async_job:` lifecycle fetches a single result — set \
+                     `pagination: none`"
                         .into(),
                 ));
             }

--- a/crates/source/rest/src/config.rs
+++ b/crates/source/rest/src/config.rs
@@ -176,6 +176,16 @@ pub struct RestStreamConfig {
     /// time (explicit values still win). See [`ODataConfig`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub odata: Option<ODataConfig>,
+
+    // ── Response-decode pipeline (#515) ─────────────────────────────────────────
+    /// Decode the response body before record extraction: a chain of
+    /// `extract` (JSONPath) / `base64` / `gunzip` / `unzip` / `parse`
+    /// (json|csv|xlsx|xml) steps. Lets a source consume base64/compressed/file
+    /// payloads (e.g. a base64 XLSX inside a SOAP body, or a gzipped-CSV export).
+    /// When set, it replaces the `response_format` body parsing, and pagination
+    /// must be `none`. See [`DecodeStep`](crate::decode::DecodeStep).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub decode: Vec<crate::decode::DecodeStep>,
 }
 
 /// OData protocol version, which selects the paging-link key.
@@ -272,6 +282,7 @@ impl Default for RestStreamConfig {
             excel_header_row: 0,
             replication_bind: None,
             odata: None,
+            decode: Vec::new(),
         }
     }
 }
@@ -318,6 +329,22 @@ impl RestStreamConfig {
             return Err(faucet_core::FaucetError::Config(
                 "rest: `odata` speaks JSON — remove `response_format: csv|excel`".into(),
             ));
+        }
+        if !self.decode.is_empty() {
+            if !matches!(self.pagination, PaginationStyle::None) {
+                return Err(faucet_core::FaucetError::Config(
+                    "rest: a `decode:` pipeline consumes a single response body — set \
+                     `pagination: none`"
+                        .into(),
+                ));
+            }
+            if !matches!(self.response_format, ResponseFormat::Json) {
+                return Err(faucet_core::FaucetError::Config(
+                    "rest: `decode:` replaces `response_format` body parsing — remove \
+                     `response_format: csv|excel`"
+                        .into(),
+                ));
+            }
         }
         Ok(())
     }
@@ -500,6 +527,12 @@ impl RestStreamConfig {
     /// sugar, and `$metadata` discovery from the block (#512).
     pub fn odata(mut self, odata: ODataConfig) -> Self {
         self.odata = Some(odata);
+        self
+    }
+
+    /// Set the response-decode pipeline (#515).
+    pub fn decode(mut self, steps: Vec<crate::decode::DecodeStep>) -> Self {
+        self.decode = steps;
         self
     }
 

--- a/crates/source/rest/src/decode.rs
+++ b/crates/source/rest/src/decode.rs
@@ -1,0 +1,576 @@
+//! Response-decode pipeline (#515).
+//!
+//! A declarative chain applied to the raw response **body** before record
+//! extraction, so a source can consume payloads that aren't plain JSON —
+//! including files embedded in a JSON/SOAP envelope:
+//!
+//! ```yaml
+//! decode:
+//!   - extract: "$.d.reportBytes"          # pull a field out of the envelope
+//!   - base64                               # base64 → bytes
+//!   - unzip: { member: "*.csv" }           # or `gunzip`
+//!   - parse: { format: csv, has_headers: true }
+//! ```
+//!
+//! Steps compose left-to-right over a byte buffer; the terminal `parse` step
+//! turns the bytes into records. Without an explicit `parse`, the bytes are
+//! parsed as JSON.
+
+use base64::Engine;
+use faucet_core::FaucetError;
+use jsonpath_rust::JsonPath;
+use quick_xml::events::Event;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::io::{Cursor, Read};
+
+/// A byte-chain step with no parameters (`- base64`, `- gunzip`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SimpleStep {
+    /// Base64-decode the (UTF-8 text) buffer into bytes.
+    Base64,
+    /// Gzip-decompress the buffer.
+    Gunzip,
+}
+
+/// Select a member of a zip archive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
+pub struct UnzipSpec {
+    /// Glob (`*.csv`, `prefix*`, `*mid*`, or an exact name) selecting the member.
+    /// When omitted, the first file entry is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member: Option<String>,
+}
+
+/// Final-parse format for a decode chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ParseFormat {
+    /// JSON (default).
+    #[default]
+    Json,
+    /// Delimited text.
+    Csv,
+    /// Excel workbook (requires the crate's `excel` feature).
+    Xlsx,
+    /// XML → JSON.
+    Xml,
+}
+
+fn default_has_headers() -> bool {
+    true
+}
+
+/// Parse the decoded bytes into records.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ParseSpec {
+    /// Output format.
+    pub format: ParseFormat,
+    /// JSONPath selecting the record array (json/xml). When omitted, an array
+    /// body becomes the records and an object becomes a single record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub records_path: Option<String>,
+    /// CSV delimiter byte (default `,`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delimiter: Option<u8>,
+    /// Whether the first CSV row is a header (default `true`).
+    #[serde(default = "default_has_headers")]
+    pub has_headers: bool,
+    /// Excel worksheet name / index-as-string (default: first).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sheet: Option<String>,
+    /// 0-based Excel header row (default `0`).
+    #[serde(default)]
+    pub header_row: usize,
+}
+
+/// One step of the decode chain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum DecodeStep {
+    /// Parameterless byte step (`base64` / `gunzip`).
+    Simple(SimpleStep),
+    /// Pull a (string) field out of a JSON body first.
+    Extract {
+        /// JSONPath to a string field whose value becomes the buffer.
+        extract: String,
+    },
+    /// Select a member from a zip archive.
+    Unzip {
+        /// Member selector.
+        unzip: UnzipSpec,
+    },
+    /// Terminal parse into records.
+    Parse {
+        /// Parse options.
+        parse: ParseSpec,
+    },
+}
+
+/// Run the decode chain over the response body, returning records.
+pub async fn run_decode(body: &[u8], steps: &[DecodeStep]) -> Result<Vec<Value>, FaucetError> {
+    let mut buf = body.to_vec();
+    for step in steps {
+        match step {
+            DecodeStep::Extract { extract } => {
+                let v: Value = serde_json::from_slice(&buf).map_err(|e| {
+                    FaucetError::Source(format!("decode `extract`: body is not JSON: {e}"))
+                })?;
+                let s = jsonpath_first_string(&v, extract).ok_or_else(|| {
+                    FaucetError::Source(format!(
+                        "decode `extract`: '{extract}' matched no string field"
+                    ))
+                })?;
+                buf = s.into_bytes();
+            }
+            DecodeStep::Simple(SimpleStep::Base64) => {
+                let text = std::str::from_utf8(&buf).map_err(|e| {
+                    FaucetError::Source(format!("decode `base64`: buffer is not UTF-8 text: {e}"))
+                })?;
+                buf = base64::engine::general_purpose::STANDARD
+                    .decode(text.trim())
+                    .map_err(|e| FaucetError::Source(format!("decode `base64`: {e}")))?;
+            }
+            DecodeStep::Simple(SimpleStep::Gunzip) => {
+                let mut out = Vec::new();
+                flate2::read::GzDecoder::new(Cursor::new(&buf))
+                    .read_to_end(&mut out)
+                    .map_err(|e| FaucetError::Source(format!("decode `gunzip`: {e}")))?;
+                buf = out;
+            }
+            DecodeStep::Unzip { unzip } => {
+                buf = unzip_member(&buf, unzip.member.as_deref())?;
+            }
+            DecodeStep::Parse { parse } => {
+                return parse_records(&buf, parse).await;
+            }
+        }
+    }
+    // No explicit `parse` → default to JSON.
+    parse_records(
+        &buf,
+        &ParseSpec {
+            format: ParseFormat::Json,
+            records_path: None,
+            delimiter: None,
+            has_headers: true,
+            sheet: None,
+            header_row: 0,
+        },
+    )
+    .await
+}
+
+fn jsonpath_first_string(v: &Value, path: &str) -> Option<String> {
+    let results = v.query(path).ok()?;
+    match results.first()? {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// Minimal glob: `*` matches any run. Supports `*.ext`, `prefix*`, `*mid*`,
+/// `*a*b*`, and exact names.
+fn glob_match(pattern: &str, name: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == name;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut pos = 0usize;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !name[pos..].starts_with(part) {
+                return false;
+            }
+            pos += part.len();
+        } else if i == parts.len() - 1 {
+            return name[pos..].ends_with(part);
+        } else {
+            match name[pos..].find(part) {
+                Some(idx) => pos += idx + part.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+fn unzip_member(bytes: &[u8], member: Option<&str>) -> Result<Vec<u8>, FaucetError> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes))
+        .map_err(|e| FaucetError::Source(format!("decode `unzip`: not a valid zip: {e}")))?;
+    // Resolve the member index first (immutable name scan), then read it.
+    let mut chosen: Option<usize> = None;
+    for i in 0..archive.len() {
+        let f = archive
+            .by_index(i)
+            .map_err(|e| FaucetError::Source(format!("decode `unzip`: {e}")))?;
+        if !f.is_file() {
+            continue;
+        }
+        let matches = match member {
+            Some(pat) => glob_match(pat, f.name()),
+            None => true, // first file
+        };
+        if matches {
+            chosen = Some(i);
+            break;
+        }
+    }
+    let idx = chosen.ok_or_else(|| {
+        FaucetError::Source(format!(
+            "decode `unzip`: no member matched {}",
+            member
+                .map(|m| format!("'{m}'"))
+                .unwrap_or_else(|| "any".into())
+        ))
+    })?;
+    let mut f = archive
+        .by_index(idx)
+        .map_err(|e| FaucetError::Source(format!("decode `unzip`: {e}")))?;
+    let mut out = Vec::new();
+    f.read_to_end(&mut out)
+        .map_err(|e| FaucetError::Source(format!("decode `unzip`: reading member: {e}")))?;
+    Ok(out)
+}
+
+async fn parse_records(bytes: &[u8], spec: &ParseSpec) -> Result<Vec<Value>, FaucetError> {
+    match spec.format {
+        ParseFormat::Json => {
+            let v: Value = serde_json::from_slice(bytes)
+                .map_err(|e| FaucetError::Source(format!("decode `parse` json: {e}")))?;
+            Ok(records_from_value(v, spec.records_path.as_deref()))
+        }
+        ParseFormat::Csv => {
+            crate::format::parse_csv(bytes, spec.delimiter.unwrap_or(b','), spec.has_headers)
+                .await
+                .map_err(|e| FaucetError::Source(format!("decode `parse` csv: {e}")))
+        }
+        ParseFormat::Xlsx => {
+            crate::format::parse_excel(bytes, spec.sheet.as_deref(), spec.header_row)
+                .map_err(|e| FaucetError::Source(format!("decode `parse` xlsx: {e}")))
+        }
+        ParseFormat::Xml => {
+            let v = xml_to_json(bytes)?;
+            Ok(records_from_value(v, spec.records_path.as_deref()))
+        }
+    }
+}
+
+/// Turn a JSON value into records: apply `records_path` if given, else an array
+/// becomes the records and any other value becomes a single record.
+fn records_from_value(v: Value, records_path: Option<&str>) -> Vec<Value> {
+    match records_path {
+        Some(path) => v
+            .query(path)
+            .ok()
+            .map(|ms| ms.into_iter().cloned().collect())
+            .unwrap_or_default(),
+        None => match v {
+            Value::Array(a) => a,
+            other => vec![other],
+        },
+    }
+}
+
+/// Compact XML → JSON: each element becomes an object of its children; repeated
+/// child tags become arrays; attributes are `@name`; text is `#text` (or the
+/// value directly when an element has only text).
+fn xml_to_json(bytes: &[u8]) -> Result<Value, FaucetError> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|e| FaucetError::Source(format!("decode `parse` xml: not UTF-8: {e}")))?;
+    let mut reader = quick_xml::Reader::from_str(text);
+    // A stack of (object, text-accumulator) frames; index 0 is the document root.
+    let mut stack: Vec<(Map<String, Value>, String)> = vec![(Map::new(), String::new())];
+
+    fn attrs(e: &quick_xml::events::BytesStart) -> Map<String, Value> {
+        let mut m = Map::new();
+        for a in e.attributes().flatten() {
+            let k = String::from_utf8_lossy(a.key.as_ref())
+                .rsplit(':')
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            if let Ok(v) = a.unescape_value() {
+                m.insert(format!("@{k}"), Value::String(v.to_string()));
+            }
+        }
+        m
+    }
+    fn local(name: &[u8]) -> String {
+        String::from_utf8_lossy(name)
+            .rsplit(':')
+            .next()
+            .unwrap_or_default()
+            .to_string()
+    }
+    fn insert_child(parent: &mut Map<String, Value>, key: String, val: Value) {
+        match parent.get_mut(&key) {
+            Some(Value::Array(arr)) => arr.push(val),
+            Some(existing) => {
+                let prev = existing.take();
+                parent.insert(key, Value::Array(vec![prev, val]));
+            }
+            None => {
+                parent.insert(key, val);
+            }
+        }
+    }
+    fn finish(obj: Map<String, Value>, text: String) -> Value {
+        let trimmed = text.trim();
+        if obj.is_empty() {
+            Value::String(trimmed.to_string())
+        } else {
+            let mut obj = obj;
+            if !trimmed.is_empty() {
+                obj.insert("#text".to_string(), Value::String(trimmed.to_string()));
+            }
+            Value::Object(obj)
+        }
+    }
+
+    loop {
+        match reader
+            .read_event()
+            .map_err(|e| FaucetError::Source(format!("decode `parse` xml: {e}")))?
+        {
+            Event::Eof => break,
+            Event::Start(e) => stack.push((attrs(&e), String::new())),
+            Event::Empty(e) => {
+                let name = local(e.name().as_ref());
+                let val = finish(attrs(&e), String::new());
+                let top = stack.last_mut().expect("root frame present");
+                insert_child(&mut top.0, name, val);
+            }
+            Event::End(e) => {
+                let (obj, text) = stack.pop().expect("matched start frame");
+                let name = local(e.name().as_ref());
+                let val = finish(obj, text);
+                let top = stack.last_mut().expect("root frame present");
+                insert_child(&mut top.0, name, val);
+            }
+            Event::Text(t) => {
+                if let Ok(s) = t.unescape() {
+                    stack.last_mut().expect("root frame present").1.push_str(&s);
+                }
+            }
+            Event::CData(t) => {
+                stack
+                    .last_mut()
+                    .expect("root frame present")
+                    .1
+                    .push_str(&String::from_utf8_lossy(&t));
+            }
+            _ => {}
+        }
+    }
+    let (root, _) = stack.pop().unwrap_or_default();
+    Ok(Value::Object(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse_json() -> ParseSpec {
+        ParseSpec {
+            format: ParseFormat::Json,
+            records_path: None,
+            delimiter: None,
+            has_headers: true,
+            sheet: None,
+            header_row: 0,
+        }
+    }
+
+    #[test]
+    fn glob_matches_common_patterns() {
+        assert!(glob_match("*.csv", "report.csv"));
+        assert!(!glob_match("*.csv", "report.txt"));
+        assert!(glob_match("data*", "data_2024.csv"));
+        assert!(glob_match("*part*", "x_part_1"));
+        assert!(glob_match("exact.csv", "exact.csv"));
+        assert!(!glob_match("exact.csv", "other.csv"));
+        assert!(glob_match("*a*b*", "xxaxxbxx"));
+        assert!(!glob_match("*a*b*", "xxbxxaxx"));
+    }
+
+    #[tokio::test]
+    async fn extract_base64_json_chain() {
+        // A JSON envelope holding a base64-encoded JSON array.
+        let inner = br#"[{"id":1},{"id":2}]"#;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(inner);
+        let body = json!({ "d": { "payload": b64 } }).to_string();
+        let steps = vec![
+            DecodeStep::Extract {
+                extract: "$.d.payload".into(),
+            },
+            DecodeStep::Simple(SimpleStep::Base64),
+            DecodeStep::Parse {
+                parse: parse_json(),
+            },
+        ];
+        let recs = run_decode(body.as_bytes(), &steps).await.unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[1]["id"], 2);
+    }
+
+    #[tokio::test]
+    async fn gunzip_csv_chain() {
+        use flate2::{Compression, write::GzEncoder};
+        use std::io::Write;
+        let csv = b"a,b\n1,2\n3,4\n";
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(csv).unwrap();
+        let gz = enc.finish().unwrap();
+        let steps = vec![
+            DecodeStep::Simple(SimpleStep::Gunzip),
+            DecodeStep::Parse {
+                parse: ParseSpec {
+                    format: ParseFormat::Csv,
+                    ..parse_json()
+                },
+            },
+        ];
+        let recs = run_decode(&gz, &steps).await.unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0]["a"], "1");
+        assert_eq!(recs[1]["b"], "4");
+    }
+
+    #[tokio::test]
+    async fn unzip_member_glob_chain() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let mut cur = Cursor::new(Vec::new());
+        {
+            let mut zw = zip::ZipWriter::new(&mut cur);
+            let opts = SimpleFileOptions::default();
+            zw.start_file("notes.txt", opts).unwrap();
+            zw.write_all(b"ignore").unwrap();
+            zw.start_file("data.csv", opts).unwrap();
+            zw.write_all(b"x\n9\n").unwrap();
+            zw.finish().unwrap();
+        }
+        let zip_bytes = cur.into_inner();
+        let steps = vec![
+            DecodeStep::Unzip {
+                unzip: UnzipSpec {
+                    member: Some("*.csv".into()),
+                },
+            },
+            DecodeStep::Parse {
+                parse: ParseSpec {
+                    format: ParseFormat::Csv,
+                    ..parse_json()
+                },
+            },
+        ];
+        let recs = run_decode(&zip_bytes, &steps).await.unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["x"], "9");
+    }
+
+    #[tokio::test]
+    async fn default_parse_is_json_and_records_path_works() {
+        let body = br#"{"items":[{"n":1},{"n":2}]}"#;
+        // No parse step → default json, whole object is one record.
+        let recs = run_decode(body, &[]).await.unwrap();
+        assert_eq!(recs.len(), 1);
+        // With records_path → the array.
+        let steps = vec![DecodeStep::Parse {
+            parse: ParseSpec {
+                records_path: Some("$.items[*]".into()),
+                ..parse_json()
+            },
+        }];
+        let recs = run_decode(body, &steps).await.unwrap();
+        assert_eq!(recs.len(), 2);
+    }
+
+    #[test]
+    fn xml_to_json_handles_repeated_elements_and_attrs() {
+        let xml = br#"<root><row id="1"><n>a</n></row><row id="2"><n>b</n></row></root>"#;
+        let v = xml_to_json(xml).unwrap();
+        let rows = &v["root"]["row"];
+        assert!(rows.is_array());
+        assert_eq!(rows[0]["@id"], "1");
+        assert_eq!(rows[0]["n"], "a");
+        assert_eq!(rows[1]["n"], "b");
+    }
+
+    #[tokio::test]
+    async fn xml_parse_with_records_path() {
+        let xml = br#"<root><row><n>a</n></row><row><n>b</n></row></root>"#;
+        let steps = vec![DecodeStep::Parse {
+            parse: ParseSpec {
+                format: ParseFormat::Xml,
+                records_path: Some("$.root.row[*]".into()),
+                ..parse_json()
+            },
+        }];
+        let recs = run_decode(xml, &steps).await.unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[1]["n"], "b");
+    }
+
+    #[tokio::test]
+    async fn base64_on_non_utf8_errors() {
+        let steps = vec![DecodeStep::Simple(SimpleStep::Base64)];
+        assert!(run_decode(&[0xff, 0xfe], &steps).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn extract_missing_field_errors() {
+        let steps = vec![DecodeStep::Extract {
+            extract: "$.nope".into(),
+        }];
+        assert!(run_decode(br#"{"a":1}"#, &steps).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unzip_no_match_errors() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let mut cur = Cursor::new(Vec::new());
+        {
+            let mut zw = zip::ZipWriter::new(&mut cur);
+            zw.start_file("a.txt", SimpleFileOptions::default())
+                .unwrap();
+            zw.write_all(b"x").unwrap();
+            zw.finish().unwrap();
+        }
+        let steps = vec![DecodeStep::Unzip {
+            unzip: UnzipSpec {
+                member: Some("*.csv".into()),
+            },
+        }];
+        assert!(run_decode(&cur.into_inner(), &steps).await.is_err());
+    }
+
+    #[test]
+    fn decode_step_deserializes_mixed_forms() {
+        let steps: Vec<DecodeStep> = serde_json::from_value(json!([
+            "base64",
+            "gunzip",
+            { "extract": "$.x" },
+            { "unzip": { "member": "*.csv" } },
+            { "parse": { "format": "csv" } }
+        ]))
+        .unwrap();
+        assert_eq!(steps.len(), 5);
+        assert!(matches!(steps[0], DecodeStep::Simple(SimpleStep::Base64)));
+        assert!(matches!(steps[1], DecodeStep::Simple(SimpleStep::Gunzip)));
+        assert!(matches!(steps[2], DecodeStep::Extract { .. }));
+        assert!(matches!(steps[3], DecodeStep::Unzip { .. }));
+        assert!(matches!(steps[4], DecodeStep::Parse { .. }));
+    }
+}

--- a/crates/source/rest/src/lib.rs
+++ b/crates/source/rest/src/lib.rs
@@ -5,6 +5,7 @@
 //! A declarative, config-driven REST API client with pluggable authentication,
 //! pagination, schema inference, and incremental replication.
 
+pub mod async_job;
 pub mod auth;
 pub mod config;
 pub mod decode;
@@ -21,6 +22,7 @@ pub use faucet_core::{
     FaucetError, RecordTransform, ReplicationMethod, Sink, Source, replication, schema, transform,
 };
 
+pub use async_job::{AsyncJobConfig, JobRequest, JobStatus, PollSpec};
 pub use auth::oauth2::DEFAULT_EXPIRY_RATIO;
 pub use auth::token_endpoint::DEFAULT_TOKEN_ENDPOINT_EXPIRY_RATIO;
 pub use auth::{Auth, ResponseValidator, fetch_oauth2_token, fetch_token_from_endpoint};

--- a/crates/source/rest/src/lib.rs
+++ b/crates/source/rest/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod auth;
 pub mod config;
+pub mod decode;
 pub mod extract;
 pub mod format;
 pub mod odata;
@@ -24,5 +25,6 @@ pub use auth::oauth2::DEFAULT_EXPIRY_RATIO;
 pub use auth::token_endpoint::DEFAULT_TOKEN_ENDPOINT_EXPIRY_RATIO;
 pub use auth::{Auth, ResponseValidator, fetch_oauth2_token, fetch_token_from_endpoint};
 pub use config::{ODataConfig, ODataVersion, ResponseFormat, RestStreamConfig, TlsClientConfig};
+pub use decode::{DecodeStep, ParseFormat, ParseSpec, SimpleStep, UnzipSpec};
 pub use pagination::PaginationStyle;
 pub use stream::RestStream;

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -1174,6 +1174,15 @@ impl RestStream {
         if bytes.iter().all(u8::is_ascii_whitespace) {
             return Ok((Value::Array(vec![]), resp_headers));
         }
+        // A `decode:` pipeline (#515) takes the raw body and produces records
+        // directly (extract → base64 → gunzip/unzip → parse). It replaces the
+        // `response_format` parsing; `validate()` guarantees pagination is
+        // `none`. The records land as an array the downstream
+        // (records_path-less) extraction passes straight through.
+        if !self.config.decode.is_empty() {
+            let records = crate::decode::run_decode(&bytes, &self.config.decode).await?;
+            return Ok((Value::Array(records), resp_headers));
+        }
         // For file response formats the whole body is a tabular file — parse it
         // into a record array here so the downstream (records_path-less)
         // extraction passes it straight through. `validate()` guarantees

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -136,6 +136,19 @@ fn credential_to_auth(cred: Credential) -> Auth {
     }
 }
 
+/// First JSONPath match rendered as a string (string verbatim, number as text).
+/// Used by the async-job runner to read the job id / status from responses.
+fn jsonpath_first_string(v: &Value, path: &str) -> Option<String> {
+    use jsonpath_rust::JsonPath;
+    let results = v.query(path).ok()?;
+    match results.first()? {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
 /// Insert a header from string parts, mapping invalid names/values to a typed
 /// config error rather than panicking.
 fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) -> Result<(), FaucetError> {
@@ -391,6 +404,14 @@ impl RestStream {
         let owned_context: Option<HashMap<String, Value>> = context.cloned();
 
         Box::pin(async_stream::try_stream! {
+            // Async-job lifecycle (#514): submit → poll → fetch replaces the
+            // normal single-GET + pagination flow and yields one result page.
+            if self.config.async_job.is_some() {
+                let records = self.run_async_job().await?;
+                yield faucet_core::StreamPage { records, bookmark: None };
+                return;
+            }
+
             // Resolve the effective start-bookmark once at the top of the stream.
             // A runtime override (applied via `Source::apply_start_bookmark` —
             // typically by the pipeline reading from a `StateStore`) takes
@@ -740,6 +761,173 @@ impl RestStream {
         match bookmark {
             Some(bm) => Ok(Some((bind.into, bind.name.clone(), bind.render(&bm)?))),
             None => Ok(None),
+        }
+    }
+
+    /// Build + send one job-lifecycle request (auth via `metadata_headers`,
+    /// plus the connector's static headers and the request's own headers/query/
+    /// json). Returns the raw response bytes; errors on non-2xx.
+    async fn job_request_bytes(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+        query: &HashMap<String, String>,
+        json: Option<&Value>,
+    ) -> Result<Vec<u8>, FaucetError> {
+        let m = reqwest::Method::from_bytes(method.to_uppercase().as_bytes()).map_err(|_| {
+            FaucetError::Config(format!("async_job: invalid HTTP method '{method}'"))
+        })?;
+        let mut hdrs = self.config.headers.clone();
+        for (k, v) in self.metadata_headers(url).await?.iter() {
+            hdrs.insert(k.clone(), v.clone());
+        }
+        for (k, v) in headers {
+            insert_header(&mut hdrs, k, v)?;
+        }
+        let mut req = self.client.request(m, url).headers(hdrs);
+        if !query.is_empty() {
+            let pairs: Vec<(&str, &str)> = query
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            req = req.query(&pairs);
+        }
+        if let Some(j) = json {
+            req = req.json(j);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| FaucetError::Source(format!("async_job: request to {url} failed: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(FaucetError::HttpStatus {
+                status: status.as_u16(),
+                url: url.to_string(),
+                body: format!("async_job: {url} returned HTTP {}", status.as_u16()),
+            });
+        }
+        Ok(resp.bytes().await?.to_vec())
+    }
+
+    async fn job_request_json(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+        query: &HashMap<String, String>,
+        json: Option<&Value>,
+    ) -> Result<Value, FaucetError> {
+        let bytes = self
+            .job_request_bytes(method, url, headers, query, json)
+            .await?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| FaucetError::Source(format!("async_job: {url} returned non-JSON: {e}")))
+    }
+
+    /// Run the submit → poll → fetch job lifecycle (#514) and return the
+    /// decoded result records.
+    async fn run_async_job(&self) -> Result<Vec<Value>, FaucetError> {
+        use crate::async_job::{JobOutcome, resolve_url, substitute_job_id};
+        let job = self
+            .config
+            .async_job
+            .as_ref()
+            .expect("run_async_job called with async_job set");
+        let base = &self.config.base_url;
+
+        // 1) Submit → capture the job id.
+        let submit_url = resolve_url(base, &job.submit.url);
+        let submit_body = self
+            .job_request_json(
+                &job.submit.method,
+                &submit_url,
+                &job.submit.headers,
+                &job.submit.query,
+                job.submit.json.as_ref(),
+            )
+            .await?;
+        let job_id = jsonpath_first_string(&submit_body, &job.job_id).ok_or_else(|| {
+            FaucetError::Source(format!(
+                "async_job: submit response had no job id at '{}'",
+                job.job_id
+            ))
+        })?;
+
+        // 2) Poll until a terminal state (with interval + timeout).
+        let poll_url = resolve_url(base, &substitute_job_id(&job.poll.url, &job_id));
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(job.poll.timeout_secs);
+        loop {
+            let body = self
+                .job_request_json(
+                    &job.poll.method,
+                    &poll_url,
+                    &job.poll.headers,
+                    &job.poll.query,
+                    None,
+                )
+                .await?;
+            let status = jsonpath_first_string(&body, &job.status.path).unwrap_or_default();
+            match job.status.classify(&status) {
+                JobOutcome::Success => break,
+                JobOutcome::Failure => {
+                    return Err(FaucetError::Source(format!(
+                        "async_job: job failed with status '{status}'"
+                    )));
+                }
+                JobOutcome::Pending => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(FaucetError::Source(format!(
+                            "async_job: polling timed out after {}s (last status '{status}')",
+                            job.poll.timeout_secs
+                        )));
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(job.poll.interval_secs))
+                        .await;
+                }
+            }
+        }
+
+        // 3) Fetch the result and decode it.
+        let fetch_url = resolve_url(base, &substitute_job_id(&job.fetch.url, &job_id));
+        let bytes = self
+            .job_request_bytes(
+                &job.fetch.method,
+                &fetch_url,
+                &job.fetch.headers,
+                &job.fetch.query,
+                job.fetch.json.as_ref(),
+            )
+            .await?;
+        if !self.config.decode.is_empty() {
+            crate::decode::run_decode(&bytes, &self.config.decode).await
+        } else {
+            match self.config.response_format {
+                crate::config::ResponseFormat::Json => {
+                    let v: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                        FaucetError::Source(format!("async_job: result is not JSON: {e}"))
+                    })?;
+                    Ok(extract::extract_records(
+                        &v,
+                        self.config.records_path.as_deref(),
+                    )?)
+                }
+                crate::config::ResponseFormat::Csv => {
+                    crate::format::parse_csv(
+                        &bytes,
+                        self.config.csv_delimiter,
+                        self.config.csv_has_headers,
+                    )
+                    .await
+                }
+                crate::config::ResponseFormat::Excel => crate::format::parse_excel(
+                    &bytes,
+                    self.config.excel_sheet.as_deref(),
+                    self.config.excel_header_row,
+                ),
+            }
         }
     }
 

--- a/crates/source/rest/tests/async_job_test.rs
+++ b/crates/source/rest/tests/async_job_test.rs
@@ -1,0 +1,97 @@
+//! Integration test for the async-job source pattern (#514):
+//! submit → poll (not-ready → ready) → fetch → decode.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use faucet_source_rest::{
+    AsyncJobConfig, DecodeStep, ParseFormat, ParseSpec, RestStream, RestStreamConfig,
+};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
+
+/// Poll responds "InProgress" once, then "Complete".
+struct PollThenComplete(Arc<AtomicUsize>);
+impl Respond for PollThenComplete {
+    fn respond(&self, _: &wiremock::Request) -> ResponseTemplate {
+        let n = self.0.fetch_add(1, Ordering::SeqCst);
+        let state = if n == 0 { "InProgress" } else { "Complete" };
+        ResponseTemplate::new(200).set_body_json(json!({ "state": state }))
+    }
+}
+
+#[tokio::test]
+async fn async_job_submit_poll_fetch_decode() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/jobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": "job-1" })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/jobs/job-1"))
+        .respond_with(PollThenComplete(Arc::new(AtomicUsize::new(0))))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/jobs/job-1/result"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("id,name\n1,alice\n2,bob\n"))
+        .mount(&server)
+        .await;
+
+    let async_job: AsyncJobConfig = serde_json::from_value(json!({
+        "submit": { "method": "POST", "url": "/jobs", "json": { "query": "SELECT 1" } },
+        "job_id": "$.id",
+        "poll": { "url": "/jobs/${job_id}", "interval_secs": 0, "timeout_secs": 30 },
+        "status": { "path": "$.state", "success": ["Complete"], "failure": ["Failed"] },
+        "fetch": { "method": "GET", "url": "/jobs/${job_id}/result" }
+    }))
+    .unwrap();
+
+    let mut cfg = RestStreamConfig::new(&server.uri(), "").decode(vec![DecodeStep::Parse {
+        parse: ParseSpec {
+            format: ParseFormat::Csv,
+            records_path: None,
+            delimiter: None,
+            has_headers: true,
+            sheet: None,
+            header_row: 0,
+        },
+    }]);
+    cfg.async_job = Some(async_job);
+
+    let records = RestStream::new(cfg).unwrap().fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["id"], "1");
+    assert_eq!(records[1]["name"], "bob");
+}
+
+#[tokio::test]
+async fn async_job_failure_status_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/jobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": "j" })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/jobs/j"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "state": "Failed" })))
+        .mount(&server)
+        .await;
+
+    let async_job: AsyncJobConfig = serde_json::from_value(json!({
+        "submit": { "method": "POST", "url": "/jobs" },
+        "job_id": "$.id",
+        "poll": { "url": "/jobs/${job_id}", "interval_secs": 0, "timeout_secs": 5 },
+        "status": { "path": "$.state", "success": ["Complete"], "failure": ["Failed"] },
+        "fetch": { "url": "/jobs/${job_id}/result" }
+    }))
+    .unwrap();
+    let mut cfg = RestStreamConfig::new(&server.uri(), "");
+    cfg.async_job = Some(async_job);
+    let err = RestStream::new(cfg).unwrap().fetch_all().await.unwrap_err();
+    assert!(err.to_string().contains("Failed"), "{err}");
+}

--- a/crates/source/rest/tests/decode_test.rs
+++ b/crates/source/rest/tests/decode_test.rs
@@ -1,0 +1,78 @@
+//! Integration tests for the response-decode pipeline (#515) through the REST
+//! source end-to-end.
+
+use faucet_source_rest::{
+    DecodeStep, PaginationStyle, ParseFormat, ParseSpec, RestStream, RestStreamConfig, SimpleStep,
+};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn parse(format: ParseFormat) -> ParseSpec {
+    ParseSpec {
+        format,
+        records_path: None,
+        delimiter: None,
+        has_headers: true,
+        sheet: None,
+        header_row: 0,
+    }
+}
+
+/// A JSON envelope holding a base64-encoded, gzipped CSV — the shape of a
+/// SOAP/JSON "reportBytes" export.
+#[tokio::test]
+async fn decodes_base64_gzip_csv_from_a_json_envelope() {
+    use base64::Engine;
+    use flate2::{Compression, write::GzEncoder};
+    use std::io::Write;
+
+    let csv = b"id,name\n1,alice\n2,bob\n";
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(csv).unwrap();
+    let gz = enc.finish().unwrap();
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&gz);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/report"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "d": { "reportBytes": b64 }
+        })))
+        .mount(&server)
+        .await;
+
+    // decode: extract the field → base64 → gunzip → parse CSV.
+    let stream = RestStream::new(RestStreamConfig::new(&server.uri(), "/report").decode(vec![
+        DecodeStep::Extract {
+            extract: "$.d.reportBytes".into(),
+        },
+        DecodeStep::Simple(SimpleStep::Base64),
+        DecodeStep::Simple(SimpleStep::Gunzip),
+        DecodeStep::Parse {
+            parse: parse(ParseFormat::Csv),
+        },
+    ]))
+    .unwrap();
+
+    let records = stream.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["id"], "1");
+    assert_eq!(records[1]["name"], "bob");
+}
+
+/// A `decode:` pipeline requires `pagination: none`.
+#[test]
+fn decode_with_pagination_is_rejected() {
+    let cfg = RestStreamConfig::new("https://x", "/y")
+        .pagination(PaginationStyle::PageNumber {
+            param_name: "page".into(),
+            start_page: 1,
+            page_size: None,
+            page_size_param: None,
+        })
+        .decode(vec![DecodeStep::Parse {
+            parse: parse(ParseFormat::Json),
+        }]);
+    assert!(RestStream::new(cfg).is_err());
+}

--- a/docs/book/src/cookbook/upsert.md
+++ b/docs/book/src/cookbook/upsert.md
@@ -335,3 +335,29 @@ creates the alias); a concrete index of that name is rejected at `begin`.
 - `delivery: exactly_once` — a full replace has no per-page watermark to resume from.
 - `schema.on_drift: evolve` — the staging target is a pre-run clone, so evolving the live target mid-run would leave the staged data a column short at swap time.
 - Scoped cleanup (`complete_for`) — cleanup requires `write_mode: upsert`; a full overwrite already removes source-deleted rows wholesale.
+
+## Scoped / windowed overwrite (#518)
+
+Replace only the destination rows in a **scope** (a date window) instead of the
+whole table — the declarative equivalent of "delete a rolling window, then
+re-insert" (period-report loads: QuickBooks / Xero / Zoho Books). Add a `scope:`
+block alongside `write_mode: overwrite`:
+
+```yaml
+sink:
+  type: bigquery            # or postgres
+  config:
+    write_mode: overwrite
+    scope:
+      window: { column: posting_date, from: "${now.month_start}", to: "${now.month_end}" }
+```
+
+At commit, the same begin→stage→swap machinery runs, but the swap is a single
+transaction of `DELETE FROM target WHERE <scope>; INSERT INTO target SELECT *
+FROM staging;` — only the in-window rows are replaced; everything outside the
+window is preserved. The window is half-open `[from, to)`.
+
+**Supported sinks (v1):** `postgres`, `bigquery` (`SCOPED_OVERWRITE_SINK_KINDS`).
+The other overwrite sinks still support **full** overwrite; scoped overwrite on
+them (and key-set scopes) is a follow-up. `scope` requires `write_mode:
+overwrite` and inherits the overwrite incompatibilities above.

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -1050,6 +1050,27 @@ See the [Lineage cookbook](../cookbook/lineage.md) for the full field reference,
 transports (HTTP, file, Kafka), the column-lineage support matrix, schema-facet behavior, and
 the Prometheus metrics (`faucet_lineage_events_total`, etc.).
 
+## `metadata_columns`
+
+Optional (#510). Stamp `_faucet_*` run/lineage metadata columns onto every row
+via a connector-agnostic **sink decorator** (works for any sink). Off unless
+present.
+
+```yaml
+metadata_columns:
+  prefix: "_faucet"                       # column-name prefix (default)
+  columns: [extracted_at, loaded_at, run_id, source]   # or add `sequence`
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Master switch (toggle off without removing the block). |
+| `prefix` | `_faucet` | Column-name prefix (`{prefix}_{column}`). |
+| `columns` | `[extracted_at, loaded_at, run_id, source]` | Subset of `extracted_at` / `loaded_at` (write time), `run_id`, `source` (connector kind), `sequence` (monotonic per-run ordinal). |
+
+`extracted_at` is captured at sink-decorator time (≈ `loaded_at` in this model).
+Non-object records pass through unchanged.
+
 ## `catalog`
 
 Optional. When present, `faucet run` / `schedule` / `replicate` record every

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -212,6 +212,17 @@
           "type": "null"
         }
       ]
+    },
+    "metadata_columns": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/MetadataColumnsSpec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional `_faucet_*` run/lineage metadata columns (#510) stamped onto\nevery row by a connector-agnostic sink decorator (works for any sink).\nOff unless present."
     }
   },
   "additionalProperties": false,
@@ -10383,6 +10394,24 @@
                         }
                       ],
                       "description": "Bind the stored bookmark into the outgoing request (query param / header /\nbody field / path) so the server returns only new rows. Composes with the\nexisting `replication_key` client-side filter, which stays active as a\nsafety net. Requires `replication_method: incremental` + `replication_key`."
+                    },
+                    "decode": {
+                      "description": "Decode the response body before record extraction: a chain of\n`extract` (JSONPath) / `base64` / `gunzip` / `unzip` / `parse`\n(json|csv|xlsx|xml) steps. Lets a source consume base64/compressed/file\npayloads (e.g. a base64 XLSX inside a SOAP body, or a gzipped-CSV export).\nWhen set, it replaces the `response_format` body parsing, and pagination\nmust be `none`. See [`DecodeStep`](crate::decode::DecodeStep).",
+                      "items": {
+                        "$ref": "#/$defs/source_rest__DecodeStep"
+                      },
+                      "type": "array"
+                    },
+                    "async_job": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/source_rest__AsyncJobConfig"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Run a submit→poll→fetch job lifecycle instead of a single GET, for\nbulk/export/report-run APIs (Salesforce Bulk, Stripe Reporting, …). The\nfetched result flows through `decode:` / `response_format`. When set,\npagination must be `none`. See [`AsyncJobConfig`](crate::async_job::AsyncJobConfig)."
                     }
                   },
                   "title": "RestStreamConfig",
@@ -14466,6 +14495,17 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "scope": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/sink_bigquery__OverwriteScope"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Scoped/windowed overwrite (#518): with `write_mode: overwrite`, replace\nonly the rows matching this scope (e.g. a partition/date window) instead\nof the whole table — the out-of-scope rows are preserved."
                     }
                   },
                   "title": "BigQuerySinkConfig",
@@ -14669,6 +14709,17 @@
                       "description": "How append-mode rows are shipped: multi-row `insert` (default) or the\n`copy` bulk-load fast-path (`COPY … FROM STDIN`, typically 5–10×\nfaster for bulk append). `copy` is append-only — it is rejected with\n`write_mode: upsert|delete` — and the exactly-once path always stays\non `insert` so data + watermark commit in one transaction.",
                       "$ref": "#/$defs/sink_postgres__PostgresWriteMethod",
                       "default": "insert"
+                    },
+                    "scope": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/sink_postgres__OverwriteScope"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Scoped/windowed overwrite (#518): with `write_mode: overwrite`, replace\nonly the rows matching this scope (e.g. a date window) instead of\ntruncating the whole table. The prior out-of-scope rows are preserved."
                     }
                   },
                   "title": "PostgresSinkConfig",
@@ -17530,6 +17581,397 @@
           "default": "${bookmark}",
           "description": "Template rendered with [`BIND_PLACEHOLDER`] (`${bookmark}`) replaced by\nthe formatted bookmark. Defaults to the bare `${bookmark}`; set e.g.\n`\"gte|${bookmark}\"` (Greenhouse) or `\"[${bookmark} TO *]\"` (Lucene).",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "MetadataColumn": {
+      "description": "A metadata column to stamp onto every row.",
+      "oneOf": [
+        {
+          "const": "extracted_at",
+          "description": "When the record entered the pipeline (ingest time). In the sink-decorator\nmodel this is captured just before the write, so it's ≈ `loaded_at`.",
+          "type": "string"
+        },
+        {
+          "const": "loaded_at",
+          "description": "Sink write time.",
+          "type": "string"
+        },
+        {
+          "const": "run_id",
+          "description": "The pipeline run id.",
+          "type": "string"
+        },
+        {
+          "const": "source",
+          "description": "The source connector kind / stream id.",
+          "type": "string"
+        },
+        {
+          "const": "sequence",
+          "description": "A monotonic per-run row ordinal.",
+          "type": "string"
+        }
+      ]
+    },
+    "MetadataColumnsSpec": {
+      "additionalProperties": false,
+      "description": "The `metadata_columns:` config block.",
+      "properties": {
+        "columns": {
+          "default": [],
+          "description": "Columns to stamp. Empty = the default set\n(`extracted_at`, `loaded_at`, `run_id`, `source`).",
+          "items": {
+            "$ref": "#/$defs/MetadataColumn"
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Master switch (default `true` when the block is present).",
+          "type": "boolean"
+        },
+        "prefix": {
+          "default": "_faucet",
+          "description": "Column-name prefix (default `_faucet`).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "sink_bigquery__OverwriteScope": {
+      "description": "Scope for a **scoped/windowed overwrite** (#518): with `write_mode:\noverwrite`, replace only the destination rows matching this scope instead of\ntruncating the whole table. The sink-side sibling of scoped cleanup (#478).\n\nv1 supports a half-open date/number **window** on a single column.",
+      "oneOf": [
+        {
+          "additionalProperties": true,
+          "description": "Replace rows where `column` is in the half-open range `[from, to)`.",
+          "properties": {
+            "window": {
+              "properties": {
+                "column": {
+                  "description": "The destination column to window on.",
+                  "type": "string"
+                },
+                "from": {
+                  "description": "Inclusive lower bound."
+                },
+                "to": {
+                  "description": "Exclusive upper bound."
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "sink_postgres__OverwriteScope": {
+      "description": "Scope for a **scoped/windowed overwrite** (#518): with `write_mode:\noverwrite`, replace only the destination rows matching this scope instead of\ntruncating the whole table. The sink-side sibling of scoped cleanup (#478).\n\nv1 supports a half-open date/number **window** on a single column.",
+      "oneOf": [
+        {
+          "additionalProperties": true,
+          "description": "Replace rows where `column` is in the half-open range `[from, to)`.",
+          "properties": {
+            "window": {
+              "properties": {
+                "column": {
+                  "description": "The destination column to window on.",
+                  "type": "string"
+                },
+                "from": {
+                  "description": "Inclusive lower bound."
+                },
+                "to": {
+                  "description": "Exclusive upper bound."
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "source_rest__AsyncJobConfig": {
+      "additionalProperties": true,
+      "description": "The `async_job:` config block.",
+      "properties": {
+        "fetch": {
+          "$ref": "#/$defs/source_rest__JobRequest",
+          "description": "Result-download request."
+        },
+        "job_id": {
+          "description": "JSONPath to the job id in the submit response.",
+          "type": "string"
+        },
+        "poll": {
+          "$ref": "#/$defs/source_rest__PollSpec",
+          "description": "Status polling."
+        },
+        "status": {
+          "$ref": "#/$defs/source_rest__JobStatus",
+          "description": "Terminal-state classification."
+        },
+        "submit": {
+          "$ref": "#/$defs/source_rest__JobRequest",
+          "description": "Job-creation request."
+        }
+      },
+      "type": "object"
+    },
+    "source_rest__DecodeStep": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/source_rest__SimpleStep",
+          "description": "Parameterless byte step (`base64` / `gunzip`)."
+        },
+        {
+          "description": "Pull a (string) field out of a JSON body first.",
+          "properties": {
+            "extract": {
+              "description": "JSONPath to a string field whose value becomes the buffer.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "description": "Select a member from a zip archive.",
+          "properties": {
+            "unzip": {
+              "$ref": "#/$defs/source_rest__UnzipSpec",
+              "description": "Member selector."
+            }
+          },
+          "type": "object"
+        },
+        {
+          "description": "Terminal parse into records.",
+          "properties": {
+            "parse": {
+              "$ref": "#/$defs/source_rest__ParseSpec",
+              "description": "Parse options."
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "description": "One step of the decode chain."
+    },
+    "source_rest__JobRequest": {
+      "additionalProperties": true,
+      "description": "One HTTP request in a job lifecycle (submit / fetch).",
+      "properties": {
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra headers.",
+          "type": "object"
+        },
+        "json": {
+          "description": "JSON request body."
+        },
+        "method": {
+          "default": "GET",
+          "description": "HTTP method (default `GET`; set `POST` for `submit`).",
+          "type": "string"
+        },
+        "query": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra query params.",
+          "type": "object"
+        },
+        "url": {
+          "description": "URL — absolute, or a `base_url`-relative path. `${job_id}` is substituted.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "source_rest__JobStatus": {
+      "additionalProperties": true,
+      "description": "How to read the job's terminal state from a poll response.",
+      "properties": {
+        "failure": {
+          "description": "Status values meaning \"failed — abort\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "JSONPath to the status value in the poll response.",
+          "type": "string"
+        },
+        "success": {
+          "description": "Status values meaning \"done — go fetch\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "source_rest__ParseFormat": {
+      "description": "Final-parse format for a decode chain.",
+      "oneOf": [
+        {
+          "const": "json",
+          "description": "JSON (default).",
+          "type": "string"
+        },
+        {
+          "const": "csv",
+          "description": "Delimited text.",
+          "type": "string"
+        },
+        {
+          "const": "xlsx",
+          "description": "Excel workbook (requires the crate's `excel` feature).",
+          "type": "string"
+        },
+        {
+          "const": "xml",
+          "description": "XML → JSON.",
+          "type": "string"
+        }
+      ]
+    },
+    "source_rest__ParseSpec": {
+      "additionalProperties": true,
+      "description": "Parse the decoded bytes into records.",
+      "properties": {
+        "delimiter": {
+          "description": "CSV delimiter byte (default `,`).",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null",
+            "string"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/source_rest__ParseFormat",
+          "description": "Output format."
+        },
+        "has_headers": {
+          "default": true,
+          "description": "Whether the first CSV row is a header (default `true`).",
+          "type": [
+            "boolean",
+            "string"
+          ]
+        },
+        "header_row": {
+          "default": 0,
+          "description": "0-based Excel header row (default `0`).",
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "records_path": {
+          "description": "JSONPath selecting the record array (json/xml). When omitted, an array\nbody becomes the records and an object becomes a single record.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sheet": {
+          "description": "Excel worksheet name / index-as-string (default: first).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "source_rest__PollSpec": {
+      "additionalProperties": true,
+      "description": "The poll request + cadence.",
+      "properties": {
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra headers.",
+          "type": "object"
+        },
+        "interval_secs": {
+          "default": 5,
+          "description": "Seconds between polls (default `5`).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "method": {
+          "default": "GET",
+          "description": "HTTP method (default `GET`).",
+          "type": "string"
+        },
+        "query": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra query params.",
+          "type": "object"
+        },
+        "timeout_secs": {
+          "default": 1800,
+          "description": "Give up after this many seconds (default `1800`).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "url": {
+          "description": "Status URL — absolute or `base_url`-relative; `${job_id}` substituted.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "source_rest__SimpleStep": {
+      "description": "A byte-chain step with no parameters (`- base64`, `- gunzip`).",
+      "oneOf": [
+        {
+          "const": "base64",
+          "description": "Base64-decode the (UTF-8 text) buffer into bytes.",
+          "type": "string"
+        },
+        {
+          "const": "gunzip",
+          "description": "Gzip-decompress the buffer.",
+          "type": "string"
+        }
+      ]
+    },
+    "source_rest__UnzipSpec": {
+      "additionalProperties": true,
+      "description": "Select a member of a zip archive.",
+      "properties": {
+        "member": {
+          "description": "Glob (`*.csv`, `prefix*`, `*mid*`, or an exact name) selecting the member.\nWhen omitted, the first file entry is used.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "type": "object"


### PR DESCRIPTION
## Summary

Round-2 Meltano-parity source/sink unlocks — four issues in one stacked PR (on top of #524). Each closes a concrete gap that previously forced a bespoke connector or manual glue.

- **Response-decode pipeline (#515)** — a `decode:` block on the `rest` source that post-processes a fetched body through composable steps: `base64` / `gunzip` decode, JSONPath `extract`, `unzip` (glob-select a member), and `parse` (json/csv/xlsx/xml → records). Turns "download a report artifact and expand it" into config. Requires `pagination: none` + a json response.
- **Async-job pattern (#514)** — an `async_job:` block on the `rest` source: `submit` → poll `job_id` until `status` reaches success/failure → `fetch` the result (which can itself feed `decode`). The standard bulk-export shape (submit an export, poll, download). `${job_id}` is reserved in the CLI interpolation pass.
- **Scoped / windowed overwrite (#518)** — `write_mode: overwrite` gains an optional `scope: { window: { column, from, to } }` on the **postgres** and **bigquery** sinks: the atomic commit replaces only in-window rows (`DELETE … WHERE col >= from AND col < to` + insert) instead of truncating the whole table. Full-refresh a single partition/day without a staging dance.
- **Run/lineage metadata columns (#510)** — a top-level `metadata_columns:` block stamps `_faucet_*` columns (`extracted_at` / `loaded_at` / `run_id` / `source` / `sequence`) onto every output record via a sink decorator, opt-in and prefix-configurable.

## Notes

- New public surface in `faucet-core` is all additive (new `OverwriteScope` + `metadata` types/module); `cargo-semver-checks` reports no update required.
- `scope` lives on the **sink** configs, not `WriteSpec` (which is frozen — adding a field is a major break), mirroring the pattern from #524.
- Schema regenerated (`schemas/faucet.schema.json`), docs + cookbook + config-reference updated, runnable examples added (`rest_decode_report.yaml`, `rest_async_job.yaml`, `metadata_columns.yaml`).

Closes #515
Closes #514
Closes #518
Closes #510

Part of the roadmap epic #38.
