### PR TITLE
docs(book): fix wordmark invisible in dark theme

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -704,10 +704,44 @@ mark {
   text-align: center;
   padding: 2rem 1rem 0.5rem;
 }
-.fs-hero img {
+.fs-hero img,
+.fs-hero .fs-wordmark {
   max-width: 420px;
   width: 70%;
   height: auto;
+  display: block;
+  margin: 0 auto;
+}
+/* Inline, theme-aware wordmark: "faucet" follows the page text color so it stays
+   legible on every theme (invisible dark-on-dark is the bug this fixes); "stream"
+   and the mark are the brand teal, brightened on dark grounds. */
+.fs-wordmark text {
+  font-family: var(--fs-sans);
+}
+.fs-wordmark .wm-mark {
+  stroke: var(--fs-green);
+}
+.fs-wordmark .wm-dots {
+  fill: var(--fs-green);
+}
+.fs-wordmark .wm-faucet {
+  fill: var(--fg);
+}
+.fs-wordmark .wm-stream {
+  fill: var(--fs-green);
+}
+.navy .fs-wordmark .wm-mark,
+.coal .fs-wordmark .wm-mark,
+.ayu .fs-wordmark .wm-mark {
+  stroke: var(--fs-green-bright);
+}
+.navy .fs-wordmark .wm-dots,
+.coal .fs-wordmark .wm-dots,
+.ayu .fs-wordmark .wm-dots,
+.navy .fs-wordmark .wm-stream,
+.coal .fs-wordmark .wm-stream,
+.ayu .fs-wordmark .wm-stream {
+  fill: var(--fs-green-bright);
 }
 .fs-hero .fs-tagline {
   font-size: 1.3rem;

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,5 +1,15 @@
 <div class="fs-hero">
-  <img src="assets/wordmark.svg" alt="faucet-stream" />
+  <svg class="fs-wordmark" viewBox="0 0 500 128" role="img" aria-label="faucet-stream">
+    <g class="wm-mark" fill="none" stroke-width="13" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M55 40 V24" /><path d="M43 24 H67" /><path d="M32 40 H78 a15 15 0 0 1 15 15 V66" />
+    </g>
+    <g class="wm-dots">
+      <circle cx="93" cy="82" r="6" /><circle cx="93" cy="99" r="5" opacity="0.7" /><circle cx="93" cy="112" r="4" opacity="0.45" />
+    </g>
+    <text x="150" y="78" font-size="52" letter-spacing="-1">
+      <tspan class="wm-faucet" font-weight="700">faucet</tspan><tspan class="wm-stream" font-weight="400">stream</tspan>
+    </text>
+  </svg>
   <p class="fs-tagline">The fast, config-driven way to <strong>move data in Rust</strong>.</p>
   <div class="fs-cta">
     <a class="primary" href="getting-started/installation.html">Get started →</a>


### PR DESCRIPTION
The docs intro wordmark was an `<img>` whose "faucet" text is a hardcoded dark slate — **invisible on the dark themes** (navy/coal/ayu), and an external SVG in `<img>` can't be recolored by CSS.

**Fix:** inline the wordmark SVG so it's theme-aware — "faucet" uses `var(--fg)` (adapts to every theme: slate in light, off-white in dark), while "stream" and the faucet mark use the brand teal (brightened via `--fs-green-bright` on dark grounds). Widened the viewBox so Geist's wider glyphs don't clip the trailing "m".

Verified the full "faucetstream" renders correctly in dark (white + teal, no clip); light is unchanged.

Follow-up from #546.