### PR TITLE
docs(book): center the header search bar over the content column

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -174,13 +174,20 @@ summary:focus-visible {
 /* The relocated search wrapper fills the bar's center. */
 .menu-bar.fs-has-search #mdbook-search-wrapper {
   display: flex !important; /* beats mdBook's `.hidden { display:none !important }` */
-  flex: 1 1 auto;
   justify-content: center;
-  position: relative; /* anchor for the results dropdown */
-  margin: 0 1rem;
+  /* Absolutely center on the (sticky) menu-bar so the pill lines up with the
+     content column, instead of centering in the asymmetric flex gap between the
+     left hamburger and the right icon group. */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: min(44rem, calc(100% - 14rem)); /* leave room for the side buttons */
+  margin: 0;
   max-height: none;
   border-bottom: none;
   padding: 0;
+  z-index: 5;
 }
 .menu-bar.fs-has-search #mdbook-searchbar-outer {
   width: 100%;


### PR DESCRIPTION
The relocated "Search ⌘K" pill was centered in the flex gap between the left hamburger and the right icon group — which are asymmetric — so it sat noticeably off-center on wide screens. This absolutely-centers it on the (sticky) menu-bar so it lines up with the content column, capped with room for the side buttons. Verified at wide widths in light and dark.