### PR TITLE
feat(serve-ui): Templates search + skip Rust CI for frontend-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      ui: ${{ steps.filter.outputs.ui }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,6 +60,12 @@ jobs:
               - '!**/*.png'
               - '!**/*.svg'
               - '!**/*.jpg'
+              - '!cli/src/serve/ui/**'
+            # serve web-console assets (JS/CSS/HTML). They embed into the binary,
+            # so a change here needs the serve-ui isolation test — but NOT the
+            # Rust matrix, clippy, semver, connector features, or supply-chain.
+            ui:
+              - 'cli/src/serve/ui/**'
 
   fmt:
     name: Format
@@ -191,6 +198,30 @@ jobs:
         # Explicitly target the embedded-console tests with serve-ui so the
         # feature-gated #![cfg(feature = "serve-ui")] gate is exercised and
         # the OpenAPI two-way sync test runs against the console-enabled router.
+        run: cargo test -p faucet-cli --features serve-ui --test serve_ui --test serve_openapi
+
+  # Safety net for frontend-only PRs (serve console assets). When a PR touches
+  # ONLY cli/src/serve/ui/** the whole Rust matrix is skipped (code == false),
+  # so this one small job rebuilds the embedded console and runs the serve-ui /
+  # serve-openapi isolation tests — a broken asset still can't merge. When real
+  # Rust changed (code == true) the full `test` job already covers these, so this
+  # job stays out of the way.
+  serve-ui:
+    name: Serve UI (assets)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.ui == 'true' && needs.changes.outputs.code != 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96.0"
+      - name: Install librdkafka prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential
+      - uses: Swatinem/rust-cache@v2
+      - name: Serve-ui + serve-openapi isolation tests
         run: cargo test -p faucet-cli --features serve-ui --test serve_ui --test serve_openapi
 
   # Verify each feature compiles in isolation (catches accidental cross-feature deps)

--- a/cli/src/serve/ui/views/templates.js
+++ b/cli/src/serve/ui/views/templates.js
@@ -40,11 +40,18 @@ export async function renderTemplates(container) {
         <button class="btn-primary" id="t-new">Register a template</button>
       </div>
       <div id="t-register" hidden></div>
+      <div class="filters" id="t-filters" hidden>
+        <input id="t-search" type="search" autocomplete="off"
+          placeholder="search templates by id or description…" />
+      </div>
       <div id="t-list" class="runs-list"></div>
     </div>`;
 
   const list = container.querySelector("#t-list");
   const registerHost = container.querySelector("#t-register");
+  const filters = container.querySelector("#t-filters");
+  const search = container.querySelector("#t-search");
+  let all = [];
 
   container.querySelector("#t-new").onclick = () => {
     registerHost.hidden = !registerHost.hidden;
@@ -53,17 +60,41 @@ export async function renderTemplates(container) {
     }
   };
   container.querySelector("#t-refresh").onclick = () => load();
+  search.oninput = () => render();
+
+  // Client-side filter over the loaded set — match id or description,
+  // case-insensitive. The registry is small, so there's no server round-trip.
+  function render() {
+    const q = search.value.trim().toLowerCase();
+    const rows = q
+      ? all.filter(
+          (t) =>
+            (t.id || "").toLowerCase().includes(q) ||
+            (t.description || "").toLowerCase().includes(q),
+        )
+      : all;
+    list.innerHTML = "";
+    if (!rows.length) {
+      list.innerHTML = `<div class="empty">No templates match “${escapeHtml(search.value.trim())}”.</div>`;
+      return;
+    }
+    for (const t of rows) list.appendChild(listRow(t));
+  }
 
   async function load() {
     try {
       const data = await api("/v1/templates");
+      all = data.templates || [];
       list.innerHTML = "";
-      if (!data.templates.length) {
+      if (!all.length) {
+        filters.hidden = true;
         list.innerHTML = `<div class="empty">No templates registered yet — register one to give operators a parameterized, versioned pipeline to trigger.</div>`;
         return;
       }
-      for (const t of data.templates) list.appendChild(listRow(t));
+      filters.hidden = false;
+      render(); // keeps any active search term across a refresh
     } catch (e) {
+      filters.hidden = true;
       if (templatesUnavailable(e)) list.innerHTML = `<div class="empty">${TEMPLATES_MISSING}</div>`;
       else toast(e.message, "error");
     }


### PR DESCRIPTION
Two related serve-console changes:

**1. Templates search** — a client-side search box on the `faucet serve` web console's Templates view; filters by template id or description (case-insensitive), reusing the runs view's `.filters` idiom, hidden until templates load, term persists across refresh. No server change.

**2. CI scoping (Closes #575)** — serve-console frontend assets (`cli/src/serve/ui/**`) embed into the binary but touch no Rust logic/API/deps. Excluded them from the `code` path filter + added a `ui` filter and a lightweight `serve-ui` job, so a frontend-only PR runs only the embedded-console isolation tests instead of the full Rust matrix. Real Rust changes still run everything. (This PR self-demonstrates it: `code=false, ui=true`.)

Verified: `node --check` on the JS, filter-logic unit check, and `ci.yml` parses (14 jobs, serve-ui present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)