### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-auth"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-cli"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "assert_cmd",
  "async-stream",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-core"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "arrow",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-sink-bigquery"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-source-graphql"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-source-rest"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "faucet-source-xml"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.12.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-cli-v1.11.0...faucet-cli-v1.12.0) - 2026-08-24
+
+### Features
+
+- *(cli,serve)* Template clean-config view (--clean, ?clean API, UI toggle) ([#593](https://github.com/faucet-hq/faucet-stream/pull/593))
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+- *(serve-ui)* Search box on the Templates list ([#574](https://github.com/faucet-hq/faucet-stream/pull/574))
+
 ## [1.11.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-cli-v1.10.0...faucet-cli-v1.11.0) - 2026-08-23
 
 ### Features

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-cli"
-version = "1.11.0"
+version = "1.12.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.2.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-auth-v1.1.0...faucet-auth-v1.2.0) - 2026-08-24
+
+### Features
+
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+
 ## [1.1.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-auth-v1.0.10...faucet-auth-v1.1.0) - 2026-08-23
 
 ### Features

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-auth"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.12.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-core-v1.11.0...faucet-core-v1.12.0) - 2026-08-24
+
+### Features
+
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+
 ## [1.11.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-core-v1.10.0...faucet-core-v1.11.0) - 2026-08-23
 
 ### Bug Fixes

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-core"
-version = "1.11.0"
+version = "1.12.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/sink/bigquery/CHANGELOG.md
+++ b/crates/sink/bigquery/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.7.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-sink-bigquery-v1.6.0...faucet-sink-bigquery-v1.7.0) - 2026-08-24
+
+### Features
+
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+
 ## [1.6.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-sink-bigquery-v1.5.1...faucet-sink-bigquery-v1.6.0) - 2026-08-23
 
 ### Features

--- a/crates/sink/bigquery/Cargo.toml
+++ b/crates/sink/bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-sink-bigquery"
-version = "1.6.0"
+version = "1.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/source/graphql/CHANGELOG.md
+++ b/crates/source/graphql/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.5.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-graphql-v1.4.0...faucet-source-graphql-v1.5.0) - 2026-08-24
+
+### Features
+
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+
 ## [1.4.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-graphql-v1.3.0...faucet-source-graphql-v1.4.0) - 2026-08-23
 
 ### Features

--- a/crates/source/graphql/Cargo.toml
+++ b/crates/source/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-source-graphql"
-version = "1.4.0"
+version = "1.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/source/rest/CHANGELOG.md
+++ b/crates/source/rest/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.6.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-rest-v1.5.0...faucet-source-rest-v1.6.0) - 2026-08-24
+
+### Features
+
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+
 ## [1.5.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-rest-v1.4.4...faucet-source-rest-v1.5.0) - 2026-08-23
 
 ### Features

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-source-rest"
-version = "1.5.0"
+version = "1.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/source/xml/CHANGELOG.md
+++ b/crates/source/xml/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+## [1.6.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-xml-v1.5.0...faucet-source-xml-v1.6.0) - 2026-08-24
+
+### Features
+
+- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
+
 ## [1.5.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-xml-v1.4.0...faucet-source-xml-v1.5.0) - 2026-08-23
 
 ### Features

--- a/crates/source/xml/Cargo.toml
+++ b/crates/source/xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-source-xml"
-version = "1.5.0"
+version = "1.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `faucet-core`: 1.11.0 -> 1.12.0
* `faucet-auth`: 1.1.0 -> 1.2.0
* `faucet-source-rest`: 1.5.0 -> 1.6.0
* `faucet-source-graphql`: 1.4.0 -> 1.5.0
* `faucet-source-xml`: 1.5.0 -> 1.6.0
* `faucet-sink-bigquery`: 1.6.0 -> 1.7.0
* `faucet-cli`: 1.11.0 -> 1.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `faucet-core`

<blockquote>

## [1.12.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-core-v1.11.0...faucet-core-v1.12.0) - 2026-08-24

### Features

- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
</blockquote>

## `faucet-auth`

<blockquote>

## [1.2.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-auth-v1.1.0...faucet-auth-v1.2.0) - 2026-08-24

### Features

- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
</blockquote>

## `faucet-source-rest`

<blockquote>

## [1.6.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-rest-v1.5.0...faucet-source-rest-v1.6.0) - 2026-08-24

### Features

- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
</blockquote>

## `faucet-source-graphql`

<blockquote>

## [1.5.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-graphql-v1.4.0...faucet-source-graphql-v1.5.0) - 2026-08-24

### Features

- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
</blockquote>

## `faucet-source-xml`

<blockquote>

## [1.6.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-source-xml-v1.5.0...faucet-source-xml-v1.6.0) - 2026-08-24

### Features

- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
</blockquote>

## `faucet-sink-bigquery`

<blockquote>

## [1.7.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-sink-bigquery-v1.6.0...faucet-sink-bigquery-v1.7.0) - 2026-08-24

### Features

- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
</blockquote>

## `faucet-cli`

<blockquote>

## [1.12.0](https://github.com/faucet-hq/faucet-stream/compare/faucet-cli-v1.11.0...faucet-cli-v1.12.0) - 2026-08-24

### Features

- *(cli,serve)* Template clean-config view (--clean, ?clean API, UI toggle) ([#593](https://github.com/faucet-hq/faucet-stream/pull/593))
- BigQuery auto-create-table + Meltano-migration connector/CLI gaps (#567–#569, #573) ([#577](https://github.com/faucet-hq/faucet-stream/pull/577))
- *(serve-ui)* Search box on the Templates list ([#574](https://github.com/faucet-hq/faucet-stream/pull/574))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).