### PR TITLE
docs(book): fix mobile search-bar overlap + dedupe sidebar rail + Cloudflare analytics

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -162,28 +162,6 @@ kbd {
 .ayu .sidebar .chapter .section li.chapter-item > a.active {
   color: var(--fs-green-bright) !important;
 }
-/* Nested sub-sections of the active page (mdBook's <ol class="section">): replace
-   the chunky default rail with a soft, thin guide rail, indented so it doesn't
-   collide with the active pill's corner. Sub-items sit quietly; the current one
-   picks up teal text (no pill). */
-.sidebar .chapter .section {
-  border-inline-start: 2px solid color-mix(in srgb, var(--fs-green) 26%, transparent) !important;
-  margin-inline-start: 0.9rem;
-  padding-inline-start: 0.5rem;
-}
-.sidebar .chapter .section li.chapter-item > a {
-  color: color-mix(in srgb, var(--sidebar-fg) 82%, transparent);
-  padding-block: 0.28rem;
-}
-.sidebar .chapter .section li.chapter-item > a.active {
-  background: transparent !important;
-  color: var(--fs-green-deep) !important;
-}
-.navy .sidebar .chapter .section li.chapter-item > a.active,
-.coal .sidebar .chapter .section li.chapter-item > a.active,
-.ayu .sidebar .chapter .section li.chapter-item > a.active {
-  color: var(--fs-green-bright) !important;
-}
 .chapter .part-title {
   color: var(--sidebar-fg);
   opacity: 0.62;
@@ -319,13 +297,38 @@ summary:focus-visible {
   height: 1.5rem;
 }
 
-/* On narrow screens keep the bar tidy: shrink the pill and drop the badge. */
+/* On narrow screens the absolute-centered pill overlaps the hamburger and the
+   right-hand icons (the hidden menu-title normally spaces the button groups
+   apart). So on mobile let the pill flow in-line, taking the space *between* the
+   two button groups — it can no longer sit on top of them. */
 @media (max-width: 700px) {
+  .menu-bar.fs-has-search #mdbook-search-wrapper {
+    position: static;
+    transform: none;
+    left: auto;
+    top: auto;
+    width: auto;
+    flex: 1 1 auto;
+    min-width: 0;
+    margin: 0 0.6rem;
+    z-index: auto;
+  }
+  .menu-bar.fs-has-search #mdbook-searchbar-outer {
+    max-width: none;
+  }
   .menu-bar.fs-has-search #mdbook-searchbar {
     padding-right: 1rem;
+    font-size: 1rem; /* 1.5rem is oversized on a phone */
   }
   .fs-kbd {
     display: none;
+  }
+  /* keep the results dropdown within the viewport under the in-flow pill */
+  .menu-bar.fs-has-search #mdbook-searchresults-outer {
+    left: 0;
+    right: 0;
+    width: auto;
+    transform: none;
   }
 }
 

--- a/docs/book/theme/head.hbs
+++ b/docs/book/theme/head.hbs
@@ -33,3 +33,9 @@
 <meta name="twitter:title" content="faucet-stream — move data in Rust, declaratively" />
 <meta name="twitter:description" content="Config-driven data movement in Rust: connectors + a declarative CLI. Streaming, CDC, exactly-once, DLQ, quality, observability." />
 <meta name="twitter:image" content="https://faucet-hq.github.io/faucet-stream/assets/social-banner.png" />
+
+<!-- Cloudflare Web Analytics (cookieless). Same token as the marketing site so
+     the docs report into the one dashboard. The token is public by design (it
+     ships in the page source); no cookies, no consent banner needed. -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+  data-cf-beacon='{"token": "32ecaeb4264f495ebc78ac02fe6652de"}'></script>


### PR DESCRIPTION
Three docs-site fixes:

1. **Mobile search overlap** — the always-visible search pill was absolutely-centered and overlapped the hamburger + right-hand icons on narrow screens. On `<=700px` it now flows in-line between the button groups (verified: no overlapping rects, desktop unchanged).
2. **Sidebar rail dedupe** — a duplicated `.sidebar .chapter .section` block (stale `2px` copy) was overriding the intended `border: 0`, so the thin nested rail was still live. Removed the duplicate.
3. **Cloudflare Web Analytics** — added the beacon (same token as the marketing site) to `theme/head.hbs` so the docs report into the one dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)