### PR TITLE
docs(book): vertically center the mobile search pill

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -312,6 +312,7 @@ summary:focus-visible {
     min-width: 0;
     margin: 0 0.6rem;
     z-index: auto;
+    align-items: center; /* vertically center the pill with the hamburger + icons */
   }
   .menu-bar.fs-has-search #mdbook-searchbar-outer {
     max-width: none;


### PR DESCRIPTION
The mobile search pill sat ~13px too high (top-aligned) vs the hamburger/icons. Add `align-items: center` to the in-flow wrapper so it's vertically centered (verified: hamburger mid 26 == search mid 26). Mobile-only; desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)