### PR TITLE
feat(cli,serve): template clean-config view (--clean, ?clean API, UI toggle)

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -512,6 +512,11 @@ pub struct TemplateShowArgs {
     /// i.e. the launched version — `newest`, `previous`, `prod`, `dev`, …).
     #[arg(long, default_value = "stable")]
     pub version: String,
+    /// Print ONLY the pure template config — comments stripped, re-emitted as
+    /// canonical YAML — so it pipes cleanly to a file. Suppresses the metadata
+    /// report. Ignored with `--json`.
+    #[arg(long)]
+    pub clean: bool,
     #[command(flatten)]
     pub common: TemplateStoreArgs,
 }

--- a/cli/src/commands/template.rs
+++ b/cli/src/commands/template.rs
@@ -657,6 +657,7 @@ pipeline:
         show(TemplateShowArgs {
             id: "cli-tpl".into(),
             version: "stable".into(),
+            clean: false,
             common: common(&store, false),
         })
         .await

--- a/cli/src/commands/template.rs
+++ b/cli/src/commands/template.rs
@@ -222,6 +222,15 @@ async fn show(args: TemplateShowArgs) -> CliResult<()> {
     let selector = VersionSelector::parse(&args.version)?;
     let want = crate::templates::resolve_version(&store, &args.id, selector).await?;
     let record = fetch(&store, &args.id, Some(want)).await?;
+
+    // `--clean`: emit ONLY the pure template config — comments stripped, canonical
+    // YAML — so it pipes to a file. Skips the metadata report (and the extra store
+    // reads below). `--json` takes precedence.
+    if args.clean && !args.common.json {
+        print!("{}", crate::templates::clean_config_yaml(&record.body)?);
+        return Ok(());
+    }
+
     let state = crate::templates::template_state(&store, &args.id).await?;
     let launches = store
         .template_launches(&args.id)
@@ -503,6 +512,36 @@ async fn run_template(args: TemplateRunArgs) -> CliResult<()> {
 mod tests {
     use super::*;
     use crate::cli::TemplateStoreArgs;
+
+    #[test]
+    fn clean_config_strips_comments_and_preserves_params() {
+        let body = "\
+version: 1  # trailing comment
+# a top-level comment
+name: orders
+pipeline:
+  source: { type: csv, config: { path: \"${param.p}\" } }  # inline
+  sink: { type: jsonl, config: { path: ./out.jsonl } }
+";
+        let out = crate::templates::clean_config_yaml(body).unwrap();
+        // comments are gone
+        assert!(!out.contains('#'), "comments must be stripped: {out}");
+        // param placeholders survive (they're plain strings)
+        assert!(out.contains("${param.p}"), "param token must survive: {out}");
+        // round-trips to the same parsed value
+        let before: serde_yaml::Value = serde_yaml::from_str(body).unwrap();
+        let after: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(before, after, "clean output must parse to the same config");
+    }
+
+    #[test]
+    fn clean_config_normalizes_json_body_to_yaml() {
+        // A JSON-format template body normalizes to YAML too (JSON ⊂ YAML).
+        let body = r#"{"version":1,"name":"j","pipeline":{"source":{"type":"csv"}}}"#;
+        let out = crate::templates::clean_config_yaml(body).unwrap();
+        assert!(out.contains("version: 1"), "should be YAML now: {out}");
+        assert!(!out.contains('{'), "no JSON braces in canonical YAML: {out}");
+    }
 
     fn common(store: &str, json: bool) -> TemplateStoreArgs {
         TemplateStoreArgs {

--- a/cli/src/commands/template.rs
+++ b/cli/src/commands/template.rs
@@ -527,7 +527,10 @@ pipeline:
         // comments are gone
         assert!(!out.contains('#'), "comments must be stripped: {out}");
         // param placeholders survive (they're plain strings)
-        assert!(out.contains("${param.p}"), "param token must survive: {out}");
+        assert!(
+            out.contains("${param.p}"),
+            "param token must survive: {out}"
+        );
         // round-trips to the same parsed value
         let before: serde_yaml::Value = serde_yaml::from_str(body).unwrap();
         let after: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
@@ -540,7 +543,10 @@ pipeline:
         let body = r#"{"version":1,"name":"j","pipeline":{"source":{"type":"csv"}}}"#;
         let out = crate::templates::clean_config_yaml(body).unwrap();
         assert!(out.contains("version: 1"), "should be YAML now: {out}");
-        assert!(!out.contains('{'), "no JSON braces in canonical YAML: {out}");
+        assert!(
+            !out.contains('{'),
+            "no JSON braces in canonical YAML: {out}"
+        );
     }
 
     fn common(store: &str, json: bool) -> TemplateStoreArgs {

--- a/cli/src/serve/handlers/templates.rs
+++ b/cli/src/serve/handlers/templates.rs
@@ -145,6 +145,10 @@ pub async fn list_templates(
 pub struct VersionQuery {
     #[serde(default)]
     pub version: Option<VersionSelector>,
+    /// `clean=true` returns the config body with comments stripped and re-emitted
+    /// as canonical YAML (the pure template). Powers the console's "Clean" toggle.
+    #[serde(default)]
+    pub clean: bool,
 }
 
 impl VersionQuery {
@@ -181,11 +185,14 @@ pub async fn get_template(
     let want = crate::templates::resolve_version(&s, &id, q.selector())
         .await
         .map_err(map_err)?;
-    let template = s
+    let mut template = s
         .template_get(&id, Some(want))
         .await
         .map_err(|e| ServeError::Internal(e.to_string()))?
         .ok_or(ServeError::NotFound)?;
+    if q.clean {
+        template.body = crate::templates::clean_config_yaml(&template.body).map_err(map_err)?;
+    }
     let state = crate::templates::template_state(&s, &id)
         .await
         .map_err(map_err)?;
@@ -719,6 +726,7 @@ mod tests {
                 "tpl-demo",
                 VersionQuery {
                     version: Some(VersionSelector::Pinned(9)),
+                    clean: false,
                 },
             )
             .await,
@@ -1083,6 +1091,7 @@ mod tests {
             "tpl-demo",
             VersionQuery {
                 version: Some(VersionSelector::Channel(VersionChannel::Canary)),
+                clean: false,
             },
         )
         .await
@@ -1110,6 +1119,7 @@ mod tests {
             Path("tpl-demo".into()),
             Query(VersionQuery {
                 version: Some(VersionSelector::newest()),
+                clean: false,
             }),
         )
         .await
@@ -1338,6 +1348,7 @@ mod tests {
             Path("tpl-demo".into()),
             Query(VersionQuery {
                 version: Some(VersionSelector::Pinned(1)),
+                clean: false,
             }),
         )
         .await
@@ -1354,6 +1365,7 @@ mod tests {
             Path("tpl-demo".into()),
             Query(VersionQuery {
                 version: Some(VersionSelector::Pinned(1)),
+                clean: false,
             }),
         )
         .await

--- a/cli/src/serve/ui/views/templates.js
+++ b/cli/src/serve/ui/views/templates.js
@@ -291,6 +291,7 @@ function renderVersions(host, id, st, d, reload) {
       <button class="btn-ghost tpl-launch" ${st.stable === v ? "disabled" : ""}
         title="${st.stable === v ? "already live" : `make v${v} live for unpinned runs`}">Launch</button>
       <button class="btn-ghost tpl-view">Config</button>
+      <button class="btn-ghost tpl-view-clean" title="comments stripped, canonical YAML">Clean</button>
       <button class="btn-danger tpl-del">Delete</button>
       <pre class="tpl-body" hidden></pre>`;
 
@@ -313,16 +314,28 @@ function renderVersions(host, id, st, d, reload) {
     };
 
     const body = row.querySelector(".tpl-body");
-    row.querySelector(".tpl-view").onclick = async () => {
-      if (!body.hidden) { body.hidden = true; return; }
-      if (!body.textContent) {
-        try {
-          const rec = await api(`/v1/templates/${encodeURIComponent(id)}?version=${v}`);
-          body.textContent = rec.body;
-        } catch (e) { toast(e.message, "error"); return; }
+    // Config = raw stored body; Clean = comments stripped, canonical YAML (the
+    // server renders it via ?clean=true, sharing the CLI's clean_config_yaml).
+    // Each toggles the shared <pre>; switching modes refetches so the two views
+    // never collide.
+    const showConfig = async (clean) => {
+      const mode = clean ? "clean" : "raw";
+      if (!body.hidden && body.dataset.mode === mode) {
+        body.hidden = true;
+        return;
       }
-      body.hidden = false;
+      try {
+        const q = clean ? `?version=${v}&clean=true` : `?version=${v}`;
+        const rec = await api(`/v1/templates/${encodeURIComponent(id)}${q}`);
+        body.textContent = rec.body;
+        body.dataset.mode = mode;
+        body.hidden = false;
+      } catch (e) {
+        toast(e.message, "error");
+      }
     };
+    row.querySelector(".tpl-view").onclick = () => showConfig(false);
+    row.querySelector(".tpl-view-clean").onclick = () => showConfig(true);
 
     row.querySelector(".tpl-del").onclick = async () => {
       if (!confirm(`Delete ${id} v${v}? Channels pointing at it are dropped too.`)) return;

--- a/cli/src/templates/mod.rs
+++ b/cli/src/templates/mod.rs
@@ -57,3 +57,17 @@ pub use store::{
     list_with_state, materialize, promote, register, resolve_store_url, resolve_version, rollback,
     set_deprecated, template_state,
 };
+
+use crate::error::{CliError, CliResult};
+
+/// Strip comments from a stored template body and re-emit it as canonical YAML.
+/// `serde_yaml` parses JSON too (JSON ⊂ YAML), so a JSON-format template
+/// normalizes to YAML as well; `${param.*}` tokens are plain strings and pass
+/// through unchanged. A pure view transform — it never mutates the stored body.
+/// Shared by `faucet template show --clean` and the serve `?clean=true` endpoint.
+pub fn clean_config_yaml(body: &str) -> CliResult<String> {
+    let value: serde_yaml::Value = serde_yaml::from_str(body)
+        .map_err(|e| CliError::Internal(format!("clean-config: parse template body: {e}")))?;
+    serde_yaml::to_string(&value)
+        .map_err(|e| CliError::Internal(format!("clean-config: re-emit YAML: {e}")))
+}

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -692,6 +692,9 @@ Promote a version up the channels as it earns trust, then `launch` it when it
 should become what unpinned callers get; `rollback` re-launches `previous`.
 `list` shows each template's status, live version, and build tip; `show` prints
 every version with the channels pointing at it plus the launch history.
+`faucet template show <id> --clean` instead prints **only** the pure template
+config — comments stripped, re-emitted as canonical YAML — so it pipes cleanly to
+a file (`… --clean > template.yaml`); `${param.…}` placeholders are preserved.
 `faucet template run` executes through the identical path as `faucet run`, so
 observability, lineage, notifications, the catalog, and SLA evaluation all behave
 the same. The stored body is verbatim — `${env:…}` / `${vault:…}` resolve at


### PR DESCRIPTION
Closes #590.

One shared `crate::templates::clean_config_yaml` re-emits a stored template body as canonical, comment-free YAML (serde_yaml reads JSON too; `${param.*}` tokens preserved). Surfaced three ways:
- CLI: `faucet template show <id> --clean` prints only the pure YAML (pipes to a file)
- HTTP: `GET /v1/templates/{id}?clean=true`
- Web console: a **Clean** toggle on each version's config view

Adds unit tests for the transform + CLI reference doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)