### PR TITLE
feat(helm): secrets-as-files, PVC existingClaim, chart-only CI fast-path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     outputs:
       code: ${{ steps.gate.outputs.code }}
       ui: ${{ steps.filter.outputs.ui }}
+      deploy: ${{ steps.filter.outputs.deploy }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -61,11 +62,18 @@ jobs:
               - '!**/*.svg'
               - '!**/*.jpg'
               - '!cli/src/serve/ui/**'
+              - '!deploy/**'
             # serve web-console assets (JS/CSS/HTML). They embed into the binary,
             # so a change here needs the serve-ui isolation test — but NOT the
             # Rust matrix, clippy, semver, connector features, or supply-chain.
             ui:
               - 'cli/src/serve/ui/**'
+            # Deployment manifests (Helm chart). A change here needs a Helm lint /
+            # template render — but NOT the Rust matrix, clippy, semver, connector
+            # features, or supply-chain. Excluded from `code` above so a chart-only
+            # PR skips the heavy suite (like docs), and validated by `helm-lint`.
+            deploy:
+              - 'deploy/helm/**'
       # The release-plz "chore: release" PR is auto-updated on every push to main
       # (version + changelog bumps), which would otherwise re-run the full CI on
       # it after every normal merge. Force `code=false` for that PR so all heavy
@@ -242,6 +250,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Serve-ui + serve-openapi isolation tests
         run: cargo test -p faucet-cli --features serve-ui --test serve_ui --test serve_openapi
+
+  # Lint + render the Helm chart on chart-only PRs (which skip the Rust suite).
+  # Pushes to main always run it so the chart stays verified.
+  helm-lint:
+    name: Helm lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.deploy == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - name: helm lint
+        run: helm lint deploy/helm/faucet-stream
+      - name: helm template (default values)
+        run: helm template faucet-stream deploy/helm/faucet-stream > /dev/null
+      - name: helm template (serve + existing PVC + secret files)
+        run: |
+          helm template faucet-stream deploy/helm/faucet-stream \
+            --set serve.enabled=true \
+            --set serve.persistence.existingClaim=my-pvc \
+            --set secretFiles.enabled=true > /dev/null
 
   # Verify each feature compiles in isolation (catches accidental cross-feature deps)
   feature-check:

--- a/deploy/helm/faucet-stream/templates/deployment.yaml
+++ b/deploy/helm/faucet-stream/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-        {{- if .Values.serve.persistence.enabled }}
+        {{- if or .Values.serve.persistence.enabled .Values.serve.persistence.existingClaim }}
         - name: scratch
           persistentVolumeClaim:
             claimName: {{ .Values.serve.persistence.existingClaim | default (printf "%s-data" (include "faucet-stream.fullname" .)) }}

--- a/deploy/helm/faucet-stream/templates/deployment.yaml
+++ b/deploy/helm/faucet-stream/templates/deployment.yaml
@@ -43,9 +43,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.serve.terminationGracePeriodSeconds }}
       {{- $verify := include "faucet-stream.verifyInitContainer" . }}
-      {{- if trim $verify }}
+      {{- if or (trim $verify) .Values.extraInitContainers }}
       initContainers:
+        {{- if trim $verify }}
         {{- $verify | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: serve
@@ -125,13 +130,18 @@ spec:
               mountPath: /etc/faucet-auth
               readOnly: true
             {{- end }}
+            {{- if .Values.secretFiles.enabled }}
+            - name: secret-files
+              mountPath: {{ .Values.secretFiles.mountPath }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
         {{- if .Values.serve.persistence.enabled }}
         - name: scratch
           persistentVolumeClaim:
-            claimName: {{ include "faucet-stream.fullname" . }}-data
+            claimName: {{ .Values.serve.persistence.existingClaim | default (printf "%s-data" (include "faucet-stream.fullname" .)) }}
         {{- else }}
         - name: scratch
           emptyDir: {}
@@ -145,6 +155,11 @@ spec:
         - name: rbac-auth
           secret:
             secretName: {{ .Values.serve.auth.existingSecret | default (include "faucet-stream.authSecretName" .) }}
+        {{- end }}
+        {{- if .Values.secretFiles.enabled }}
+        - name: secret-files
+          secret:
+            secretName: {{ .Values.secretFiles.existingSecret | default (include "faucet-stream.envSecretName" .) }}
         {{- end }}
       {{- with .Values.serve.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/faucet-stream/templates/pvc.yaml
+++ b/deploy/helm/faucet-stream/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serve.enabled .Values.serve.persistence.enabled -}}
+{{- if and .Values.serve.enabled .Values.serve.persistence.enabled (not .Values.serve.persistence.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/deploy/helm/faucet-stream/values.yaml
+++ b/deploy/helm/faucet-stream/values.yaml
@@ -74,6 +74,24 @@ secret:
   #   PGPASSWORD: "s3cr3t"
   #   GOOGLE_APPLICATION_CREDENTIALS_JSON: "..."
 
+# Mount secrets as FILES (for `${file:...}` interpolation), in addition to the
+# env / envFrom paths above. Each Secret key becomes a file under mountPath. Uses
+# the chart-managed env Secret (secret.create=true) by default, or an existing one.
+# NB: this is a k8s-native Secret volume — for an EXTERNAL fetcher (Vault etc.)
+# use extraInitContainers below to populate a shared volume.
+secretFiles:
+  enabled: false
+  mountPath: /var/run/secrets/faucet
+  existingSecret: ""   # defaults to the chart-managed env Secret when secret.create=true
+
+# Extra init containers (verbatim k8s specs) run before the app starts — e.g. a
+# Vault/cloud secrets fetcher that writes into a shared volume the app also mounts.
+# The chart's own optional `verify` init container still runs alongside these.
+extraInitContainers: []
+#  - name: fetch-secrets
+#    image: my/secrets-fetcher:tag
+#    volumeMounts: [{ name: secret-files, mountPath: /var/run/secrets/faucet }]
+
 # -----------------------------------------------------------------------------
 # Pipeline config (a `faucet` YAML/JSON). Mounted read-only at
 # pipelineConfig.mountPath. Used by Job/CronJob, and optionally as the serve
@@ -153,6 +171,12 @@ serve:
     storageClass: ""
     accessModes: [ReadWriteOnce]
     mountPath: /var/lib/faucet
+    # Reuse an existing PVC instead of letting the chart create one; when set, the
+    # chart renders no PVC of its own. Leave empty for a chart-managed claim.
+    existingClaim: ""
+    # Tip: point durable sink outputs (and the sqlite history/catalog) under
+    # mountPath so they survive restarts, e.g.:
+    #   sink: { type: jsonl, config: { path: /var/lib/faucet/out.jsonl } }
 
   livenessProbe:
     httpGet:

--- a/deploy/helm/faucet-stream/values.yaml
+++ b/deploy/helm/faucet-stream/values.yaml
@@ -171,8 +171,9 @@ serve:
     storageClass: ""
     accessModes: [ReadWriteOnce]
     mountPath: /var/lib/faucet
-    # Reuse an existing PVC instead of letting the chart create one; when set, the
-    # chart renders no PVC of its own. Leave empty for a chart-managed claim.
+    # Reuse an existing PVC instead of letting the chart create one. Setting this
+    # mounts the claim on its own (no need to also set `enabled`), and the chart
+    # renders no PVC of its own. Leave empty for a chart-managed claim.
     existingClaim: ""
     # Tip: point durable sink outputs (and the sqlite history/catalog) under
     # mountPath so they survive restarts, e.g.:


### PR DESCRIPTION
Closes #584. Closes #585. Closes #595.

**#584** — secrets as **files** (for `${file:...}` interpolation): new `secretFiles` block mounting a k8s-native Secret volume (defaults to the chart-managed env Secret) at a configurable path, plus an `extraInitContainers` passthrough for external fetchers (Vault agent, cloud secret CSI, etc.). Secrets-as-env already shipped previously.

**#585** — `serve.persistence.existingClaim` to reuse an operator-provisioned PVC (the chart skips rendering its own when set). **Fix:** `existingClaim` now activates the PVC on its own — previously the scratch volume stayed an `emptyDir` unless `persistence.enabled` was also set, silently discarding the claim and any data under `mountPath` on restart (a data-loss footgun). Values docs point sink outputs under the persisted mount.

**#595** — chart-only PRs no longer run the full ~25-min Rust suite: `deploy/**` is excluded from the `code` paths-filter (like `docs/**`), and a new **`helm-lint`** job (`helm lint` + three `helm template` renders, gated on a `deploy` filter) validates the chart instead. This PR is itself the first beneficiary — it touches only `deploy/**` + `.github/**`, so `code=false` and the heavy jobs skip.

Validated locally (helm v4.2.4): `helm lint` clean; renders confirmed for existingClaim-only (`claimName: my-pvc`, no duplicate chart PVC), `persistence.enabled` (chart PVC created + mounted), default (`emptyDir`), and `secretFiles.enabled` (secret volume + mount at `/var/run/secrets/faucet`).

Cross-links roadmap epic #38.