### PR TITLE
docs: add "Ask AI" menu to the docs header

### DIFF
--- a/docs/book/ask-ai.js
+++ b/docs/book/ask-ai.js
@@ -1,0 +1,149 @@
+// "Ask AI" menu for the docs header. Injects a dropdown into mdBook's menu bar
+// that opens the CURRENT docs page in a chosen AI assistant (Claude, ChatGPT,
+// Perplexity, Grok, Gemini) with a prefilled prompt pointing at the page URL and
+// the site's llms.txt. Loaded site-wide via book.toml `additional-js`. Styled
+// with mdBook's own theme variables so it follows light/dark. A no-op if the
+// menu bar is absent. Providers whose query param is unreliable (Gemini) open
+// without a prefill.
+(function () {
+  "use strict";
+
+  var SPARK =
+    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3Z"/><path d="M18.5 14.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8Z"/></svg>';
+  var CARET =
+    '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>';
+
+  var PROVIDERS = [
+    { id: "claude",     label: "Claude",     url: "https://claude.ai/new",            param: "q",  color: "#d97757" },
+    { id: "chatgpt",    label: "ChatGPT",    url: "https://chatgpt.com/",             param: "q",  color: "#10a37f" },
+    { id: "perplexity", label: "Perplexity", url: "https://www.perplexity.ai/search", param: "q",  color: "#20b8cd" },
+    { id: "grok",       label: "Grok",       url: "https://grok.com/",                param: "q",  color: "#888888" },
+    { id: "gemini",     label: "Gemini",     url: "https://gemini.google.com/app",    param: null, color: "#4285f4" },
+  ];
+
+  function injectStyle() {
+    if (document.getElementById("fs-askai-style")) return;
+    var css =
+      ".fs-askai{position:relative;display:inline-flex}" +
+      ".fs-askai-btn{display:inline-flex;align-items:center;gap:.35rem;height:2rem;padding:0 .6rem;border-radius:7px;border:1px solid var(--theme-popup-border);background:transparent;color:var(--icons);font-size:.85rem;font-weight:500;cursor:pointer;font-family:inherit}" +
+      ".fs-askai-btn:hover{color:var(--fg);background:var(--theme-hover)}" +
+      ".fs-askai-btn .fs-askai-caret{opacity:.7}" +
+      ".fs-askai[data-open='true'] .fs-askai-caret{transform:rotate(180deg)}" +
+      ".fs-askai-menu{position:absolute;top:calc(100% + .4rem);right:0;min-width:14.5rem;padding:.4rem;border:1px solid var(--theme-popup-border);border-radius:9px;background:var(--theme-popup-bg);box-shadow:0 8px 28px rgba(0,0,0,.18);z-index:200}" +
+      ".fs-askai-menu[hidden]{display:none}" +
+      ".fs-askai-head{margin:.2rem .5rem .3rem;font-size:.66rem;letter-spacing:.06em;text-transform:uppercase;opacity:.6}" +
+      ".fs-askai-item{display:flex;align-items:center;gap:.55rem;padding:.5rem .5rem;border-radius:6px;font-size:.9rem;color:var(--fg);text-decoration:none}" +
+      ".fs-askai-item:hover{background:var(--theme-hover)}" +
+      ".fs-askai-dot{width:.6rem;height:.6rem;border-radius:50%;flex:none}" +
+      ".fs-askai-foot{margin:.35rem .5rem .1rem;padding-top:.4rem;border-top:1px solid var(--theme-popup-border);font-size:.7rem;line-height:1.5;opacity:.6}" +
+      "@media(max-width:700px){.fs-askai-label{display:none}.fs-askai-btn{padding:0 .5rem}}";
+    var s = document.createElement("style");
+    s.id = "fs-askai-style";
+    s.textContent = css;
+    document.head.appendChild(s);
+  }
+
+  function buildPrompt() {
+    var pageUrl = window.location.href.split("#")[0];
+    var llmsUrl = window.location.origin + "/llms.txt";
+    return (
+      "I'm reading " + pageUrl + " — a page from the faucet-stream documentation " +
+      "(faucet-stream is a fast, config-driven data-movement platform for Rust). " +
+      "Please read that page (and the site guide at " + llmsUrl + ") and help me " +
+      "understand it and answer my questions."
+    );
+  }
+
+  function init() {
+    var bar = document.getElementById("mdbook-menu-bar");
+    if (!bar) return;
+    var right = bar.querySelector(".right-buttons");
+    if (!right) return;
+    if (document.querySelector(".fs-askai")) return; // guard against double-init
+
+    injectStyle();
+    var prompt = buildPrompt();
+
+    var wrap = document.createElement("div");
+    wrap.className = "fs-askai";
+
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "fs-askai-btn";
+    btn.setAttribute("aria-haspopup", "menu");
+    btn.setAttribute("aria-expanded", "false");
+    btn.title = "Ask this page with an AI assistant";
+    btn.innerHTML =
+      SPARK + '<span class="fs-askai-label">Ask AI</span>' +
+      '<span class="fs-askai-caret" style="display:inline-flex">' + CARET + "</span>";
+
+    var menu = document.createElement("div");
+    menu.className = "fs-askai-menu";
+    menu.setAttribute("role", "menu");
+    menu.hidden = true;
+
+    var head = document.createElement("p");
+    head.className = "fs-askai-head";
+    head.textContent = "Open this page in…";
+    menu.appendChild(head);
+
+    PROVIDERS.forEach(function (p) {
+      var a = document.createElement("a");
+      a.className = "fs-askai-item";
+      a.setAttribute("role", "menuitem");
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      if (p.param) {
+        var u = new URL(p.url);
+        u.searchParams.set(p.param, prompt);
+        a.href = u.toString();
+      } else {
+        a.href = p.url;
+      }
+      var dot = document.createElement("span");
+      dot.className = "fs-askai-dot";
+      dot.style.background = p.color;
+      a.appendChild(dot);
+      a.appendChild(document.createTextNode(p.label));
+      a.addEventListener("click", close);
+      menu.appendChild(a);
+    });
+
+    var foot = document.createElement("p");
+    foot.className = "fs-askai-foot";
+    foot.textContent = "Sends a link to this page + llms.txt.";
+    menu.appendChild(foot);
+
+    wrap.appendChild(btn);
+    wrap.appendChild(menu);
+    right.insertBefore(wrap, right.firstChild);
+
+    function open() {
+      menu.hidden = false;
+      wrap.setAttribute("data-open", "true");
+      btn.setAttribute("aria-expanded", "true");
+    }
+    function close() {
+      menu.hidden = true;
+      wrap.removeAttribute("data-open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+    btn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      if (menu.hidden) open();
+      else close();
+    });
+    document.addEventListener("click", function (e) {
+      if (!wrap.contains(e.target)) close();
+    });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && !menu.hidden) {
+        close();
+        btn.focus();
+      }
+    });
+  }
+
+  if (document.readyState !== "loading") init();
+  else document.addEventListener("DOMContentLoaded", init);
+})();

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -25,8 +25,10 @@ no-section-label = false
 #                custom.css); a no-op on the landing page and short pages.
 # header-ui.js — Pydantic-style header: relocates mdBook's search into the bar as
 #                an always-visible "Search ⌘K" pill + a single light/dark toggle.
+# ask-ai.js    — "Ask AI" menu in the header: opens the current page in Claude /
+#                ChatGPT / Perplexity / Grok / Gemini with a prefilled prompt.
 additional-css = ["custom.css", "learn-toggle.css"]
-additional-js = ["learn-toggle.js", "page-toc.js", "header-ui.js", "fs-flow.js", "mermaid.min.js", "mermaid-init.js"]
+additional-js = ["learn-toggle.js", "page-toc.js", "header-ui.js", "ask-ai.js", "fs-flow.js", "mermaid.min.js", "mermaid-init.js"]
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
Adds an **Ask AI** dropdown to the mdBook docs header. Each entry opens the *current* docs page in the chosen assistant with a prefilled prompt pointing at the page URL and the site's `llms.txt`.

**Providers:** Claude, ChatGPT, Perplexity, Grok, Gemini.

**Implementation**
- New self-contained `docs/book/ask-ai.js` (registered in `book.toml` `additional-js`), modeled on the existing `header-ui.js` — injects the control into `#mdbook-menu-bar`'s right buttons on load.
- Styled with mdBook's own theme variables (`--fg`, `--theme-popup-bg`, `--theme-hover`, …) so it follows light/dark automatically.
- Href built client-side from `window.location` so it always reflects the page being read; Gemini opens without a prefill (its query param is unreliable).
- A no-op if the menu bar is absent; guards against double-init.

Verified locally: `mdbook build` clean; the hashed `ask-ai.js` is emitted and referenced on all 76 generated pages.

This is the docs-site counterpart to the marketing-site "Ask AI" menu (separate repo).