### PR TITLE
fix(serve-ui): repair templates UI — actions row, search, sortable header

### DIFF
--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -313,6 +313,8 @@ button { font-family: inherit; }
   border-radius: var(--r);
   box-shadow: var(--shadow-1);
 }
+/* Fill the filter bar so the placeholder is never clipped. */
+.filters #t-search { flex: 1 1 auto; min-width: 0; }
 
 input, select, textarea {
   font-family: var(--font-sans);
@@ -797,7 +799,44 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 /* ============================================================================
    pipeline templates (#444)
    ========================================================================== */
-.tpl-row { grid-template-columns: 120px 1fr auto auto auto; }
+/* status · name · updated · live · newest · params — fixed meta widths so the
+   column header (a separate grid) lines up with the rows below it. */
+.tpl-row { grid-template-columns: 120px 1fr 175px 56px 64px 60px; }
+.tpl-list-head {
+  display: grid;
+  grid-template-columns: 120px 1fr 175px 56px 64px 60px;
+  align-items: center;
+  gap: 14px;
+  /* match .run-row content inset: 16px padding + 3px transparent left border */
+  padding: 2px 16px 6px;
+  border-left: 3px solid transparent;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.tpl-list-head .tpl-col-r { text-align: right; }
+/* Sortable column headers — look like the plain labels, but clickable. */
+.tpl-list-head .tpl-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.tpl-list-head .tpl-sort:hover { color: var(--ink); }
+.tpl-list-head .tpl-sort.is-active { color: var(--brand); }
+.tpl-list-head .tpl-sort.tpl-col-r { justify-content: flex-end; }
+.tpl-sort-caret { font-size: 0.9em; }
+.tpl-list-head .tpl-sort:not(.is-active) .tpl-sort-caret { opacity: 0.4; }
 .tpl-row-id { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .tpl-row-id b { font-weight: 600; font-size: 0.95rem; }
 .tpl-row-desc {
@@ -841,7 +880,7 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 .tpl-versions { display: flex; flex-direction: column; gap: 6px; }
 .tpl-version {
   display: grid;
-  grid-template-columns: 52px 1fr auto auto auto auto;
+  grid-template-columns: 52px 1fr auto auto auto auto auto;
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
@@ -887,4 +926,9 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 @media (max-width: 760px) {
   .tpl-version { grid-template-columns: 52px 1fr; row-gap: 8px; }
   .tpl-version .tpl-assign { max-width: none; }
+  /* The fixed column header can't line up once rows stack — hide it and let the
+     rows collapse to status + name with the meta wrapping below. */
+  .tpl-list-head { display: none; }
+  .tpl-row { grid-template-columns: auto 1fr; row-gap: 4px; }
+  .tpl-row .run-meta { text-align: left; }
 }

--- a/cli/src/serve/ui/views/templates.js
+++ b/cli/src/serve/ui/views/templates.js
@@ -44,14 +44,41 @@ export async function renderTemplates(container) {
         <input id="t-search" type="search" autocomplete="off"
           placeholder="search templates by id or description…" />
       </div>
+      <div class="tpl-list-head" id="t-list-head" hidden>
+        <button type="button" class="tpl-sort" data-sort="status">status<span class="tpl-sort-caret"></span></button>
+        <button type="button" class="tpl-sort" data-sort="name">name<span class="tpl-sort-caret"></span></button>
+        <button type="button" class="tpl-sort tpl-col-r" data-sort="updated">last updated<span class="tpl-sort-caret"></span></button>
+        <span class="tpl-col-r">live</span>
+        <span class="tpl-col-r">newest</span>
+        <span class="tpl-col-r">params</span>
+      </div>
       <div id="t-list" class="runs-list"></div>
     </div>`;
 
   const list = container.querySelector("#t-list");
   const registerHost = container.querySelector("#t-register");
   const filters = container.querySelector("#t-filters");
+  const listHead = container.querySelector("#t-list-head");
   const search = container.querySelector("#t-search");
   let all = [];
+
+  // Column sort. `col === null` keeps registry order (the default); clicking a
+  // sortable header sets the column and toggles asc/desc on repeat clicks.
+  const sort = { col: null, dir: 1 };
+  const STATUS_RANK = { launched: 0, draft: 1, deprecated: 2 };
+  const sortKey = {
+    status: (t) => STATUS_RANK[(t.state || {}).status] ?? 9,
+    name: (t) => (t.id || "").toLowerCase(),
+    updated: (t) => new Date(t.created_at || 0).getTime() || 0,
+  };
+  listHead.querySelectorAll(".tpl-sort").forEach((btn) => {
+    btn.onclick = () => {
+      const col = btn.dataset.sort;
+      if (sort.col === col) sort.dir *= -1;
+      else { sort.col = col; sort.dir = 1; }
+      render();
+    };
+  });
 
   container.querySelector("#t-new").onclick = () => {
     registerHost.hidden = !registerHost.hidden;
@@ -72,13 +99,33 @@ export async function renderTemplates(container) {
             (t.id || "").toLowerCase().includes(q) ||
             (t.description || "").toLowerCase().includes(q),
         )
-      : all;
+      : all.slice();
+    if (sort.col) {
+      const key = sortKey[sort.col];
+      rows.sort((a, b) => {
+        const av = key(a), bv = key(b);
+        return (av < bv ? -1 : av > bv ? 1 : 0) * sort.dir;
+      });
+    }
+    updateSortCarets();
     list.innerHTML = "";
+    listHead.hidden = !rows.length; // only show the column header when rows are shown
     if (!rows.length) {
       list.innerHTML = `<div class="empty">No templates match “${escapeHtml(search.value.trim())}”.</div>`;
       return;
     }
     for (const t of rows) list.appendChild(listRow(t));
+  }
+
+  // Reflect the active sort on the header: ▲/▼ on the sorted column, a faint ↕
+  // hint on the other sortable columns.
+  function updateSortCarets() {
+    listHead.querySelectorAll(".tpl-sort").forEach((btn) => {
+      const active = sort.col === btn.dataset.sort;
+      btn.classList.toggle("is-active", active);
+      btn.setAttribute("aria-sort", active ? (sort.dir > 0 ? "ascending" : "descending") : "none");
+      btn.querySelector(".tpl-sort-caret").textContent = active ? (sort.dir > 0 ? " ▲" : " ▼") : " ↕";
+    });
   }
 
   async function load() {
@@ -88,6 +135,7 @@ export async function renderTemplates(container) {
       list.innerHTML = "";
       if (!all.length) {
         filters.hidden = true;
+        listHead.hidden = true;
         list.innerHTML = `<div class="empty">No templates registered yet — register one to give operators a parameterized, versioned pipeline to trigger.</div>`;
         return;
       }
@@ -95,6 +143,7 @@ export async function renderTemplates(container) {
       render(); // keeps any active search term across a refresh
     } catch (e) {
       filters.hidden = true;
+      listHead.hidden = true;
       if (templatesUnavailable(e)) list.innerHTML = `<div class="empty">${TEMPLATES_MISSING}</div>`;
       else toast(e.message, "error");
     }
@@ -116,9 +165,10 @@ function listRow(t) {
       <b class="mono">${escapeHtml(t.id)}</b>
       ${t.description ? `<span class="tpl-row-desc">${escapeHtml(t.description)}</span>` : ""}
     </span>
-    <span class="run-meta" title="live version — what an unpinned run uses">live ${live}</span>
-    <span class="run-meta" title="newest registered build">newest v${st.newest ?? t.version}</span>
-    <span class="run-meta">${params} param${params === 1 ? "" : "s"}</span>`;
+    <span class="run-meta" title="last registered / updated">${fmtTime(t.created_at)}</span>
+    <span class="run-meta" title="live version — what an unpinned run uses">${live}</span>
+    <span class="run-meta" title="newest registered build">v${st.newest ?? t.version}</span>
+    <span class="run-meta" title="declared params">${params}</span>`;
   return el;
 }
 


### PR DESCRIPTION
Fixes a layout regression introduced by the clean-config work (#590) plus two list-view improvements requested during review.

### Detail view — version actions row
Adding the `Clean` button made the row have 7 items, but `.tpl-version` was a 6-column grid, so grid auto-placement pushed **Delete** onto its own line, left-aligned under the version. Added the 7th column → Delete sits back in the button row.

### List view
- **Search:** the input now fills the filter bar (`flex: 1`) — the placeholder is no longer clipped.
- **Column header row:** `status · name · last updated · live · newest · params`, with fixed meta-column widths so the header (a separate grid) lines up over the rows. Redundant inline labels dropped from the cells ("live v1" → "v1").
- **"last updated" column:** from each template's `created_at` (newest version's registration time).
- **Sortable headers:** status, name, and last-updated are clickable — `↕` affordance, active column turns teal with `▲`/`▼`, click toggles asc/desc. Client-side over the loaded set (no server round-trip). Status sorts by rank (launched → draft → deprecated).

Only `cli/src/serve/ui/{styles.css,views/templates.js}` change → CI takes the `ui` fast-path. Verified: `node --check` on the JS, balanced CSS, and a rendered screenshot of the list (header aligned, search full-width, single status dot, sort carets).