### PR TITLE
feat(serve-ui): themed date picker, dropdown chevrons, and schema/template polish

### DIFF
--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -333,6 +333,81 @@ input:focus, select:focus, textarea:focus {
 }
 input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 
+/* Themed select: drop the native arrow for a custom chevron with real breathing
+   room on the right, so it stops crowding the border. */
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 30px;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='14'%20height='14'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='%2351616b'%20stroke-width='2.2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M6%209l6%206%206-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 11px center;
+  background-size: 14px;
+  cursor: pointer;
+}
+[data-theme="dark"] select {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='14'%20height='14'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='%2393a7a3'%20stroke-width='2.2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M6%209l6%206%206-6'/%3E%3C/svg%3E");
+}
+@media (prefers-color-scheme: dark) {
+  [data-theme="auto"] select {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='14'%20height='14'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='%2393a7a3'%20stroke-width='2.2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M6%209l6%206%206-6'/%3E%3C/svg%3E");
+  }
+}
+
+/* ============================================================================
+   date-time picker (themed replacement for the native datetime-local popup)
+   ========================================================================== */
+.date-input { cursor: pointer; min-width: 168px; }
+.dp-pop {
+  position: fixed;
+  z-index: 400;
+  width: 268px;
+  padding: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.22);
+  font-size: 0.85rem;
+  color: var(--ink);
+}
+.dp-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.dp-title { font-weight: 650; }
+.dp-nav {
+  display: inline-grid; place-items: center;
+  width: 26px; height: 26px; border-radius: 7px;
+  border: 1px solid var(--border); background: var(--surface-2);
+  color: var(--ink-dim); cursor: pointer; font-size: 1rem; line-height: 1;
+}
+.dp-nav:hover { color: var(--ink); border-color: var(--border-strong); }
+.dp-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+.dp-wd { margin-bottom: 2px; }
+.dp-wdc { text-align: center; font-size: 0.68rem; color: var(--ink-faint); padding: 2px 0; }
+.dp-day {
+  aspect-ratio: 1 / 1; border: 0; background: transparent; cursor: pointer;
+  border-radius: 7px; color: var(--ink); font-size: 0.82rem;
+  font-family: var(--font-sans);
+  transition: background 0.12s, color 0.12s;
+}
+.dp-day:hover { background: var(--surface-sunken); }
+.dp-muted { color: var(--ink-faint); }
+.dp-today-c { box-shadow: inset 0 0 0 1px var(--brand-ring); }
+.dp-sel { background: var(--brand); color: #fff; font-weight: 600; }
+.dp-sel:hover { background: var(--brand-strong); }
+.dp-time { display: flex; align-items: center; gap: 6px; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border); }
+.dp-time-lbl { font-size: 0.72rem; color: var(--ink-faint); text-transform: uppercase; letter-spacing: 0.04em; margin-right: auto; }
+.dp-time input { width: 46px; text-align: center; padding: 5px 4px; }
+.dp-colon { color: var(--ink-dim); }
+.dp-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 10px; }
+.dp-foot-r { display: flex; gap: 6px; }
+.dp-clear, .dp-today, .dp-done {
+  border: 1px solid var(--border); background: var(--surface-2); color: var(--ink-dim);
+  border-radius: var(--r-sm); padding: 5px 11px; font-size: 0.8rem; cursor: pointer;
+  font-family: var(--font-sans);
+}
+.dp-clear:hover, .dp-today:hover { color: var(--ink); border-color: var(--border-strong); }
+.dp-done { background: var(--brand); border-color: var(--brand); color: #fff; font-weight: 550; }
+.dp-done:hover { background: var(--brand-strong); border-color: var(--brand-strong); }
+
 /* ============================================================================
    runs list
    ========================================================================== */
@@ -436,6 +511,9 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 /* tables */
 .tbl {
   width: 100%;
+  /* Fixed layout + wrapping so a long description column can't force the table
+     wider than its card (was overflowing the boundary). */
+  table-layout: fixed;
   border-collapse: collapse;
   font-size: 0.84rem;
   background: var(--surface);
@@ -443,6 +521,10 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
   border-radius: var(--r);
   overflow: hidden;
 }
+.tbl th, .tbl td { overflow-wrap: anywhere; }
+.tbl th:nth-child(1), .tbl td:nth-child(1) { width: 26%; }
+.tbl th:nth-child(2), .tbl td:nth-child(2) { width: 14%; }
+.tbl th:nth-child(3), .tbl td:nth-child(3) { width: 12%; }
 .tbl th {
   text-align: left;
   font-size: 0.72rem;
@@ -583,7 +665,11 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
   font-family: var(--font-mono);
   font-size: 0.8rem;
   color: var(--ink-dim);
-  padding-top: 7px;
+  /* Center the label against the input's height so their text lines up, instead
+     of pinning it to the top while the input text sits centered. */
+  min-height: 34px;
+  display: flex;
+  align-items: center;
   word-break: break-word;
 }
 .sf-field input:not([type="checkbox"]),
@@ -622,6 +708,20 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
   overflow: auto;
   padding-right: 4px;
 }
+.schema-note {
+  margin: 0 0 14px; padding: 9px 11px;
+  background: var(--surface-2); border: 1px solid var(--border);
+  border-radius: var(--r-sm); font-size: 0.74rem; line-height: 1.5; color: var(--ink-dim);
+}
+.schema-note b { color: var(--ink); font-weight: 600; }
+.schema-note code { font-size: 0.92em; }
+.schema-state-list { display: flex; flex-direction: column; gap: 6px; }
+.schema-state {
+  padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+.schema-state b { font-size: 0.82rem; color: var(--ink); }
+.schema-state span { display: block; margin-top: 2px; font-size: 0.72rem; line-height: 1.45; color: var(--ink-faint); }
 .schema-group { display: flex; flex-direction: column; gap: 3px; }
 .schema-item {
   appearance: none;
@@ -921,7 +1021,10 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 }
 .tpl-params { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px 18px; }
 .tpl-param { display: flex; flex-direction: column; gap: 5px; }
-.tpl-param-name { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; font-size: 0.82rem; }
+.tpl-param-name { font-size: 0.82rem; font-weight: 600; color: var(--ink); }
+/* Tags sit on their own row beneath the variable name, and are a touch smaller. */
+.tpl-param-tags { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin-bottom: 1px; }
+.tpl-param-tags .pill { font-size: 0.6rem; padding: 1px 7px; }
 
 @media (max-width: 760px) {
   .tpl-version { grid-template-columns: 52px 1fr; row-gap: 8px; }

--- a/cli/src/serve/ui/views/date-picker.js
+++ b/cli/src/serve/ui/views/date-picker.js
@@ -1,0 +1,183 @@
+// Themed date-time picker. The browser-native datetime-local popup can't be
+// styled, so we replace it with our own calendar + time UI. Presentation only:
+// the chosen value is written raw (YYYY-MM-DDTHH:mm, local) to
+// `input.dataset.value` — exactly what `new Date(...)` already consumes upstream
+// — and shown human-friendly in `input.value`. A "change" event fires on apply
+// and clear so callers can react. Safe to drop in: no value-format change.
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+const WD = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+const pad = (n) => String(n).padStart(2, "0");
+const sameDay = (a, b) =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+function toRaw(d) {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+function toDisplay(d) {
+  return `${pad(d.getDate())} ${MONTHS[d.getMonth()].slice(0, 3)} ${d.getFullYear()}, ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+function parseRaw(s) {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Turn a readonly text input into a themed date-time picker.
+ * @param {HTMLInputElement} input
+ */
+export function attachDatePicker(input) {
+  let popup = null;
+  let view = parseRaw(input.dataset.value) || new Date();
+  // The in-progress selection while the popup is open (committed on "Done").
+  let pending = parseRaw(input.dataset.value);
+
+  const isOpen = () => popup !== null;
+
+  function commit(date) {
+    if (date) {
+      input.dataset.value = toRaw(date);
+      input.value = toDisplay(date);
+    } else {
+      input.dataset.value = "";
+      input.value = "";
+    }
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function timeFromInputs() {
+    if (!popup) return { h: 0, m: 0 };
+    const h = Math.min(23, Math.max(0, parseInt(popup.querySelector(".dp-h").value, 10) || 0));
+    const m = Math.min(59, Math.max(0, parseInt(popup.querySelector(".dp-m").value, 10) || 0));
+    return { h, m };
+  }
+
+  function dayCell(d, muted, today) {
+    const cls = ["dp-day"];
+    if (muted) cls.push("dp-muted");
+    if (pending && sameDay(d, pending)) cls.push("dp-sel");
+    if (sameDay(d, today)) cls.push("dp-today-c");
+    return `<button type="button" class="${cls.join(" ")}" data-d="${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}">${d.getDate()}</button>`;
+  }
+
+  function render() {
+    const y = view.getFullYear();
+    const m = view.getMonth();
+    const startWd = new Date(y, m, 1).getDay();
+    const daysInMonth = new Date(y, m + 1, 0).getDate();
+    const today = new Date();
+    let cells = "";
+    for (let i = 0; i < startWd; i++) {
+      cells += dayCell(new Date(y, m, 1 - (startWd - i)), true, today);
+    }
+    for (let day = 1; day <= daysInMonth; day++) {
+      cells += dayCell(new Date(y, m, day), false, today);
+    }
+    const filled = startWd + daysInMonth;
+    for (let i = 1; i <= 42 - filled; i++) {
+      cells += dayCell(new Date(y, m + 1, i), true, today);
+    }
+    const t = pending || new Date();
+    popup.innerHTML = `
+      <div class="dp-head">
+        <button type="button" class="dp-nav" data-nav="-1" aria-label="Previous month">‹</button>
+        <span class="dp-title">${MONTHS[m]} ${y}</span>
+        <button type="button" class="dp-nav" data-nav="1" aria-label="Next month">›</button>
+      </div>
+      <div class="dp-grid dp-wd">${WD.map((w) => `<span class="dp-wdc">${w}</span>`).join("")}</div>
+      <div class="dp-grid dp-days">${cells}</div>
+      <div class="dp-time">
+        <span class="dp-time-lbl">Time</span>
+        <input class="dp-h" type="number" min="0" max="23" value="${pad(t.getHours())}" aria-label="Hour" />
+        <span class="dp-colon">:</span>
+        <input class="dp-m" type="number" min="0" max="59" value="${pad(t.getMinutes())}" aria-label="Minute" />
+      </div>
+      <div class="dp-foot">
+        <button type="button" class="dp-clear">Clear</button>
+        <div class="dp-foot-r">
+          <button type="button" class="dp-today">Today</button>
+          <button type="button" class="dp-done">Done</button>
+        </div>
+      </div>`;
+
+    popup.querySelectorAll(".dp-nav").forEach((b) => {
+      b.onclick = () => { view = new Date(y, m + Number(b.dataset.nav), 1); render(); };
+    });
+    popup.querySelectorAll(".dp-day").forEach((b) => {
+      b.onclick = () => {
+        const [yy, mm, dd] = b.dataset.d.split("-").map(Number);
+        const { h, m: mi } = timeFromInputs();
+        pending = new Date(yy, mm - 1, dd, h, mi);
+        view = new Date(yy, mm - 1, 1);
+        render();
+      };
+    });
+    const syncTime = () => {
+      const { h, m: mi } = timeFromInputs();
+      pending = pending || new Date();
+      pending.setHours(h, mi, 0, 0);
+    };
+    popup.querySelector(".dp-h").onchange = syncTime;
+    popup.querySelector(".dp-m").onchange = syncTime;
+    popup.querySelector(".dp-clear").onclick = () => { pending = null; commit(null); close(); };
+    popup.querySelector(".dp-today").onclick = () => {
+      pending = new Date(); pending.setSeconds(0, 0); view = new Date(); render();
+    };
+    popup.querySelector(".dp-done").onclick = () => { commit(pending); close(); };
+  }
+
+  function place() {
+    const r = input.getBoundingClientRect();
+    popup.style.top = `${r.bottom + 6}px`;
+    let left = r.left;
+    const pw = popup.offsetWidth;
+    if (left + pw > window.innerWidth - 8) left = Math.max(8, window.innerWidth - pw - 8);
+    popup.style.left = `${left}px`;
+  }
+
+  function open() {
+    if (isOpen()) return;
+    pending = parseRaw(input.dataset.value);
+    view = pending ? new Date(pending) : new Date();
+    popup = document.createElement("div");
+    popup.className = "dp-pop";
+    document.body.appendChild(popup);
+    render();
+    place();
+    // defer so the opening click doesn't immediately close it
+    setTimeout(() => document.addEventListener("mousedown", onOutside), 0);
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    document.addEventListener("keydown", onKey);
+  }
+
+  function close() {
+    if (!isOpen()) return;
+    document.removeEventListener("mousedown", onOutside);
+    window.removeEventListener("resize", place);
+    window.removeEventListener("scroll", place, true);
+    document.removeEventListener("keydown", onKey);
+    popup.remove();
+    popup = null;
+  }
+
+  function onOutside(e) {
+    if (popup && !popup.contains(e.target) && e.target !== input) close();
+  }
+  function onKey(e) {
+    if (e.key === "Escape") { close(); input.focus(); }
+  }
+
+  input.readOnly = true;
+  input.addEventListener("click", () => (isOpen() ? close() : open()));
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") { e.preventDefault(); open(); }
+  });
+}

--- a/cli/src/serve/ui/views/runs.js
+++ b/cli/src/serve/ui/views/runs.js
@@ -1,6 +1,7 @@
 import { api, toast } from "../api.js";
 import { navigate } from "../router.js";
 import { escapeHtml } from "../utils.js";
+import { attachDatePicker } from "./date-picker.js";
 
 const STATUSES = ["", "queued", "running", "completed", "failed", "cancelled"];
 
@@ -18,8 +19,8 @@ export async function renderRuns(container) {
       <div class="filters">
         <select id="f-status">${STATUSES.map((s) => `<option value="${s}">${s || "all statuses"}</option>`).join("")}</select>
         <input id="f-name" placeholder="name" />
-        <input id="f-since" type="datetime-local" />
-        <input id="f-until" type="datetime-local" />
+        <input id="f-since" class="date-input" type="text" readonly placeholder="from…" />
+        <input id="f-until" class="date-input" type="text" readonly placeholder="to…" />
         <button class="btn-ghost" id="f-apply">Apply</button>
         <button class="btn-ghost" id="f-refresh">↻</button>
       </div>
@@ -29,6 +30,8 @@ export async function renderRuns(container) {
 
   const list = container.querySelector("#runs-list");
   container.querySelector("#r-submit").onclick = () => navigate("#/submit");
+  attachDatePicker(container.querySelector("#f-since"));
+  attachDatePicker(container.querySelector("#f-until"));
 
   function query(reset) {
     if (reset) cursor = null;
@@ -66,8 +69,8 @@ export async function renderRuns(container) {
     filters = {
       status: container.querySelector("#f-status").value,
       name: container.querySelector("#f-name").value.trim(),
-      since: container.querySelector("#f-since").value,
-      until: container.querySelector("#f-until").value,
+      since: container.querySelector("#f-since").dataset.value || "",
+      until: container.querySelector("#f-until").dataset.value || "",
     };
     load(true);
   };

--- a/cli/src/serve/ui/views/schemas.js
+++ b/cli/src/serve/ui/views/schemas.js
@@ -5,6 +5,17 @@ export async function renderSchemas(container) {
   let catalog = { sources: [], sinks: [], transforms: [], state: [] };
   try { catalog = await api("/v1/schemas"); } catch (e) { toast(e.message, "error"); }
 
+  // State stores have no per-connector JSON schema (they're simple kinds), so we
+  // show a short description instead of a clickable schema link. Unknown kinds
+  // fall back to just the name.
+  const STATE_DESC = {
+    memory: "In-process only — checkpoints last for the run; nothing survives a restart.",
+    file: "Local file — durable checkpoints via fsync + atomic rename.",
+    redis: "Redis — shared checkpoints; durability follows your Redis persistence config.",
+    postgres: "Postgres table — durable checkpoints, upserted per commit.",
+    sqlite: "Local SQLite — durable checkpoints in a single file.",
+  };
+
   const group = (title, kind, items) =>
     `<div class="schema-group"><h3>${title}</h3>${items
       .map((i) => `<button class="schema-item" data-kind="${kind}" data-name="${escapeHtml(i.name)}" title="${escapeHtml(i.description)}">${escapeHtml(i.name)}</button>`)
@@ -13,10 +24,15 @@ export async function renderSchemas(container) {
   container.innerHTML = `
     <div class="page schemas-page">
       <aside class="schema-list">
+        <p class="schema-note">Showing the <b>${catalog.sources.length} source${catalog.sources.length === 1 ? "" : "s"}</b> and <b>${catalog.sinks.length} sink${catalog.sinks.length === 1 ? "" : "s"}</b> built into this server. Rebuild with more Cargo features (e.g. <code>--features full</code>) to enable the rest.</p>
         ${group("Sources", "source", catalog.sources)}
         ${group("Sinks", "sink", catalog.sinks)}
         ${group("Transforms", "transform", catalog.transforms)}
-        <div class="schema-group"><h3>State stores</h3>${catalog.state.map((s) => `<span class="tag">${escapeHtml(s)}</span>`).join("")}</div>
+        <div class="schema-group"><h3>State stores</h3>
+          <div class="schema-state-list">
+            ${catalog.state.map((s) => `<div class="schema-state"><b class="mono">${escapeHtml(s)}</b>${STATE_DESC[s] ? `<span>${escapeHtml(STATE_DESC[s])}</span>` : ""}</div>`).join("")}
+          </div>
+        </div>
       </aside>
       <section id="schema-view" class="schema-view"><div class="empty">Select a connector to view its schema.</div></section>
     </div>`;

--- a/cli/src/serve/ui/views/templates.js
+++ b/cli/src/serve/ui/views/templates.js
@@ -335,7 +335,7 @@ function renderVersions(host, id, st, d, reload) {
       <span class="tpl-vnum mono">v${v}</span>
       <span class="tpl-vchannels">${pills || `<span class="run-meta">no channel</span>`}</span>
       <select class="tpl-assign" title="point a channel at v${v}">
-        <option value="">assign channel…</option>
+        <option value="">assign channel</option>
         ${ASSIGNABLE.map((c) => `<option value="${c}">${c}</option>`).join("")}
       </select>
       <button class="btn-ghost tpl-launch" ${st.stable === v ? "disabled" : ""}
@@ -442,10 +442,12 @@ function renderTrigger(host, id, st, d) {
         : `<input data-name="${escapeHtml(name)}" ${p.secret ? 'type="password"' : type === "int" || type === "float" ? 'type="number"' : ""}
              placeholder="${p.default !== undefined && p.default !== null ? escapeHtml(String(p.default)) : type}" />`;
     field.innerHTML = `
-      <span class="tpl-param-name mono">${escapeHtml(name)}
+      <span class="tpl-param-name mono">${escapeHtml(name)}</span>
+      <span class="tpl-param-tags">
         <span class="pill">${escapeHtml(type)}</span>
         ${p.required ? `<span class="pill pill-failed">required</span>` : ""}
-        ${p.secret ? `<span class="pill pill-cancelled">secret</span>` : ""}</span>
+        ${p.secret ? `<span class="pill pill-cancelled">secret</span>` : ""}
+      </span>
       ${input}
       ${p.description ? `<span class="help">${escapeHtml(p.description)}</span>` : ""}`;
     paramHost.appendChild(field);


### PR DESCRIPTION
A batch of web-console UI fixes (all under `cli/src/serve/ui/**` → CI `ui` fast-path). Each verified with a rendered screenshot.

- **Dropdown chevrons** — every `<select>` (Runs status filter, submit-page `format`, schema-form) gets a themed chevron with real right-padding, instead of the native arrow crammed against the border.
- **Themed date-time picker** — the native `datetime-local` popup can't be CSS-styled, so the Runs filter now uses a custom calendar + time picker matching the theme. Presentation-only: it writes the same `YYYY-MM-DDTHH:mm` value the query path already parses (verified: picking a day yields e.g. `20 Aug 2026, 11:38`).
- **Submit-page form** — field labels are vertically centered against their inputs.
- **Templates trigger form** — each param's `type`/`required`/`secret` tags move below the variable name at a smaller size.
- **"assign channel…"** → drop the stray ellipsis.
- **Schemas page** — table no longer overflows its card (`table-layout: fixed` + wrap); a note clarifies the list reflects connectors compiled into this build; state stores show a short description instead of bare, unclickable names.

Verified via preview harness using the real `styles.css` + `date-picker.js` (themed picker, centered labels, tags-below-name, schema table wrapping, note).