### PR TITLE
feat(serve-ui): timezone selector, templates sort/filter, inline-markdown descriptions + polish

### DIFF
--- a/cli/src/serve/ui/app.js
+++ b/cli/src/serve/ui/app.js
@@ -1,5 +1,6 @@
 import { token, onUnauthorized, authOk } from "./api.js";
-import { startRouter, navigate } from "./router.js";
+import { startRouter, navigate, refresh } from "./router.js";
+import { getTz, setTz, TZ_OPTIONS } from "./tz.js";
 import { renderRuns } from "./views/runs.js";
 import { renderDetail } from "./views/detail.js";
 import { renderSubmit } from "./views/submit.js";
@@ -42,6 +43,16 @@ function wireChrome() {
     const cur = document.documentElement.dataset.theme;
     applyTheme(cur === "dark" ? "light" : cur === "light" ? "auto" : "dark");
   };
+  // Display-timezone selector: populate, reflect the saved choice, and re-render
+  // the current view (all timestamps + the date picker follow it) on change.
+  const tzSel = document.getElementById("tz-select");
+  if (tzSel) {
+    tzSel.innerHTML = TZ_OPTIONS.map(
+      (o) => `<option value="${o.value}">${o.label}</option>`,
+    ).join("");
+    tzSel.value = getTz();
+    tzSel.onchange = () => { setTz(tzSel.value); refresh(); };
+  }
   document.getElementById("token-btn").onclick = openTokenModal;
   document.getElementById("token-save").onclick = () => {
     const v = document.getElementById("token-input").value.trim();

--- a/cli/src/serve/ui/index.html
+++ b/cli/src/serve/ui/index.html
@@ -22,6 +22,7 @@
         <button id="nav-lineage">Lineage</button>
       </nav>
       <div class="spacer"></div>
+      <select id="tz-select" class="tz-select" title="Display timezone — how all times are shown"></select>
       <button id="theme-toggle" class="icon-btn" title="Toggle theme">◐</button>
       <button id="token-btn" class="icon-btn" title="Access token">🔑</button>
     </header>

--- a/cli/src/serve/ui/router.js
+++ b/cli/src/serve/ui/router.js
@@ -2,6 +2,7 @@
 // teardown() (used to stop log streams / polling on navigation).
 const routes = [];
 let teardown = null;
+let rootContainer = null;
 
 export function route(pattern, render) {
   // pattern like "#/runs/:id" → regex with named groups
@@ -40,6 +41,12 @@ async function dispatch(container) {
 }
 
 export function startRouter(container) {
+  rootContainer = container;
   window.addEventListener("hashchange", () => dispatch(container));
   dispatch(container);
+}
+
+/** Re-render the current route in place (e.g. after a timezone-preference change). */
+export function refresh() {
+  if (rootContainer) dispatch(rootContainer);
 }

--- a/cli/src/serve/ui/schema-form.js
+++ b/cli/src/serve/ui/schema-form.js
@@ -4,7 +4,7 @@
 // "type" discriminator (the {type,config} auth pattern). Anything else falls
 // back to a raw-JSON textarea so no config is ever unreachable.
 
-import { escapeHtml } from "./utils.js";
+import { escapeHtml, mdInline } from "./utils.js";
 
 function resolveRef(schema, root) {
   if (schema && schema.$ref) {
@@ -19,7 +19,7 @@ function resolveRef(schema, root) {
 // Build a control for `schema`; returns { el, read() }.
 function build(schema, root, value, required) {
   schema = resolveRef(schema, root) || {};
-  const desc = schema.description ? `<small class="help">${escapeHtml(firstSentence(schema.description))}</small>` : "";
+  const desc = schema.description ? `<small class="help">${mdInline(firstSentence(schema.description))}</small>` : "";
 
   // Discriminated union: oneOf/anyOf whose branches each fix a `type` const.
   const variants = schema.oneOf || schema.anyOf;

--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -333,6 +333,9 @@ input:focus, select:focus, textarea:focus {
 }
 input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 
+/* Timezone selector in the topbar — compact; inherits the themed chevron below. */
+.tz-select { font-size: 0.8rem; max-width: 190px; padding-top: 5px; padding-bottom: 5px; background: transparent; }
+
 /* Themed select: drop the native arrow for a custom chevron with real breathing
    room on the right, so it stops crowding the border. */
 select {
@@ -395,6 +398,7 @@ select {
 .dp-sel:hover { background: var(--brand-strong); }
 .dp-time { display: flex; align-items: center; gap: 6px; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border); }
 .dp-time-lbl { font-size: 0.72rem; color: var(--ink-faint); text-transform: uppercase; letter-spacing: 0.04em; margin-right: auto; }
+.dp-tz { text-transform: none; letter-spacing: 0; opacity: 0.85; }
 .dp-time input { width: 46px; text-align: center; padding: 5px 4px; }
 .dp-colon { color: var(--ink-dim); }
 .dp-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 10px; }
@@ -688,6 +692,9 @@ select {
 .sf-raw { width: 100%; min-height: 64px; font-family: var(--font-mono); font-size: 0.8rem; }
 
 .help { display: block; color: var(--ink-faint); font-size: 0.74rem; margin-top: 4px; line-height: 1.4; }
+/* Align the description under the input's text (input has a ~11px inset: 1px
+   border + 10px padding), so it doesn't hang to the left of the field. */
+.sf-field .help { padding-left: 11px; }
 
 /* ============================================================================
    schema explorer
@@ -709,11 +716,11 @@ select {
   padding-right: 4px;
 }
 .schema-note {
-  margin: 0 0 14px; padding: 9px 11px;
-  background: var(--surface-2); border: 1px solid var(--border);
-  border-radius: var(--r-sm); font-size: 0.74rem; line-height: 1.5; color: var(--ink-dim);
+  margin: 0 0 16px; padding: 2px 0 2px 10px;
+  border-left: 2px solid var(--brand-ring);
+  font-size: 0.72rem; line-height: 1.5; color: var(--ink-faint);
 }
-.schema-note b { color: var(--ink); font-weight: 600; }
+.schema-note b { color: var(--ink-dim); font-weight: 600; }
 .schema-note code { font-size: 0.92em; }
 .schema-state-list { display: flex; flex-direction: column; gap: 6px; }
 .schema-state {
@@ -1025,6 +1032,16 @@ select {
 /* Tags sit on their own row beneath the variable name, and are a touch smaller. */
 .tpl-param-tags { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin-bottom: 1px; }
 .tpl-param-tags .pill { font-size: 0.6rem; padding: 1px 7px; }
+
+/* Status filter chips on the templates list (multi-toggle; launched+draft on by default). */
+.tpl-status-filter { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.tpl-chip {
+  border: 1px solid var(--border); background: var(--surface-2); color: var(--ink-faint);
+  border-radius: 999px; padding: 5px 12px; font-size: 0.78rem; cursor: pointer;
+  font-family: var(--font-sans); transition: color 0.14s, background 0.14s, border-color 0.14s;
+}
+.tpl-chip:hover { color: var(--ink); border-color: var(--border-strong); }
+.tpl-chip.is-on { background: var(--brand-tint); border-color: var(--brand-ring); color: var(--brand); font-weight: 550; }
 
 @media (max-width: 760px) {
   .tpl-version { grid-template-columns: 52px 1fr; row-gap: 8px; }

--- a/cli/src/serve/ui/tz.js
+++ b/cli/src/serve/ui/tz.js
@@ -1,0 +1,88 @@
+// UI timezone preference. Data is ALWAYS UTC on the wire — this module only
+// controls how timestamps are *displayed* and how the date picker interprets an
+// entered wall-clock time. Default is the browser's local zone. Persisted in
+// localStorage so it survives reloads (like the theme toggle).
+
+const KEY = "faucet-tz";
+
+export function getTz() {
+  try { return localStorage.getItem(KEY) || "local"; } catch { return "local"; }
+}
+export function setTz(z) {
+  try { localStorage.setItem(KEY, z); } catch { /* ignore */ }
+}
+
+const LOCAL_ZONE = (() => {
+  try { return Intl.DateTimeFormat().resolvedOptions().timeZone || ""; } catch { return ""; }
+})();
+
+/** Curated zone list for the selector (Local first, then UTC, then a spread). */
+export const TZ_OPTIONS = [
+  { value: "local", label: `Local${LOCAL_ZONE ? ` — ${LOCAL_ZONE}` : ""}` },
+  { value: "UTC", label: "UTC" },
+  { value: "America/Los_Angeles", label: "Los Angeles" },
+  { value: "America/New_York", label: "New York" },
+  { value: "Europe/London", label: "London" },
+  { value: "Europe/Berlin", label: "Berlin" },
+  { value: "Asia/Kolkata", label: "Kolkata" },
+  { value: "Asia/Singapore", label: "Singapore" },
+  { value: "Asia/Tokyo", label: "Tokyo" },
+  { value: "Australia/Sydney", label: "Sydney" },
+];
+
+/** Short label for inline hints (e.g. the picker's TIME row). */
+export function tzShort() {
+  const tz = getTz();
+  return tz === "local" ? "local" : tz;
+}
+
+const zoneOpt = (tz) => (tz === "local" ? {} : { timeZone: tz });
+
+/** Format a UTC/ISO value for display in the selected zone. "—" if empty/invalid. */
+export function formatTs(value) {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "—";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: true,
+      ...zoneOpt(getTz()),
+    }).format(d);
+  } catch {
+    return d.toLocaleString();
+  }
+}
+
+function partsInZone(date, tz, withSeconds) {
+  const p = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", ...(withSeconds ? { second: "2-digit" } : {}),
+    hour12: false,
+  }).formatToParts(date).reduce((a, x) => { a[x.type] = x.value; return a; }, {});
+  return p;
+}
+
+/**
+ * Interpret a wall-clock (fields as the user typed them, in the selected zone)
+ * as a real UTC instant. For "local" this is just `new Date(...)`; for a named
+ * zone it computes that zone's offset at the instant and corrects for it.
+ */
+export function zonedWallToUtc(y, mo, d, h, mi) {
+  const tz = getTz();
+  if (tz === "local") return new Date(y, mo, d, h, mi);
+  const asUtc = Date.UTC(y, mo, d, h, mi);
+  const p = partsInZone(new Date(asUtc), tz, true);
+  const shown = Date.UTC(+p.year, +p.month - 1, +p.day, +p.hour % 24, +p.minute, +p.second);
+  return new Date(asUtc - (shown - asUtc)); // subtract the zone's offset
+}
+
+/** UTC Date → the wall-clock fields it shows as in the selected zone (for reopening). */
+export function utcToZonedWall(date) {
+  const tz = getTz();
+  if (tz === "local") {
+    return { y: date.getFullYear(), mo: date.getMonth(), d: date.getDate(), h: date.getHours(), mi: date.getMinutes() };
+  }
+  const p = partsInZone(date, tz, false);
+  return { y: +p.year, mo: +p.month - 1, d: +p.day, h: +p.hour % 24, mi: +p.minute };
+}

--- a/cli/src/serve/ui/utils.js
+++ b/cli/src/serve/ui/utils.js
@@ -7,3 +7,14 @@ export function escapeHtml(s) {
     (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
   );
 }
+
+/**
+ * Render the minimal inline markdown used in connector descriptions — `**bold**`
+ * and `` `code` `` — as safe HTML. The text is HTML-escaped first, then our own
+ * tags are injected, so it never introduces markup from the source string.
+ */
+export function mdInline(s) {
+  return escapeHtml(s)
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/`([^`]+)`/g, "<code>$1</code>");
+}

--- a/cli/src/serve/ui/views/date-picker.js
+++ b/cli/src/serve/ui/views/date-picker.js
@@ -5,10 +5,15 @@
 // — and shown human-friendly in `input.value`. A "change" event fires on apply
 // and clear so callers can react. Safe to drop in: no value-format change.
 
+import { zonedWallToUtc, utcToZonedWall, tzShort } from "../tz.js";
+
 const MONTHS = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
 ];
+
+// A naive Date holding wall-clock fields (used only for calendar/time display).
+const wallFromZoned = ({ y, mo, d, h, mi }) => new Date(y, mo, d, h, mi);
 const WD = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
 const pad = (n) => String(n).padStart(2, "0");
@@ -43,7 +48,14 @@ export function attachDatePicker(input) {
 
   function commit(date) {
     if (date) {
-      input.dataset.value = toRaw(date);
+      // `date` holds the wall-clock the user picked (in the selected zone). Store
+      // the true UTC instant so the query path sends the right time regardless of
+      // the display zone; show the entered wall-clock in the field.
+      const utc = zonedWallToUtc(
+        date.getFullYear(), date.getMonth(), date.getDate(),
+        date.getHours(), date.getMinutes(),
+      );
+      input.dataset.value = utc.toISOString();
       input.value = toDisplay(date);
     } else {
       input.dataset.value = "";
@@ -94,7 +106,7 @@ export function attachDatePicker(input) {
       <div class="dp-grid dp-wd">${WD.map((w) => `<span class="dp-wdc">${w}</span>`).join("")}</div>
       <div class="dp-grid dp-days">${cells}</div>
       <div class="dp-time">
-        <span class="dp-time-lbl">Time</span>
+        <span class="dp-time-lbl">Time <span class="dp-tz">· ${tzShort()}</span></span>
         <input class="dp-h" type="number" min="0" max="23" value="${pad(t.getHours())}" aria-label="Hour" />
         <span class="dp-colon">:</span>
         <input class="dp-m" type="number" min="0" max="59" value="${pad(t.getMinutes())}" aria-label="Minute" />
@@ -144,7 +156,9 @@ export function attachDatePicker(input) {
 
   function open() {
     if (isOpen()) return;
-    pending = parseRaw(input.dataset.value);
+    // Stored value is a UTC instant — show it as the wall-clock in the selected zone.
+    const utc = parseRaw(input.dataset.value);
+    pending = utc ? wallFromZoned(utcToZonedWall(utc)) : null;
     view = pending ? new Date(pending) : new Date();
     popup = document.createElement("div");
     popup.className = "dp-pop";

--- a/cli/src/serve/ui/views/runs.js
+++ b/cli/src/serve/ui/views/runs.js
@@ -2,6 +2,7 @@ import { api, toast } from "../api.js";
 import { navigate } from "../router.js";
 import { escapeHtml } from "../utils.js";
 import { attachDatePicker } from "./date-picker.js";
+import { formatTs } from "../tz.js";
 
 const STATUSES = ["", "queued", "running", "completed", "failed", "cancelled"];
 
@@ -96,6 +97,5 @@ function row(r) {
 }
 
 export function fmtTime(s) {
-  if (!s) return "—";
-  try { return new Date(s).toLocaleString(); } catch { return "—"; }
+  return formatTs(s); // formats in the user's selected display timezone (default local)
 }

--- a/cli/src/serve/ui/views/schemas.js
+++ b/cli/src/serve/ui/views/schemas.js
@@ -1,5 +1,5 @@
 import { api, toast } from "../api.js";
-import { escapeHtml } from "../utils.js";
+import { escapeHtml, mdInline } from "../utils.js";
 
 export async function renderSchemas(container) {
   let catalog = { sources: [], sinks: [], transforms: [], state: [] };
@@ -61,7 +61,7 @@ function fieldTable(schema) {
     .map(([name, p]) => {
       const type = p.type || (p.$ref ? p.$ref.split("/").pop() : p.enum ? "enum" : p.oneOf || p.anyOf ? "union" : "object");
       const def = p.default !== undefined ? `<code>${escapeHtml(JSON.stringify(p.default))}</code>` : "";
-      return `<tr><td>${escapeHtml(name)}${req.has(name) ? " *" : ""}</td><td>${escapeHtml(String(type))}</td><td>${def}</td><td>${escapeHtml(firstSentence(p.description || ""))}</td></tr>`;
+      return `<tr><td>${escapeHtml(name)}${req.has(name) ? " *" : ""}</td><td>${escapeHtml(String(type))}</td><td>${def}</td><td>${mdInline(firstSentence(p.description || ""))}</td></tr>`;
     })
     .join("");
   return `<table class="tbl"><thead><tr><th>field</th><th>type</th><th>default</th><th>description</th></tr></thead><tbody>${rows}</tbody></table>`;

--- a/cli/src/serve/ui/views/templates.js
+++ b/cli/src/serve/ui/views/templates.js
@@ -9,7 +9,7 @@
 //   • `stable` / `previous` / `newest` are derived; `dev`…`prod` are assignable
 import { api, toast } from "../api.js";
 import { navigate } from "../router.js";
-import { escapeHtml } from "../utils.js";
+import { escapeHtml, mdInline } from "../utils.js";
 import { fmtTime } from "./runs.js";
 
 const TEMPLATES_MISSING =
@@ -43,9 +43,14 @@ export async function renderTemplates(container) {
       <div class="filters" id="t-filters" hidden>
         <input id="t-search" type="search" autocomplete="off"
           placeholder="search templates by id or description…" />
+        <div class="tpl-status-filter" id="t-status-filter" role="group" aria-label="Filter by status">
+          <button type="button" class="tpl-chip is-on" data-status="launched">launched</button>
+          <button type="button" class="tpl-chip is-on" data-status="draft">draft</button>
+          <button type="button" class="tpl-chip" data-status="deprecated">deprecated</button>
+        </div>
       </div>
       <div class="tpl-list-head" id="t-list-head" hidden>
-        <button type="button" class="tpl-sort" data-sort="status">status<span class="tpl-sort-caret"></span></button>
+        <span>status</span>
         <button type="button" class="tpl-sort" data-sort="name">name<span class="tpl-sort-caret"></span></button>
         <button type="button" class="tpl-sort tpl-col-r" data-sort="updated">last updated<span class="tpl-sort-caret"></span></button>
         <span class="tpl-col-r">live</span>
@@ -62,12 +67,11 @@ export async function renderTemplates(container) {
   const search = container.querySelector("#t-search");
   let all = [];
 
-  // Column sort. `col === null` keeps registry order (the default); clicking a
-  // sortable header sets the column and toggles asc/desc on repeat clicks.
-  const sort = { col: null, dir: 1 };
-  const STATUS_RANK = { launched: 0, draft: 1, deprecated: 2 };
+  // Column sort — alphabetical by name is the default; clicking a sortable header
+  // sets the column and toggles asc/desc on repeat clicks. Status is a filter
+  // (below), not a sort column.
+  const sort = { col: "name", dir: 1 };
   const sortKey = {
-    status: (t) => STATUS_RANK[(t.state || {}).status] ?? 9,
     name: (t) => (t.id || "").toLowerCase(),
     updated: (t) => new Date(t.created_at || 0).getTime() || 0,
   };
@@ -76,6 +80,19 @@ export async function renderTemplates(container) {
       const col = btn.dataset.sort;
       if (sort.col === col) sort.dir *= -1;
       else { sort.col = col; sort.dir = 1; }
+      render();
+    };
+  });
+
+  // Status filter — launched + draft on by default; deprecated hidden until its
+  // chip is toggled on.
+  const statusFilter = new Set(["launched", "draft"]);
+  container.querySelectorAll("#t-status-filter .tpl-chip").forEach((chip) => {
+    chip.onclick = () => {
+      const s = chip.dataset.status;
+      if (statusFilter.has(s)) statusFilter.delete(s);
+      else statusFilter.add(s);
+      chip.classList.toggle("is-on", statusFilter.has(s));
       render();
     };
   });
@@ -93,15 +110,14 @@ export async function renderTemplates(container) {
   // case-insensitive. The registry is small, so there's no server round-trip.
   function render() {
     const q = search.value.trim().toLowerCase();
-    const rows = q
-      ? all.filter(
-          (t) =>
-            (t.id || "").toLowerCase().includes(q) ||
-            (t.description || "").toLowerCase().includes(q),
-        )
-      : all.slice();
-    if (sort.col) {
-      const key = sortKey[sort.col];
+    const rows = all.filter((t) => {
+      const status = (t.state || {}).status || "draft";
+      if (!statusFilter.has(status)) return false;
+      if (q && !((t.id || "").toLowerCase().includes(q) || (t.description || "").toLowerCase().includes(q))) return false;
+      return true;
+    });
+    const key = sortKey[sort.col];
+    if (key) {
       rows.sort((a, b) => {
         const av = key(a), bv = key(b);
         return (av < bv ? -1 : av > bv ? 1 : 0) * sort.dir;
@@ -111,7 +127,10 @@ export async function renderTemplates(container) {
     list.innerHTML = "";
     listHead.hidden = !rows.length; // only show the column header when rows are shown
     if (!rows.length) {
-      list.innerHTML = `<div class="empty">No templates match “${escapeHtml(search.value.trim())}”.</div>`;
+      const why = q
+        ? `No templates match “${escapeHtml(search.value.trim())}”.`
+        : "No templates match the selected status filter.";
+      list.innerHTML = `<div class="empty">${why}</div>`;
       return;
     }
     for (const t of rows) list.appendChild(listRow(t));
@@ -449,7 +468,7 @@ function renderTrigger(host, id, st, d) {
         ${p.secret ? `<span class="pill pill-cancelled">secret</span>` : ""}
       </span>
       ${input}
-      ${p.description ? `<span class="help">${escapeHtml(p.description)}</span>` : ""}`;
+      ${p.description ? `<span class="help">${mdInline(p.description)}</span>` : ""}`;
     paramHost.appendChild(field);
   }
 

--- a/docs/book/ask-ai.js
+++ b/docs/book/ask-ai.js
@@ -9,7 +9,7 @@
   "use strict";
 
   var SPARK =
-    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3Z"/><path d="M18.5 14.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8Z"/></svg>';
+    '<svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3Z"/><path d="M18.5 14.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8Z"/></svg>';
   var CARET =
     '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>';
 


### PR DESCRIPTION
Web-console batch (all under `cli/src/serve/ui/**` + `docs/**` → CI fast-path). Each verified with rendered screenshots + a unit test for the tz math.

- **Timezone selector** (topbar) — a UI-wide display-zone preference (curated 10: Local, UTC + 8 hubs), persisted in localStorage, re-rendering all timestamps through the shared `fmtTime`. The date picker interprets entered wall-clock in the selected zone and converts to UTC (DST-correct; validated: Kolkata 11:38→06:08Z, NY 09:00 EDT→13:00Z). **Closes #602.**
- **Templates list** — default **alphabetical** sort; **status is now a multi-toggle filter** (launched + draft on, deprecated off) rather than a sort column; name/last-updated stay sortable.
- **Inline markdown** — connector descriptions render `**bold**` and ``code`` safely (HTML-escaped first) in the schemas table, submit-form help, and template params.
- **Schemas page** — state stores show a short description (they have no schema to open); the 'built into this server' note is a slim left-accent caption instead of an orphaned box.
- **Submit-form help** aligns under the input; **bigger docs Ask AI sparkle**.

Verified: tz math unit-tested (incl. DST), selector reformats live (UTC/NY confirmed), templates filter/sort, inline-markdown render, schema note/table, help alignment.