### PR TITLE
fix(serve-ui): wider schemas page, timestamp no-wrap, single-dash tz label

### DIFF
--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -700,6 +700,11 @@ select {
    schema explorer
    ========================================================================== */
 .schemas-page {
+  /* The schema explorer is a 2-column layout (list + wide reference table), so it
+     needs more room than the default 1080px reading width. Widen it (stays
+     centered, so it grows on both sides) to stop the type/description columns
+     from wrapping awkwardly. */
+  max-width: 1360px;
   display: grid;
   grid-template-columns: 260px 1fr;
   gap: 24px;
@@ -908,10 +913,11 @@ select {
    ========================================================================== */
 /* status · name · updated · live · newest · params — fixed meta widths so the
    column header (a separate grid) lines up with the rows below it. */
-.tpl-row { grid-template-columns: 120px 1fr 175px 56px 64px 60px; }
+.tpl-row { grid-template-columns: 120px 1fr 205px 56px 64px 60px; }
+.tpl-row .run-meta { white-space: nowrap; } /* keep the timestamp (incl. AM/PM) on one line */
 .tpl-list-head {
   display: grid;
-  grid-template-columns: 120px 1fr 175px 56px 64px 60px;
+  grid-template-columns: 120px 1fr 205px 56px 64px 60px;
   align-items: center;
   gap: 14px;
   /* match .run-row content inset: 16px padding + 3px transparent left border */

--- a/cli/src/serve/ui/tz.js
+++ b/cli/src/serve/ui/tz.js
@@ -18,7 +18,7 @@ const LOCAL_ZONE = (() => {
 
 /** Curated zone list for the selector (Local first, then UTC, then a spread). */
 export const TZ_OPTIONS = [
-  { value: "local", label: `Local${LOCAL_ZONE ? ` — ${LOCAL_ZONE}` : ""}` },
+  { value: "local", label: `Local${LOCAL_ZONE ? ` - ${LOCAL_ZONE}` : ""}` },
   { value: "UTC", label: "UTC" },
   { value: "America/Los_Angeles", label: "Los Angeles" },
   { value: "America/New_York", label: "New York" },


### PR DESCRIPTION
- Schemas page: wider centered max-width so the type/description columns stop wrapping (`string,null` no longer breaks mid-word).
- Templates list: widen 'last updated' column + nowrap so AM/PM stays on one line.
- Timezone 'Local' label: single hyphen instead of em dash.