### PR TITLE
fix(serve): bound the unlimited preview path; refuse external outputs

### DIFF
--- a/cli/src/serve/handlers/preview.rs
+++ b/cli/src/serve/handlers/preview.rs
@@ -4,7 +4,7 @@
 //! This is the **trust / input policy** layer over the generic
 //! [preview engine](crate::serve::preview). The engine reads any source; this
 //! handler decides which reads are allowed on *this* surface, and there are only
-//! three things it does:
+//! four things it does:
 //!
 //! 1. **Refuse unless the operator opted in.** Off by default
 //!    (`--preview-local-outputs`), because returning file contents over HTTP is a
@@ -15,7 +15,13 @@
 //!    so there is no string in the request that could point the read anywhere
 //!    else. Path traversal is not defended against here; it is *unrepresentable*,
 //!    which is the only defence worth having.
-//! 3. **Bound the read.** `row_count_to_load` is resolved through
+//! 3. **Refuse a file faucet does not own.** The retention GC will not *delete*
+//!    a `pre_existing` output — one faucet wrote to but did not create — because
+//!    that is somebody else's data. Serving its contents back over HTTP
+//!    discloses the same data the delete-side guard exists to protect, so the
+//!    read side refuses it too. A guardrail on one verb and not the other is not
+//!    a guardrail.
+//! 4. **Bound the read.** `row_count_to_load` is resolved through
 //!    [`PreviewConfig`](crate::serve::preview::PreviewConfig): omitted → the soft
 //!    cap, present → clamped to the hard cap. `row_count_to_load=all` asks for
 //!    the whole dataset and gets it only if the operator lifted the ceiling
@@ -40,10 +46,12 @@
 
 use crate::local_outputs::{LocalOutputRecord, LocalOutputState};
 use crate::serve::error::ServeError;
+use crate::serve::preview::engine::PREVIEW_UNLIMITED_PAGE_ROWS;
 use crate::serve::preview::{Capped, PreviewPage, PreviewRequest, RowCap, RowRequest, read_capped};
+use crate::serve::rbac::AuthContext;
 use crate::serve::state::ServerState;
 use axum::Json;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Extension, Path, Query, State};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -123,6 +131,7 @@ pub struct PreviewResponse {
 ///   a run that died mid-flush).
 pub async fn preview_output(
     State(state): State<ServerState>,
+    Extension(actor): Extension<AuthContext>,
     Path(id): Path<String>,
     Query(query): Query<PreviewQuery>,
 ) -> Result<Json<PreviewResponse>, ServeError> {
@@ -142,7 +151,30 @@ pub async fn preview_output(
     let page = read_capped(&request, &crate::auth_catalog::AuthCatalog::new())
         .await
         .map_err(|e| read_error(&record, e))?;
+    audit(&state, &actor, &record, page.rows.len()).await;
     Ok(Json(response(&record, page, rows, policy.max_rows())))
+}
+
+/// Record a served preview in the audit log.
+///
+/// Reads are not audited elsewhere in this control plane, and this one is the
+/// exception on purpose: every other read returns *metadata about* a pipeline,
+/// while this one returns the pipeline's **data**. "Who read the contents of this
+/// file, and how much of it" is the question an audit log exists to answer, and
+/// it cannot be reconstructed afterwards from anything else.
+///
+/// Only successful reads are logged here — a refusal already writes its own
+/// entry through the RBAC middleware.
+async fn audit(state: &ServerState, actor: &AuthContext, record: &LocalOutputRecord, rows: usize) {
+    crate::serve::audit::write(
+        state,
+        actor,
+        "local_output.preview",
+        Some(record.run_id.clone()),
+        None,
+        &format!("output={} kind={} rows={rows}", record.id, record.kind),
+    )
+    .await;
 }
 
 /// The refusal text for a server that did not opt in. Names the flag, because
@@ -178,18 +210,41 @@ fn source_spec(record: &LocalOutputRecord, rows: RowCap) -> Result<PreviewReques
             record.path
         )));
     }
+    // The read-side twin of the GC's `pre_existing` refusal. faucet wrote to this
+    // file but did not create it, so its contents are not faucet's to hand out —
+    // and the part of it that predates faucet is exactly what the delete-side
+    // guard protects. Refusing to *unlink* somebody's export while streaming it
+    // back over HTTP would be a guardrail in name only.
+    if record.state() == LocalOutputState::External {
+        return Err(ServeError::Forbidden(format!(
+            "`{}` already existed when faucet first opened it, so faucet wrote to a file \
+             it does not own. Its contents are not previewed, for the same reason the \
+             retention GC will not delete it. The output is still listed, with state \
+             `external`.",
+            record.path
+        )));
+    }
     // The per-page size handed to the source. For a bounded read it is the cap
     // plus the one surplus record the engine uses to detect truncation, so the
-    // first page is already enough and nothing further is decoded. For an
-    // unlimited read it is `0` — every source's "do not batch" sentinel — so the
-    // whole dataset arrives without pointless re-chunking.
+    // first page is already enough and nothing further is decoded.
+    //
+    // For an unlimited read it must **not** be `0`. That is every source's
+    // "drain into one page" sentinel, and it is how this handler used to ask
+    // jsonl and csv to materialize an entire file into a single `Vec` before the
+    // engine's byte budget or deadline — both checked as pages arrive — could
+    // look at any of it. Unlimited means unlimited in *rows*; the read is still
+    // paged. (`limit: 0` below is the jsonl reader's own "no row limit", which is
+    // the part that should be unbounded.)
     let page = match rows {
+        RowCap::Rows(n) => n.saturating_add(1),
+        RowCap::Unlimited => PREVIEW_UNLIMITED_PAGE_ROWS,
+    };
+    let row_limit = match rows {
         RowCap::Rows(n) => n.saturating_add(1),
         RowCap::Unlimited => 0,
     };
     let config = match record.kind.as_str() {
-        // `limit: 0` is the reader's own "no limit", so the two agree.
-        "jsonl" => json!({ "path": record.path, "batch_size": page, "limit": page }),
+        "jsonl" => json!({ "path": record.path, "batch_size": page, "limit": row_limit }),
         "csv" => json!({ "path": record.path, "batch_size": page }),
         // `local_path` is `ParquetLocation`'s snake_case tag; a rolled parquet
         // run records each part as its own ledger row, so this is always one
@@ -283,6 +338,16 @@ mod tests {
         })
     }
 
+    /// A `viewer` — the lowest role that holds `LocalOutputRead`, so the handler
+    /// tests run as the least-privileged principal that can reach this route.
+    fn actor() -> AuthContext {
+        AuthContext {
+            principal: "bob".into(),
+            role: crate::serve::rbac::Role::Viewer,
+            source_ip: None,
+        }
+    }
+
     fn touch(dir: &FsPath, name: &str) -> std::path::PathBuf {
         let p = dir.join(name);
         std::fs::write(&p, "{\"a\":1}\n").unwrap();
@@ -362,15 +427,82 @@ mod tests {
     }
 
     #[test]
-    fn an_external_file_is_previewable() {
-        // `pre_existing` bars *deletion*, not reading: the path is still a sink
-        // path faucet was pointed at, and reading is not destructive.
+    fn an_external_file_is_not_previewable() {
+        // `pre_existing` means faucet wrote to a file it did not create. The GC
+        // refuses to delete it; serving its contents back over HTTP would
+        // disclose the very data that refusal protects, so the read side refuses
+        // too — and says why, since the output stays visible in the list.
         let dir = tempfile::tempdir().unwrap();
         let p = touch(dir.path(), "theirs.jsonl");
         let mut r = record(&p, "jsonl");
         r.pre_existing = true;
         assert_eq!(r.state(), LocalOutputState::External);
-        assert!(source_spec(&r, RowCap::Rows(10)).is_ok());
+        match source_spec(&r, RowCap::Rows(10)).unwrap_err() {
+            ServeError::Forbidden(m) => {
+                assert!(m.contains("does not own"), "{m}");
+                assert!(m.contains("external"), "the state stays discoverable: {m}");
+            }
+            other => panic!("expected Forbidden, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_abandoned_read_is_unavailable_not_a_500() {
+        // The 503 arm: the engine reports its hard timeout as `CliError::Serve`,
+        // and abandoning a read is not a verdict on the file — so it must not
+        // become a 422 ("your data is malformed") or a 500.
+        let dir = tempfile::tempdir().unwrap();
+        let p = touch(dir.path(), "out.jsonl");
+        let err = read_error(
+            &record(&p, "jsonl"),
+            crate::error::CliError::Serve("preview abandoned after 60s".into()),
+        );
+        match err {
+            ServeError::Unavailable(m) => assert!(m.contains("abandoned"), "{m}"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+        assert_eq!(
+            ServeError::Unavailable(String::new()).status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn an_unreadable_file_is_unprocessable_and_keeps_the_connectors_diagnostic() {
+        // A file that is present but cannot be parsed is a fact about the
+        // caller's data, and the connector's own message (which names the line or
+        // byte offset) is the useful part — so it must survive the mapping.
+        let dir = tempfile::tempdir().unwrap();
+        let p = touch(dir.path(), "rows.csv");
+        let err = read_error(
+            &record(&p, "csv"),
+            crate::error::CliError::Config("ragged CSV row at line 7".into()),
+        );
+        match err {
+            ServeError::Unprocessable { message, .. } => {
+                assert!(message.contains("line 7"), "{message}");
+                assert!(message.contains("rows.csv"), "{message}");
+            }
+            other => panic!("expected Unprocessable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_missing_connector_says_the_build_lacks_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = touch(dir.path(), "part.parquet");
+        let err = read_error(
+            &record(&p, "parquet"),
+            crate::error::CliError::UnknownConnector {
+                kind: "source",
+                name: "parquet".into(),
+                available: "csv".into(),
+            },
+        );
+        match err {
+            ServeError::BadConfig(m) => assert!(m.contains("parquet"), "{m}"),
+            other => panic!("expected BadConfig, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -379,6 +511,7 @@ mod tests {
         assert!(!state.preview().enabled, "off by default");
         let err = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path("whatever".into()),
             axum::extract::Query(PreviewQuery::default()),
         )
@@ -399,6 +532,7 @@ mod tests {
         let state = crate::serve::test_support::state_from(&config);
         let err = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path("no-such-output".into()),
             axum::extract::Query(PreviewQuery::default()),
         )
@@ -433,6 +567,7 @@ mod tests {
 
         let axum::Json(body) = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(id.clone()),
             axum::extract::Query(PreviewQuery::default()),
         )
@@ -479,6 +614,7 @@ mod tests {
 
         let axum::Json(body) = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(crate::local_outputs::ledger::output_id(&path)),
             axum::extract::Query(PreviewQuery {
                 row_count_to_load: Some("1000".into()),
@@ -528,16 +664,36 @@ mod tests {
     }
 
     #[test]
-    fn an_unlimited_read_asks_the_source_not_to_batch() {
-        // `0` is every source's "do not batch" sentinel, and the jsonl reader's
-        // own "no limit" — so a whole-dataset preview must send 0, not a huge
-        // number that would chunk the read for no reason.
+    fn an_unlimited_read_is_unlimited_in_rows_but_still_paged() {
+        // The regression that made the unlimited path OOM: `batch_size: 0` is
+        // every source's "drain into one page" sentinel, so the engine's byte and
+        // time bounds — both checked as pages arrive — never got a chance to act
+        // on a 40 GiB file. The row limit is the part that must be unbounded.
         let dir = tempfile::tempdir().unwrap();
         let p = touch(dir.path(), "out.jsonl");
         let spec = source_spec(&record(&p, "jsonl"), RowCap::Unlimited).unwrap();
-        assert_eq!(spec.config["batch_size"], 0);
-        assert_eq!(spec.config["limit"], 0);
+        assert_eq!(
+            spec.config["batch_size"], PREVIEW_UNLIMITED_PAGE_ROWS,
+            "an unbounded page defeats every bound the engine has"
+        );
+        assert_ne!(spec.config["batch_size"], 0);
+        assert_eq!(spec.config["limit"], 0, "no *row* limit, though");
         assert_eq!(spec.rows, RowCap::Unlimited);
+    }
+
+    #[test]
+    fn every_kind_is_paged_under_an_unlimited_read() {
+        // csv takes its page size from the same field, and parquet from its own
+        // `batch_size`; none of them may be handed the drain-everything sentinel.
+        let dir = tempfile::tempdir().unwrap();
+        for kind in ["jsonl", "csv", "parquet"] {
+            let p = touch(dir.path(), &format!("out.{kind}"));
+            let spec = source_spec(&record(&p, kind), RowCap::Unlimited).unwrap();
+            assert_eq!(
+                spec.config["batch_size"], PREVIEW_UNLIMITED_PAGE_ROWS,
+                "{kind} was handed an unbounded page"
+            );
+        }
     }
 
     #[tokio::test]
@@ -549,6 +705,7 @@ mod tests {
 
         let axum::Json(body) = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(id),
             axum::extract::Query(PreviewQuery {
                 row_count_to_load: Some("all".into()),
@@ -574,6 +731,7 @@ mod tests {
 
         let axum::Json(body) = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(id),
             axum::extract::Query(PreviewQuery {
                 row_count_to_load: Some("all".into()),
@@ -595,6 +753,7 @@ mod tests {
 
         let axum::Json(body) = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(id),
             axum::extract::Query(PreviewQuery {
                 row_count_to_load: Some("0".into()),
@@ -614,6 +773,7 @@ mod tests {
 
         let err = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(id),
             axum::extract::Query(PreviewQuery {
                 row_count_to_load: Some("lots".into()),
@@ -655,6 +815,7 @@ mod tests {
 
         let err = preview_output(
             axum::extract::State(state),
+            axum::extract::Extension(actor()),
             axum::extract::Path(crate::local_outputs::ledger::output_id(&path)),
             axum::extract::Query(PreviewQuery::default()),
         )

--- a/cli/src/serve/preview/engine.rs
+++ b/cli/src/serve/preview/engine.rs
@@ -34,14 +34,31 @@
 //! | bound | limit | on hit |
 //! |---|---|---|
 //! | rows | [`RowCap`] | [`Capped::Rows`] |
-//! | response size | [`PREVIEW_MAX_BYTES`] | [`Capped::Bytes`] |
-//! | wall clock | [`PREVIEW_DEADLINE`] | [`Capped::Time`] |
+//! | response size | [`Bounds::max_bytes`] | [`Capped::Bytes`] |
+//! | wall clock | [`Bounds::deadline`] | [`Capped::Time`] |
 //!
 //! All three produce a **partial answer that says it is partial**, never an
-//! error and never an OOM: asking for a whole dataset that does not fit gets you
-//! as much of it as fits, plus the reason it stopped. Only
-//! [`PREVIEW_HARD_TIMEOUT`] — a single page that never returns at all — fails
-//! the request outright, because there is nothing partial to hand back.
+//! error: asking for a whole dataset that does not fit gets you as much of it as
+//! fits, plus the reason it stopped. Only [`Bounds::hard_timeout`] — a single
+//! page that never returns at all — fails the request outright, because there is
+//! nothing partial to hand back.
+//!
+//! ### The bounds only work if every page is bounded
+//!
+//! Both are checked *as pages arrive*, so they can only interrupt a read that
+//! arrives in pieces. Ask a source for one unbounded page and it will hand back
+//! the whole file in a single `Vec` before either bound is ever consulted —
+//! which is precisely what this engine used to do on the unlimited path
+//! (`batch_size: 0`, every source's "drain into one page" sentinel), turning a
+//! 40 GiB `out.jsonl` into an OOM while the docs promised a truncated answer.
+//!
+//! So the engine **never requests an unbounded page**: an unlimited read is
+//! unlimited in *rows*, paged at [`PREVIEW_UNLIMITED_PAGE_ROWS`]. The residual,
+//! stated plainly because it is not something this layer can fix: a source that
+//! ignores the page-size hint and materializes its whole result set anyway (the
+//! default [`Source::stream_pages`] does exactly that, via `fetch_with_context`)
+//! is bounded by that source, not by us. It matters for #591's remote sources,
+//! not for the three file readers here, all of which page lazily.
 
 use crate::auth_catalog::AuthCatalog;
 use crate::error::{CliError, CliResult};
@@ -77,6 +94,44 @@ pub const PREVIEW_HARD_TIMEOUT: Duration = Duration::from_secs(60);
 /// estimate rather than by serializing each record, so the intent is a bound of
 /// the right order of magnitude, not an exact content-length.
 pub const PREVIEW_MAX_BYTES: usize = 64 * 1024 * 1024;
+
+/// Page size for an [unlimited](RowCap::Unlimited) read.
+///
+/// An unlimited preview is unlimited in **rows**, not in page size. Requesting
+/// one unbounded page (`batch_size: 0`) would hand the engine the entire file in
+/// a single `Vec` before the byte budget or the deadline could look at it, so
+/// "unlimited" has to mean "paged, without a row ceiling".
+/// [`faucet_core::DEFAULT_BATCH_SIZE`] is the same cadence the pipeline itself
+/// streams at.
+pub const PREVIEW_UNLIMITED_PAGE_ROWS: usize = faucet_core::DEFAULT_BATCH_SIZE;
+
+/// The non-row bounds on one read.
+///
+/// Separated from the constants above, and passed in rather than read from them,
+/// so every bound has a test that exercises the **real** loop: a 30-second
+/// deadline and a 64 MiB budget are not things a unit test can reach otherwise,
+/// and an untested bound is a bound that quietly stops working.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bounds {
+    /// Approximate response-size budget for the returned rows.
+    pub max_bytes: usize,
+    /// Wall-clock budget. On expiry the read returns what it has, as
+    /// [`Capped::Time`].
+    pub deadline: Duration,
+    /// Ceiling on the whole read, after which it fails rather than returning a
+    /// partial answer. Guards a single page that never completes.
+    pub hard_timeout: Duration,
+}
+
+impl Default for Bounds {
+    fn default() -> Self {
+        Self {
+            max_bytes: PREVIEW_MAX_BYTES,
+            deadline: PREVIEW_DEADLINE,
+            hard_timeout: PREVIEW_HARD_TIMEOUT,
+        }
+    }
+}
 
 /// What to read: a source spec plus the bound, already resolved against the
 /// server's caps by the caller ([`super::PreviewConfig::resolve_rows`]).
@@ -142,17 +197,26 @@ impl PreviewPage {
 }
 
 /// Read through the source `req.kind` describes, under `req.rows` and the
-/// engine's byte/time bounds.
+/// engine's default [`Bounds`].
 pub async fn read_capped(req: &PreviewRequest, auth: &AuthCatalog) -> CliResult<PreviewPage> {
+    read_capped_with(req, auth, Bounds::default()).await
+}
+
+/// [`read_capped`] with explicit bounds — the form the bound tests drive, so
+/// each of the three is exercised in the real loop rather than by inspection.
+pub async fn read_capped_with(
+    req: &PreviewRequest,
+    auth: &AuthCatalog,
+    bounds: Bounds,
+) -> CliResult<PreviewPage> {
     let started = Instant::now();
-    let page = tokio::time::timeout(PREVIEW_HARD_TIMEOUT, read_inner(req, auth, started))
+    let page = tokio::time::timeout(bounds.hard_timeout, read_inner(req, auth, started, bounds))
         .await
         .map_err(|_| {
             CliError::Serve(format!(
-                "preview abandoned after {}s reading a `{}` source — a single page never \
+                "preview abandoned after {:?} reading a `{}` source — a single page never \
                  returned",
-                PREVIEW_HARD_TIMEOUT.as_secs(),
-                req.kind
+                bounds.hard_timeout, req.kind
             ))
         })??;
     Ok(PreviewPage {
@@ -165,6 +229,7 @@ async fn read_inner(
     req: &PreviewRequest,
     auth: &AuthCatalog,
     started: Instant,
+    bounds: Bounds,
 ) -> CliResult<PreviewPage> {
     // One past the cap: enough to *know* whether more rows exist. An unlimited
     // read has no such number — the byte and time bounds are what stop it.
@@ -185,11 +250,10 @@ async fn read_inner(
     let mut capped_by = None;
     {
         let context = HashMap::new();
-        // The per-page hint. Every file source in the workspace takes its page
-        // size from its own config (see the callers in `handlers::preview`), so
-        // this is advisory; `0` is the "do not batch" sentinel, which is what an
-        // unlimited read wants.
-        let hint = want.unwrap_or(0);
+        // The per-page hint. Never `0` ("drain into one page"): a bound that is
+        // checked as pages arrive cannot interrupt a read that arrives all at
+        // once. An unlimited read is unlimited in rows, paged all the same.
+        let hint = want.unwrap_or(PREVIEW_UNLIMITED_PAGE_ROWS);
         let mut pages = source.stream_pages(&context, hint);
         'outer: while let Some(page) = pages.next().await {
             let page = page?;
@@ -202,7 +266,7 @@ async fn read_inner(
                 if want.is_some_and(|want| rows.len() >= want) {
                     break 'outer;
                 }
-                if bytes >= PREVIEW_MAX_BYTES {
+                if bytes >= bounds.max_bytes {
                     capped_by = Some(Capped::Bytes);
                     break 'outer;
                 }
@@ -212,7 +276,7 @@ async fn read_inner(
             // Checked between pages: a bound that can only be observed after a
             // page completes is still a bound, and it keeps the check off the
             // per-record path.
-            if started.elapsed() >= PREVIEW_DEADLINE {
+            if started.elapsed() >= bounds.deadline {
                 capped_by = Some(Capped::Time);
                 break;
             }
@@ -277,7 +341,14 @@ fn approx_bytes(value: &Value) -> usize {
     }
 }
 
-/// Column names across `rows`, first-seen order, de-duplicated.
+/// Column names across `rows`, de-duplicated, in the order the records present
+/// them.
+///
+/// "The order the records present them" is `serde_json::Map`'s iteration order,
+/// which is alphabetical unless something in the dependency tree turns on
+/// `preserve_order`. Nothing here depends on which: the union is stable and
+/// complete either way, and the header always matches the keys the rows actually
+/// carry, because it is computed from those rows.
 ///
 /// Ragged records (a field only some rows carry) contribute their extra keys at
 /// the end rather than being dropped — a preview that hid a column would be
@@ -492,30 +563,121 @@ mod tests {
         assert!(approx_bytes(&nested) > approx_bytes(&small));
     }
 
+    /// The spec the **handler** builds for an unlimited read, so these tests
+    /// exercise the page size production actually uses rather than a convenient
+    /// one. Mirrors `handlers::preview::source_spec`.
+    fn unlimited_request(path: &str) -> PreviewRequest {
+        PreviewRequest {
+            kind: "jsonl".into(),
+            config: serde_json::json!({
+                "path": path,
+                "batch_size": PREVIEW_UNLIMITED_PAGE_ROWS,
+                "limit": 0,
+            }),
+            rows: RowCap::Unlimited,
+        }
+    }
+
     #[tokio::test]
     async fn the_byte_budget_bounds_an_unlimited_read() {
         // The property that makes "preview the whole dataset" safe to offer: a
-        // dataset larger than the budget comes back as a partial answer that
-        // says so, not as an OOM.
+        // dataset past the budget comes back as a partial answer that says so.
+        //
+        // Driven through the *handler's* page size and a small budget, rather
+        // than through `batch_size: 1` and the real 64 MiB — the previous version
+        // of this test did the latter and so passed green while production, which
+        // sent `batch_size: 0`, materialized the whole file before the budget was
+        // ever consulted.
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join("fat.jsonl");
-        // ~1 MiB per record, so the 64 MiB budget trips well before EOF.
-        let blob = "x".repeat(1024 * 1024);
-        let mut body = String::new();
-        for _ in 0..80 {
-            body.push_str(&format!("{{\"blob\":\"{blob}\"}}\n"));
-        }
+        let blob = "x".repeat(4096);
+        let body: String = (0..500)
+            .map(|i| format!("{{\"i\":{i},\"blob\":\"{blob}\"}}\n"))
+            .collect();
+        std::fs::write(&p, body).unwrap();
+
+        let bounds = Bounds {
+            max_bytes: 64 * 1024,
+            ..Bounds::default()
+        };
+        let page = read_capped_with(
+            &unlimited_request(&p.to_string_lossy()),
+            &AuthCatalog::new(),
+            bounds,
+        )
+        .await
+        .unwrap();
+        assert_eq!(page.capped_by, Some(Capped::Bytes), "{:?}", page.capped_by);
+        assert!(page.rows.len() < 500, "the read must stop before EOF");
+        assert!(!page.rows.is_empty(), "…but still return what it read");
+        assert!(page.truncated());
+    }
+
+    #[tokio::test]
+    async fn an_unbounded_page_would_defeat_the_byte_budget() {
+        // Why `PREVIEW_UNLIMITED_PAGE_ROWS` exists, pinned as a test rather than
+        // as a comment. `batch_size: 0` makes the jsonl reader hand over the
+        // whole file in one page; the budget is checked as pages arrive, so it
+        // cannot stop what has already arrived. Nothing in production sends 0 —
+        // `every_kind_is_paged_under_an_unlimited_read` holds that line — and
+        // this documents the consequence if it ever did.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("all-at-once.jsonl");
+        let body: String = (0..500).map(|i| format!("{{\"i\":{i}}}\n")).collect();
         std::fs::write(&p, body).unwrap();
 
         let req = PreviewRequest {
             kind: "jsonl".into(),
-            config: serde_json::json!({ "path": p.to_string_lossy(), "batch_size": 1 }),
+            // The sentinel the handler must never send.
+            config: serde_json::json!({ "path": p.to_string_lossy(), "batch_size": 0 }),
             rows: RowCap::Unlimited,
         };
-        let page = read_capped(&req, &AuthCatalog::new()).await.unwrap();
-        assert_eq!(page.capped_by, Some(Capped::Bytes), "{:?}", page.capped_by);
-        assert!(page.rows.len() < 80, "the read must stop before EOF");
-        assert!(!page.rows.is_empty(), "…but still return what it read");
+        let page = read_capped_with(
+            &req,
+            &AuthCatalog::new(),
+            Bounds {
+                max_bytes: 64,
+                ..Bounds::default()
+            },
+        )
+        .await
+        .unwrap();
+        // The budget did stop *accumulation* mid-page, but the source had already
+        // built all 500 records — the memory the budget was meant to bound.
+        assert_eq!(page.pages_read, 1, "one page: the whole file");
+        assert!(page.rows.len() < 500);
+    }
+
+    #[tokio::test]
+    async fn the_deadline_returns_a_partial_answer_rather_than_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_jsonl(dir.path(), 5_000);
+        let bounds = Bounds {
+            deadline: Duration::ZERO,
+            ..Bounds::default()
+        };
+        let page = read_capped_with(&unlimited_request(&path), &AuthCatalog::new(), bounds)
+            .await
+            .unwrap();
+        assert_eq!(page.capped_by, Some(Capped::Time));
+        assert!(page.truncated());
+        // One page's worth, not zero rows and not the file: the deadline is
+        // checked *after* a page, so the caller always gets something back.
+        assert_eq!(page.rows.len(), PREVIEW_UNLIMITED_PAGE_ROWS);
+    }
+
+    // The hard timeout itself (the `tokio::time::timeout` wrapper) has no unit
+    // test here: making it fire deterministically needs a source that never
+    // yields, and the only injection point — `PluginRegistry::install` — is a
+    // process-wide `OnceLock` that a lib-test binary cannot claim without
+    // poisoning it for every other test. Racing it against a real file read
+    // (`hard_timeout: ZERO`) passes or fails on timer granularity, which is worse
+    // than no test. What it maps to over HTTP *is* covered, deterministically:
+    // see `handlers::preview::tests::an_abandoned_read_is_unavailable_not_a_500`.
+
+    #[test]
+    fn the_unlimited_page_size_is_never_the_drain_everything_sentinel() {
+        assert_ne!(PREVIEW_UNLIMITED_PAGE_ROWS, 0);
     }
 
     #[test]

--- a/cli/src/serve/ui/views/datasets.js
+++ b/cli/src/serve/ui/views/datasets.js
@@ -93,7 +93,8 @@ const CLEAN_ALL_PROMPT = (what) =>
 const STATE_HINT = {
   present: "on disk",
   expired: "cleaned — the run record is kept",
-  external: "faucet wrote this file but did not create it, so it is never cleaned",
+  external:
+    "faucet wrote this file but did not create it, so it is never cleaned — and not previewed either",
 };
 
 /**
@@ -273,7 +274,7 @@ function outputRow(o, canManage, canPreview) {
         <span class="run-meta">${escapeHtml(fmtAge(o.age_secs))}</span>
         <span class="run-meta run-time" title="last written">${fmtTime(o.last_written_at)}</span>
         ${
-          canPreview && PREVIEWABLE.has(o.kind) && o.state !== "expired"
+          canPreview && PREVIEWABLE.has(o.kind) && o.state === "present"
             ? `<button class="btn-ghost lo-preview-btn">Preview</button>`
             : `<span class="run-meta"></span>`
         }
@@ -299,6 +300,11 @@ function outputRow(o, canManage, canPreview) {
 // The server owns the caps; this panel only *reflects* them (`max` on the input,
 // the pre-filled default), so a typed number is never silently clamped without
 // the user having been told the ceiling.
+//
+// Only a `present` output gets a button. An `expired` one has no file left, and an
+// `external` one is a file faucet wrote to but did not create — the server refuses
+// to serve its contents for the same reason the GC refuses to delete it — so
+// offering either would be offering a button that can only fail.
 
 /** Sink kinds that have a reader on the server. Anything else gets no button. */
 const PREVIEWABLE = new Set(["jsonl", "csv", "parquet"]);

--- a/cli/tests/serve_preview.rs
+++ b/cli/tests/serve_preview.rs
@@ -18,6 +18,10 @@
 //! 5. **Retention interaction (#587)**: once an output is cleaned, previewing it
 //!    is a `409` explaining that the file is gone and the run record is kept —
 //!    never a 500 from a failed open.
+//! 6. **Every readable format is actually read back**, parquet included — and in
+//!    the rolled multi-part shape the handler is built for, where one UUID-named
+//!    part is one ledger row. A spec-inspection test cannot catch an Arrow
+//!    regression; only a real read can.
 #![cfg(all(
     feature = "catalog",
     feature = "source-csv",
@@ -440,6 +444,209 @@ async fn a_server_with_no_ceiling_serves_the_whole_dataset() {
     let (status, body) = preview(&base, &client, "admin-tok", &id, "row_count_to_load=0").await;
     assert_eq!(status, 200, "{body}");
     assert_eq!(body["rows"].as_array().unwrap().len(), 1_500);
+}
+
+/// A csv → parquet pipeline. `dest` is a file for single-file mode, or a
+/// directory when `max_rows_per_file` rolls parts over.
+#[cfg(all(feature = "source-parquet", feature = "sink-parquet"))]
+fn csv_to_parquet(input: &str, dest: &str, max_rows_per_file: Option<usize>) -> String {
+    let rollover = match max_rows_per_file {
+        // `batch_size` matters as much as the threshold: rollover is evaluated
+        // after each batch, so a single 10-row page would otherwise land in one
+        // file regardless of `max_rows_per_file`. Slicing the page is what makes
+        // the sink actually roll.
+        Some(n) => format!(", max_rows_per_file: {n}, batch_size: {n}"),
+        None => String::new(),
+    };
+    format!(
+        "version: 1\nname: preview-e2e\npipeline:\n  \
+         source: {{ type: csv, config: {{ path: {input} }} }}\n  \
+         sink: {{ type: parquet, config: {{ destination: {{ type: local_path, path: {dest} }}{rollover} }} }}\n",
+    )
+}
+
+#[cfg(all(feature = "source-parquet", feature = "sink-parquet"))]
+#[tokio::test(flavor = "multi_thread")]
+async fn previews_a_parquet_output_through_the_parquet_source() {
+    // Finding #3 of the post-merge review: parquet was only ever checked by
+    // inspecting the generated spec JSON, so an Arrow read-back regression would
+    // have shipped green. This reads the file.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.parquet");
+    write_input(&input, 6);
+
+    let port = free_port();
+    spawn_server(port, dir.path(), true, 100, 1000).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    run_pipeline(
+        &base,
+        &client,
+        &csv_to_parquet(
+            &input.display().to_string(),
+            &output.display().to_string(),
+            None,
+        ),
+    )
+    .await;
+    assert!(output.exists(), "the sink should have written the file");
+
+    let id = id_of(&list_outputs(&base, &client).await, "out.parquet");
+    let (status, body) = preview(&base, &client, "admin-tok", &id, "").await;
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["kind"], "parquet");
+    assert_eq!(body["rows"].as_array().unwrap().len(), 6);
+    assert_eq!(body["row_count"], 6);
+    assert_eq!(body["truncated"], false);
+    assert_eq!(body["capped_by"], Value::Null);
+    assert_eq!(body["columns"], serde_json::json!(["id", "name"]));
+    // Values come back through Arrow, so this also pins the decode.
+    assert_eq!(body["rows"][0]["name"], "name-0");
+    assert_eq!(body["rows"][5]["name"], "name-5");
+}
+
+#[cfg(all(feature = "source-parquet", feature = "sink-parquet"))]
+#[tokio::test(flavor = "multi_thread")]
+async fn previews_each_part_of_a_rolled_parquet_output_independently() {
+    // The shape the handler's `local_path` (never a glob) choice exists for: a
+    // rolling parquet sink names each part with a fresh UUID and the ledger
+    // records one row per part, so each preview must read exactly its own part —
+    // not the directory, and not the other parts.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let out_dir = dir.path().join("parts");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    write_input(&input, 10);
+
+    let port = free_port();
+    spawn_server(port, dir.path(), true, 100, 1000).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    run_pipeline(
+        &base,
+        &client,
+        &csv_to_parquet(
+            &input.display().to_string(),
+            &out_dir.display().to_string(),
+            Some(4),
+        ),
+    )
+    .await;
+
+    let listed = list_outputs(&base, &client).await;
+    let parts: Vec<&Value> = listed["outputs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|o| o["path"].as_str().unwrap().ends_with(".parquet"))
+        .collect();
+    assert!(
+        parts.len() > 1,
+        "expected the sink to roll over into several parts, got {}: {listed}",
+        parts.len()
+    );
+
+    // Every part previews on its own, and the parts together account for all 10
+    // rows — which is what proves each read was scoped to one file.
+    let mut total = 0usize;
+    for part in &parts {
+        let id = part["id"].as_str().unwrap();
+        let (status, body) = preview(&base, &client, "admin-tok", id, "").await;
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(body["kind"], "parquet");
+        let n = body["rows"].as_array().unwrap().len();
+        assert!(
+            n > 0 && n <= 4,
+            "part should hold 1..=4 rows, got {n}: {body}"
+        );
+        assert_eq!(body["columns"], serde_json::json!(["id", "name"]));
+        total += n;
+    }
+    assert_eq!(
+        total, 10,
+        "the parts must partition the dataset, not repeat it"
+    );
+}
+
+#[cfg(feature = "compression")]
+#[tokio::test(flavor = "multi_thread")]
+async fn previews_a_compressed_output_by_decompressing_it() {
+    // Both sides auto-detect from the `.gz` suffix — the jsonl sink writes gzip,
+    // the preview reader decompresses — so a compressed output must round-trip.
+    // Untested until now, which meant a compressed preview could have been
+    // silently reported as a malformed file.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl.gz");
+    write_input(&input, 5);
+
+    let port = free_port();
+    spawn_server(port, dir.path(), true, 100, 1000).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    run_pipeline(
+        &base,
+        &client,
+        &csv_to(
+            "jsonl",
+            &input.display().to_string(),
+            &output.display().to_string(),
+        ),
+    )
+    .await;
+    // Confirm it really is gzip, or the test proves nothing about decompression.
+    let bytes = std::fs::read(&output).unwrap();
+    assert_eq!(&bytes[..2], &[0x1f, 0x8b], "sink should have written gzip");
+
+    let id = id_of(&list_outputs(&base, &client).await, "out.jsonl.gz");
+    let (status, body) = preview(&base, &client, "admin-tok", &id, "").await;
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["rows"].as_array().unwrap().len(), 5);
+    assert_eq!(body["columns"], serde_json::json!(["id", "name"]));
+    assert_eq!(body["rows"][4]["name"], "name-4");
+    assert_eq!(body["truncated"], false);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_malformed_output_is_unprocessable_rather_than_a_server_error() {
+    // A run that died mid-flush leaves a half-written last line. The file is
+    // there, so this is a fact about the data, not a server fault.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    write_input(&input, 3);
+
+    let port = free_port();
+    spawn_server(port, dir.path(), true, 100, 1000).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    run_pipeline(
+        &base,
+        &client,
+        &csv_to(
+            "jsonl",
+            &input.display().to_string(),
+            &output.display().to_string(),
+        ),
+    )
+    .await;
+    let id = id_of(&list_outputs(&base, &client).await, "out.jsonl");
+
+    // Truncate the last record the way an interrupted flush would.
+    let mut body = std::fs::read_to_string(&output).unwrap();
+    body.push_str("{\"id\": \"9\", \"name\"");
+    std::fs::write(&output, body).unwrap();
+
+    let (status, body) = preview(&base, &client, "admin-tok", &id, "").await;
+    assert_eq!(status, 422, "{body}");
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(message.contains("line 4"), "names the bad line: {message}");
+    assert!(message.contains("out.jsonl"), "{message}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/deploy/helm/faucet-stream/templates/validation.yaml
+++ b/deploy/helm/faucet-stream/templates/validation.yaml
@@ -21,3 +21,9 @@
 {{- if and .Values.serve.enabled (lt (int .Values.serve.localOutputs.inFlightGraceSeconds) 0) -}}
 {{- fail (printf "serve.localOutputs.inFlightGraceSeconds must be 0 (disabled) or a positive number of seconds (got %v)." .Values.serve.localOutputs.inFlightGraceSeconds) -}}
 {{- end -}}
+{{- if and .Values.serve.enabled (lt (int .Values.serve.preview.rows) 0) -}}
+{{- fail (printf "serve.preview.rows must be 0 (preview the whole dataset by default) or a positive number of rows (got %v)." .Values.serve.preview.rows) -}}
+{{- end -}}
+{{- if and .Values.serve.enabled (lt (int .Values.serve.preview.maxRows) 0) -}}
+{{- fail (printf "serve.preview.maxRows must be 0 (no ceiling) or a positive number of rows (got %v)." .Values.serve.preview.maxRows) -}}
+{{- end -}}

--- a/docs/book/src/cookbook/web-console.md
+++ b/docs/book/src/cookbook/web-console.md
@@ -234,6 +234,12 @@ still stops at a 64 MiB response budget or a 30-second deadline if the dataset i
 larger than that, saying which. A partial answer always names the bound that
 produced it.
 
+Only a `present` output gets a Preview button. An `expired` one has no file left,
+and an **`external`** one — a file faucet wrote to but did not create — is never
+previewed: its contents are not faucet's to serve, which is the read-side twin of
+the retention GC's refusal to delete it. Each served preview is recorded in the
+audit log as `local_output.preview`.
+
 **It is off by default and intended for local testing** — it returns file
 *contents* over HTTP, and reading needs only `LocalOutputRead` (`viewer` and up),
 so enabling it lets every viewer see the data those pipelines wrote. Without the

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -1002,14 +1002,27 @@ having one. With `--preview-max-rows 0` the response reports `row_limit: null`
 and `preview_max_rows: null`, and the console offers "All rows" as something that
 will genuinely load everything.
 
-**Unlimited is not unbounded.** An uncapped read still stops at a response-size
-budget (64 MiB) and a 30-second deadline, and a read stopped by any of the three
-bounds comes back as a *partial answer that names the bound* — `capped_by` is
-`rows`, `bytes`, or `time`, and absent when the response is the whole dataset. So
-asking for a dataset larger than the server can hold gets you as much of it as
-fits plus the reason it stopped, never an out-of-memory or a silently clipped
-table. (Only a single page that never returns at all — 60s — fails the request,
-as a `503`.)
+**Unlimited is not unbounded.** An uncapped read is unlimited in *rows* only: it
+is still paged, and still stops at a response-size budget (64 MiB) and a
+30-second deadline. A read stopped by any of the three bounds comes back as a
+*partial answer that names the bound* — `capped_by` is `rows`, `bytes`, or
+`time`, and absent when the response is the whole dataset. So asking for a
+dataset larger than the server can hold gets you as much of it as fits plus the
+reason it stopped, never an out-of-memory or a silently clipped table. (Only a
+single page that never returns at all — 60s — fails the request, as a `503`.)
+
+The paging is what makes those bounds work, and it is not incidental: both are
+checked as pages arrive, so a read that arrives all at once cannot be
+interrupted. That is why an unlimited preview asks its source for pages of 1000
+rows rather than for one unbounded page.
+
+**An `external` output is never previewed.** faucet wrote to that file but did not
+create it, so its contents are not faucet's to serve — the read-side twin of the
+retention GC's refusal to delete it. The output stays listed, with state
+`external`, and the console renders no Preview control for it. Every served
+preview also writes a `local_output.preview` audit entry (principal, output, row
+count): this is the one read on the control plane that returns pipeline *data*
+rather than metadata, so it is the one read worth recording.
 
 These caps govern the **serve** preview only. `faucet preview` is a local,
 deliberate, single-user command with its own `--limit` flag: a different trust

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -310,7 +310,15 @@ first few kilobytes; nothing past the cap is decoded.
 **It is off by default.** Without `--preview-local-outputs`
 (`FAUCET_SERVE_PREVIEW_LOCAL_OUTPUTS`) every request is a `403` naming the flag,
 for every role — it is a server capability, not a permission. Reading needs
-`LocalOutputRead` (`viewer` and up), the same scope that lists these files.
+`LocalOutputRead` (`viewer` and up), the same scope that lists these files, and a
+served preview writes a `local_output.preview` **audit** entry naming the
+principal, the output, and the row count: it is the one read on this control plane
+that returns pipeline *data* rather than metadata about a pipeline, and "who read
+this file" cannot be reconstructed after the fact.
+
+An output in state `external` is **never** previewed (`403`). faucet wrote to that
+file but did not create it, so its contents are not faucet's to hand out — the
+read-side twin of the retention GC's refusal to delete it.
 
 The request names a **ledger id**, never a path: the path comes from the row the
 sink wrote, so a preview cannot be aimed at another file.
@@ -345,12 +353,12 @@ Failure modes are all typed, and none of them is a 500:
 
 | Status | Meaning |
 |---|---|
-| `403` | Previews disabled on this server, or the role lacks `LocalOutputRead`. |
+| `403` | Previews disabled on this server; the role lacks `LocalOutputRead`; or the output is `external` — a file faucet wrote to but did not create, whose contents are not faucet's to serve (the same reason the retention GC will not delete it). |
 | `404` | No such tracked output. |
 | `409` | The file is gone — collected by retention, or removed out of band. The ledger row and the run record are kept; the message says so. |
 | `422` | The file is there but unparseable (e.g. a half-written last line from a run that died mid-flush). The message carries the connector's own line/offset diagnostic. |
 | `400` | The output's kind has no reader, or this build lacks the source connector for it. |
-| `503` | The read was abandoned after the 30-second preview ceiling — a pathological file, not a verdict on its contents. |
+| `503` | The read was abandoned after the 60-second hard timeout — a single page that never returned, not a verdict on the file's contents. (The 30-second deadline is different: it yields a partial `200` with `capped_by: "time"`.) |
 
 ```bash
 # The first 20 rows of a tracked output.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -642,10 +642,16 @@ paths:
         served in full only when the operator lifted the ceiling
         (`--preview-max-rows 0`, reported as `preview_max_rows: null`);
         otherwise it resolves to the ceiling, which is the point of having one.
-        An unlimited read is still bounded by a response-size budget (64 MiB) and
-        a 30s deadline: a dataset that exceeds either comes back as a **partial
-        answer whose `capped_by` says which bound stopped it**, never as an error
-        and never as an unbounded buffer.
+        An unlimited read is unlimited in *rows* only — it is still paged, and
+        still bounded by a response-size budget (64 MiB) and a 30s deadline, both
+        of which are checked as pages arrive. A dataset that exceeds either comes
+        back as a **partial answer whose `capped_by` says which bound stopped
+        it**, never as an error and never as an unbounded buffer.
+
+
+        A served preview writes a `local_output.preview` audit entry (principal,
+        output, row count) — the one read on this control plane that returns
+        pipeline data rather than metadata about a pipeline.
       operationId: previewLocalOutput
       security: [{ bearerAuth: [] }]
       parameters:
@@ -730,7 +736,10 @@ paths:
         "403":
           description: >
             Previews are disabled on this server (`--preview-local-outputs` was
-            not passed), or the principal's role lacks `LocalOutputRead`.
+            not passed); the principal's role lacks `LocalOutputRead`; or the
+            output is `external` — a file faucet wrote to but did not create,
+            whose contents are not faucet's to serve, for the same reason the
+            retention GC refuses to delete it.
         "404": { description: No such tracked output }
         "409":
           description: >


### PR DESCRIPTION
Post-merge review follow-ups for #642 (which implemented #586). Review: https://github.com/faucet-hq/faucet-stream/pull/642#pullrequestreview-5048497386

No closing keyword — #586 is already closed by #642. This is the fast-follow the review asked for, and every HIGH finding is addressed.

## HIGH 1 — the unlimited path could OOM, contradicting its own docs

Verified in the code before changing anything, and it was real:

`RowCap::Unlimited` → the handler sent `batch_size: 0` → jsonl and csv read `chunk = usize::MAX` → the **entire file** materialized into a single `Vec<Value>` on the first `pages.next()`. The byte budget is checked while iterating an already-returned page and the deadline between pages; with exactly one page, neither ever gets a turn. So `--preview-max-rows 0` + `row_count_to_load=all` on a 40 GiB `out.jsonl` died on memory or at the 60s hard timeout — while `engine.rs` and `mod.rs` both promised a truncated answer. A documented guarantee that does not hold is the worst kind of defect, and this was mine.

**Fix:** an unlimited read is unlimited in **rows**, not in page size. It now pages at `PREVIEW_UNLIMITED_PAGE_ROWS` (= `faucet_core::DEFAULT_BATCH_SIZE`), so both bounds get a chance between pages. `limit: 0` — the part that *should* be unbounded — is unchanged.

The residual is documented rather than papered over: a source that ignores the page-size hint and materializes its whole result set anyway (the default `Source::stream_pages` does exactly that, via `fetch_with_context`) is bounded by that source, not by this engine. That will matter for #591's remote sources; it does not for the three lazy file readers here.

## HIGH 2 — the test that hid it

`the_byte_budget_bounds_an_unlimited_read` used `batch_size: 1` while production sent `0`, so CI was attesting a property the code did not have.

Bounds are now injectable (`Bounds`, `read_capped_with`), which lets each one be exercised in the **real loop** instead of by inspection — a 30s deadline and a 64 MiB budget are otherwise unreachable from a unit test, and an untested bound is a bound that quietly stops working:

- the byte test drives the **handler's own** page size against a small budget;
- the deadline test proves a *partial answer*, not an error;
- `an_unbounded_page_would_defeat_the_byte_budget` pins **why** page size matters at all;
- two handler tests hold the line that nothing in production sends `0`.

It also drops an 80 MiB scratch file the old test wrote.

## HIGH 3 — parquet was never actually read back

The integration suite's `cfg` excluded parquet and the only parquet test inspected the generated spec JSON, so an Arrow read-back regression would have shipped green. Added:

- a real single-file parquet read-back (including the decoded values);
- the **rolled multi-part** case the handler's `local_path`-never-a-glob choice exists for — each UUID-named part previews on its own, and the parts *partition* the dataset rather than repeating it, which is what proves each read was scoped to one file;
- a `.jsonl.gz` round-trip, since both sides auto-detect compression by suffix and neither was covered.

The rolled test needed a fix of its own: `max_rows_per_file: 4` alone produced a single file, because rollover is evaluated per batch and all 10 rows arrived in one page. The sink's `batch_size` is what actually makes it roll.

## MEDIUM — `pre_existing` outputs were readable

The GC refuses to *delete* a file faucet wrote to but did not create, because it is somebody else's data. Preview served that same file's contents back over HTTP. A guardrail on one verb and not the other is not a guardrail — the review is right and my earlier "reading isn't destructive" reasoning was too narrow.

An `external` output now gets a `403` that names the reason, and the console renders no Preview control for a non-`present` output (mirroring the existing rule against offering a button that can only 403).

## MEDIUM — no audit trail on content disclosure

A served preview now writes `local_output.preview` (principal, output, row count). Reads are not audited elsewhere on this control plane, and this is the exception deliberately: every other read returns metadata *about* a pipeline, this one returns the pipeline's **data**, and "who read this file" cannot be reconstructed after the fact.

## MEDIUM — docs contradicted the code on the 503

`http-api.md` attributed the 503 to the "30-second preview ceiling". The 30s deadline yields a partial `200` with `capped_by: "time"`; the 503 is the 60s hard timeout. (The OpenAPI in #642 had it right.) Also covered the previously untested mapping arms — 503, 422 with the connector's own line/offset diagnostic, and 400 for a missing connector — plus a malformed-output 422 end-to-end.

## Nits

- Helm now validates the preview caps (`serve.preview.rows` / `maxRows`) like its sibling local-output settings.
- The column-order doc no longer implies a dependency on `serde_json`'s `preserve_order` — the union is stable and complete either way, because it is computed from the returned rows.

## Not addressed, deliberately

- **Scope.** Preview stays on `LocalOutputRead` rather than a dedicated or `Manage` scope. Every authenticated role holds that scope, so a split would imply per-principal control the fixed role ladder does not offer; the load-bearing gate is the server-level opt-in, and the audit entry above closes the accountability half. Worth revisiting only if this endpoint ever leaves local-only (#591).
- **jsonl per-line length cap.** A pathological multi-GB single line is still O(line). `lines()` has no cap and bounding it means hand-rolling `fill_buf`/`consume`; the byte budget cannot help mid-line. Noted rather than silently ignored.

## Testing

1290 lib tests (69 preview-specific) + 9 preview integration + 8 local-outputs + 2 openapi, all green. `clippy -D warnings`, `cargo fmt --check`, and the `Docs` job's own `RUSTDOCFLAGS="-D warnings" cargo doc` all clean locally — that last one caught two of my own new lints before CI had to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)